### PR TITLE
Update empty query data return

### DIFF
--- a/source/hooks/useQuery.ts
+++ b/source/hooks/useQuery.ts
@@ -25,7 +25,7 @@ export const useQueryData = () => {
   const params = useQuery();
 
   return React.useMemo(() => {
-    if (!params.data) return undefined;
+    if (!params.data) return {};
     return JSON.parse(params.data);
   }, [params]);
 };

--- a/source/pages/Send/Confirm.tsx
+++ b/source/pages/Send/Confirm.tsx
@@ -23,8 +23,7 @@ export const SendConfirm = () => {
   // when using the default routing, state will have the tx data
   // when using createPopup (DApps), the data comes from route params
   const { state }: { state: any } = useLocation();
-  const { ...externalTx } = useQueryData();
-  const host = useQueryData()?.host;
+  const { host, ...externalTx } = useQueryData();
   const isExternal = Boolean(externalTx.amount);
   const tx = isExternal ? externalTx : state.tx;
 


### PR DESCRIPTION
- [x] Return an empty object (instead of undefined) from `useQueryData` when there is no data