### PR TITLE
Fix controller assignment. Fix pali restart when first opening the browser

### DIFF
--- a/source/scripts/Background/index.ts
+++ b/source/scripts/Background/index.ts
@@ -15,13 +15,12 @@ declare global {
   }
 }
 
+if (!window.controller) {
+  window.controller = Object.freeze(MasterController());
+  setInterval(window.controller.stateUpdater, 3 * 60 * 1000);
+}
+
 browser.runtime.onInstalled.addListener(() => {
-  if (!window.controller) {
-    window.controller = Object.freeze(MasterController());
-
-    setInterval(window.controller.stateUpdater, 3 * 60 * 1000);
-  }
-
   console.emoji('🤩', 'Pali extension enabled');
 
   sysweb3Di.getStateStorageDb().setPrefix('sysweb3-');


### PR DESCRIPTION
Pali would restart every first time being open. I changed the way the controller is assigned