### PR TITLE
Fix handle refresh

### DIFF
--- a/source/hooks/useUtils.ts
+++ b/source/hooks/useUtils.ts
@@ -1,8 +1,8 @@
 import { useAlert } from 'react-alert';
-import { IAccountState } from 'state/wallet/types';
 import { useNavigate } from 'react-router-dom';
 import { useCallback, useEffect, useState } from 'react';
-import { IMasterController } from 'scripts/Background/controllers';
+
+import { useAccount, useController } from '.';
 
 export const isNFT = (guid: number): boolean => {
   const assetGuid = BigInt.asUintN(64, BigInt(guid));
@@ -20,18 +20,17 @@ export const getHost = (url: string): string => {
 export const useUtils = () => {
   const alert = useAlert();
   const navigate = useNavigate();
+  const controller = useController();
+  const { activeAccount } = useAccount();
 
   const useSettingsView = () =>
     useCallback((view) => {
       navigate(view);
     }, []);
 
-  const handleRefresh = (
-    controller: IMasterController,
-    activeAccount: IAccountState
-  ): void => {
+  const handleRefresh = (): void => {
     controller.wallet.account.getLatestUpdate();
-    controller.wallet.account.watchMemPool(activeAccount);
+    if (activeAccount) controller.wallet.account.watchMemPool(activeAccount);
     controller.stateUpdater();
   };
 

--- a/source/pages/Home/Home.tsx
+++ b/source/pages/Home/Home.tsx
@@ -22,9 +22,8 @@ export const Home = () => {
   const { accounts, activeNetwork, fiat } = useStore();
 
   useEffect(() => {
-    if (!controller.wallet.isLocked() && accounts.length > 0 && activeAccount) {
-      handleRefresh(controller, activeAccount);
-    }
+    if (!controller.wallet.isLocked() && accounts.length > 0 && activeAccount)
+      handleRefresh();
   }, [!controller.wallet.isLocked(), accounts.length > 0]);
 
   return (


### PR DESCRIPTION
`handleRefresh` from useUtils had calls with no arguments.

This fix removes the arguments (controller and activeAcc) and replaces them inside useUtils so that `handleRefresh` can be easely binded to `onClick`