### PR TITLE
Refactor dapp listeners storage

### DIFF
--- a/source/scripts/Background/controllers/DAppController.ts
+++ b/source/scripts/Background/controllers/DAppController.ts
@@ -80,6 +80,7 @@ const DAppController = (): IDAppController => {
     _dapps[host].port.postMessage({ id, data });
   };
 
+  //* ----- Event listeners -----
   const addListener = (host: string, eventName: string) => {
     if (!DAppEvents[eventName]) return;
 
@@ -99,6 +100,7 @@ const DAppController = (): IDAppController => {
   const hasListener = (host: string, eventName: string) =>
     _dapps[host] && _dapps[host].listens.includes(eventName);
 
+  //* ----- Getters/Setters -----
   const get = (host: string) => store.getState().dapp.dapps[host];
 
   const getAll = () => store.getState().dapp.dapps;

--- a/source/scripts/Background/controllers/DAppController.ts
+++ b/source/scripts/Background/controllers/DAppController.ts
@@ -1,13 +1,7 @@
+import _ from 'lodash';
 import { Runtime } from 'webextension-polyfill-ts';
 
-import {
-  addDApp,
-  removeDApp,
-  addListener as addListenerAction,
-  removeListener as removeListenerAction,
-  removeListeners as removeListenersAction,
-  updateDAppAccount,
-} from 'state/dapp';
+import { addDApp, removeDApp, updateDAppAccount } from 'state/dapp';
 import { IDApp } from 'state/dapp/types';
 import store from 'state/store';
 import { IDAppController } from 'types/controllers';
@@ -15,9 +9,10 @@ import { IDAppController } from 'types/controllers';
 import { onDisconnect, onMessage } from './message-handler';
 import { DAppEvents } from './message-handler/types';
 
-interface IDappUtils {
+interface IDappsSession {
   [host: string]: {
     hasWindow: boolean;
+    listens: string[];
     port: Runtime.Port;
   };
 }
@@ -28,7 +23,7 @@ interface IDappUtils {
  * DApps connections use the site host as id
  */
 const DAppController = (): IDAppController => {
-  const _dapps: IDappUtils = {};
+  const _dapps: IDappsSession = {};
 
   const isConnected = (host: string) => {
     const { dapps } = store.getState().dapp;
@@ -39,7 +34,11 @@ const DAppController = (): IDAppController => {
   const setup = (port: Runtime.Port) => {
     const { host } = new URL(port.sender.url);
 
-    _dapps[host] = { port, hasWindow: false };
+    _dapps[host] = {
+      hasWindow: false,
+      listens: [],
+      port,
+    };
 
     port.onMessage.addListener(onMessage);
     port.onDisconnect.addListener(onDisconnect);
@@ -84,25 +83,21 @@ const DAppController = (): IDAppController => {
   const addListener = (host: string, eventName: string) => {
     if (!DAppEvents[eventName]) return;
 
-    store.dispatch(addListenerAction({ host, eventName }));
+    _dapps[host].listens.push(eventName);
   };
 
   const removeListener = (host: string, eventName: string) => {
     if (!DAppEvents[eventName]) return;
 
-    store.dispatch(removeListenerAction({ host, eventName }));
+    _.remove(_dapps[host].listens, (e) => e === eventName);
   };
 
   const removeListeners = (host: string) => {
-    const listeners = store.getState().dapp.listeners[host];
-    if (listeners) store.dispatch(removeListenersAction(host));
+    _dapps[host].listens = [];
   };
 
-  const hasListener = (host: string, eventName: string) => {
-    const { dapp } = store.getState();
-
-    return dapp.listeners[host] && dapp.listeners[host].includes(eventName);
-  };
+  const hasListener = (host: string, eventName: string) =>
+    _dapps[host] && _dapps[host].listens.includes(eventName);
 
   const get = (host: string) => store.getState().dapp.dapps[host];
 

--- a/source/state/dapp/dapp.spec.ts
+++ b/source/state/dapp/dapp.spec.ts
@@ -1,89 +1,44 @@
 import reducer, {
-  addListener,
-  removeListener,
   addDApp,
   removeDApp,
   updateDAppAccount,
   initialState,
-  removeListeners,
 } from '.';
 import { IDApp } from './types';
 
 /*  ----- Tests ----- */
 
 describe('dapp store actions', () => {
-  describe('Listeners tests', () => {
-    //* addListener
-    it('should add a listener', () => {
-      const payload = {
-        eventName: 'fake event',
-        host: 'fake host',
-      };
-      const newState = reducer(initialState, addListener(payload));
-      expect(newState.listeners[payload.host]).toContain(payload.eventName);
-    });
+  const FAKE_DAPP: IDApp = {
+    host: 'fakehost.net',
+    chain: 'syscoin',
+    chainId: 57,
+    accountId: 0,
+  };
 
-    //* removeListener
-    it('should remove a listener ', () => {
-      const payload = {
-        eventName: 'fake event',
-        host: 'fake host',
-      };
+  //* addDApp
+  it('should add a dapp', () => {
+    const newState = reducer(initialState, addDApp(FAKE_DAPP));
 
-      const customState = reducer(initialState, addListener(payload));
-
-      const newState = reducer(customState, removeListener(payload));
-
-      expect(newState.listeners).not.toContain(payload.host);
-    });
-
-    //* removeListeners
-    it('should remove a listener ', () => {
-      const host = 'hostname.com';
-      const event1 = { eventName: 'event1', host };
-      const event2 = { eventName: 'event2', host };
-
-      let customState = reducer(initialState, addListener(event1));
-      customState = reducer(customState, addListener(event2));
-
-      const newState = reducer(customState, removeListeners(host));
-
-      expect(newState.listeners[host]).toBeUndefined();
-    });
+    expect(newState.dapps[FAKE_DAPP.host]).toEqual(FAKE_DAPP);
   });
 
-  describe('Dapp tests', () => {
-    const FAKE_DAPP: IDApp = {
-      host: 'fakehost.net',
-      chain: 'syscoin',
-      chainId: 57,
-      accountId: 0,
-    };
+  //* removeDApp
+  it('should remove a dapp', () => {
+    const customState = reducer(initialState, addDApp(FAKE_DAPP));
+    const newState = reducer(customState, removeDApp(FAKE_DAPP.host));
 
-    //* addDApp
-    it('should add a dapp', () => {
-      const newState = reducer(initialState, addDApp(FAKE_DAPP));
+    expect(newState.dapps).toEqual(initialState.dapps);
+  });
 
-      expect(newState.dapps[FAKE_DAPP.host]).toEqual(FAKE_DAPP);
-    });
+  //* updateDAppAccount
+  it('should remove a dapp', () => {
+    const payload = { host: FAKE_DAPP.host, accountId: 1 };
 
-    //* removeDApp
-    it('should remove a dapp', () => {
-      const customState = reducer(initialState, addDApp(FAKE_DAPP));
-      const newState = reducer(customState, removeDApp(FAKE_DAPP.host));
+    const customState = reducer(initialState, addDApp(FAKE_DAPP));
+    const newState = reducer(customState, updateDAppAccount(payload));
 
-      expect(newState.dapps).toEqual(initialState.dapps);
-    });
-
-    //* updateDAppAccount
-    it('should remove a dapp', () => {
-      const payload = { host: FAKE_DAPP.host, accountId: 1 };
-
-      const customState = reducer(initialState, addDApp(FAKE_DAPP));
-      const newState = reducer(customState, updateDAppAccount(payload));
-
-      const dapp = newState.dapps[FAKE_DAPP.host];
-      expect(dapp.accountId).toEqual(payload.accountId);
-    });
+    const dapp = newState.dapps[FAKE_DAPP.host];
+    expect(dapp.accountId).toEqual(payload.accountId);
   });
 });

--- a/source/state/dapp/dapp.spec.ts
+++ b/source/state/dapp/dapp.spec.ts
@@ -32,7 +32,7 @@ describe('dapp store actions', () => {
   });
 
   //* updateDAppAccount
-  it('should remove a dapp', () => {
+  it('should update the dapp account', () => {
     const payload = { host: FAKE_DAPP.host, accountId: 1 };
 
     const customState = reducer(initialState, addDApp(FAKE_DAPP));

--- a/source/state/dapp/index.ts
+++ b/source/state/dapp/index.ts
@@ -4,41 +4,12 @@ import { IDAppState, IDApp } from './types';
 
 export const initialState: IDAppState = {
   dapps: {},
-  listeners: {},
 };
 
 const DAppState = createSlice({
   name: 'dapp',
   initialState,
   reducers: {
-    addListener(
-      state: IDAppState,
-      action: PayloadAction<{ eventName: string; host: string }>
-    ) {
-      const { host, eventName } = action.payload;
-
-      if (!state.listeners[host]) state.listeners[host] = [eventName];
-      if (state.listeners[host].includes(eventName)) return;
-
-      state.listeners[host].push(eventName);
-    },
-
-    removeListener(
-      state: IDAppState,
-      action: PayloadAction<{ eventName: string; host: string }>
-    ) {
-      const { host, eventName } = action.payload;
-
-      const index = state.listeners[host].findIndex((e) => e === eventName);
-      if (index === -1) return;
-
-      state.listeners[host].splice(index, 1);
-    },
-
-    removeListeners(state: IDAppState, action: PayloadAction<string>) {
-      delete state.listeners[action.payload];
-    },
-
     addDApp(state: IDAppState, action: PayloadAction<IDApp>) {
       state.dapps[action.payload.host] = action.payload;
     },
@@ -61,13 +32,6 @@ const DAppState = createSlice({
   },
 });
 
-export const {
-  addDApp,
-  removeDApp,
-  updateDAppAccount,
-  addListener,
-  removeListener,
-  removeListeners,
-} = DAppState.actions;
+export const { addDApp, removeDApp, updateDAppAccount } = DAppState.actions;
 
 export default DAppState.reducer;

--- a/source/state/dapp/types.ts
+++ b/source/state/dapp/types.ts
@@ -13,11 +13,4 @@ export interface IDAppState {
   dapps: {
     [host: string]: IDApp;
   };
-
-  /**
-   * Dapps that are currently listening for updates
-   */
-  listeners: {
-    [host: string]: Array<string>;
-  };
 }


### PR DESCRIPTION
- [x] Use the dapp controller to store which events are being listened by each dapp

Previously it was stored at the store. The controller storage **resets all listeners every session**. While the store was persistent