### PR TITLE
Display the asset image placeholder

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -124,7 +124,15 @@ module.exports = {
         exclude: /node_modules/,
       },
       {
-        test: /\.(jpg|png|svg)x?$/,
+        test: /\.(jpg|png)x?$/,
+        loader: 'file-loader',
+        exclude: /node_modules/,
+        options: {
+          name: '/source/assets/images/[name].[ext]',
+        },
+      },
+      {
+        test: /\.(svg)x?$/,
         loader: 'file-loader',
         exclude: /node_modules/,
       },


### PR DESCRIPTION
- [x] Separate the webpack file-loader rule for svg and images extensions and add options to it

After this modification, the placeholder png loads