### PR TITLE
fix/send-eth

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,10 @@
     "notifications",
     "activeTab",
     "webRequest",
-    "*://*.eth/"
+    "*://*.eth/",
+    "clipboardWrite",
+    "unlimitedStorage",
+    "http://localhost:8545/"
   ],
   "content_security_policy": "script-src 'self'; object-src 'self'",
   "__chrome|firefox__author": "Pollum Sys Teams",
@@ -52,7 +55,7 @@
   "content_scripts": [
     {
       "all_frames": true,
-      "matches": ["http://*/*", "https://*/*"],
+      "matches": ["file://*/*", "http://*/*", "https://*/*"],
       "run_at": "document_start",
       "js": ["js/webextension.bundle.js", "js/contentScript.bundle.js"]
     },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@headlessui/react": "^1.6.0",
     "@heroicons/react": "^1.0.5",
     "@pollum-io/sysweb3-core": "1.0.19",
-    "@pollum-io/sysweb3-keyring": "^1.0.432",
+    "@pollum-io/sysweb3-keyring": "^1.0.434",
     "@pollum-io/sysweb3-network": "^1.0.85",
     "@pollum-io/sysweb3-utils": "^1.1.218",
     "@reduxjs/toolkit": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@headlessui/react": "^1.6.0",
     "@heroicons/react": "^1.0.5",
     "@pollum-io/sysweb3-core": "1.0.19",
-    "@pollum-io/sysweb3-keyring": "^1.0.434",
+    "@pollum-io/sysweb3-keyring": "^1.0.438",
     "@pollum-io/sysweb3-network": "^1.0.85",
     "@pollum-io/sysweb3-utils": "^1.1.218",
     "@reduxjs/toolkit": "^1.4.0",

--- a/source/assets/styles/index.css
+++ b/source/assets/styles/index.css
@@ -100,12 +100,16 @@ div[role='alert'] {
 }
 
 /** input size medium **/
+.input-medium {
+  @apply flex items-center;
+}
+
 .input-medium .ant-input {
   @apply input-default p-4 w-80 text-sm;
 }
 
 .input-medium .ant-input-suffix {
-  @apply absolute right-2 top-2.5;
+  @apply absolute right-14;
 }
 
 /** Group disabled input **/
@@ -146,6 +150,10 @@ input[type='number']::-webkit-inner-spin-button {
 
 .ant-input-suffix .anticon-loading {
   @apply text-brand-graylight;
+}
+
+.ant-form-item-feedback-icon {
+  @apply flex items-center;
 }
 
 /** Input Type Radio **/

--- a/source/pages/Home/Panel/ActivityPanel.tsx
+++ b/source/pages/Home/Panel/ActivityPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { Fullscreen } from 'components/Fullscreen';
@@ -12,13 +12,31 @@ export const TransactionsPanel = () => {
     (state: RootState) => state.vault.activeAccount
   );
   const { isLoadingTxs } = useSelector((state: RootState) => state.vault);
+  const [internalLoading, setInternalLoading] = useState<any>(isLoadingTxs);
   const transactions = Object.values(activeAccount.transactions);
+  const seconds = 10000;
 
   const NoTransactionsComponent = () => (
     <div className="flex items-center justify-center p-3 text-brand-white text-sm">
       <p>You have no transaction history.</p>
     </div>
   );
+
+  const validateTimeoutError = () => {
+    if (isLoadingTxs) {
+      setTimeout(() => {
+        setInternalLoading(false);
+      }, seconds);
+    }
+  };
+
+  useEffect(() => {
+    validateTimeoutError();
+  }, [isLoadingTxs]);
+
+  useEffect(() => {
+    setInternalLoading(isLoadingTxs);
+  }, [isLoadingTxs]);
 
   return transactions.length === 0 ? (
     <>
@@ -28,7 +46,7 @@ export const TransactionsPanel = () => {
   ) : (
     <>
       <div className="p-4 w-full text-white text-base bg-bkg-3">
-        {isLoadingTxs ? <LoadingComponent /> : <TransactionsList />}
+        {internalLoading ? <LoadingComponent /> : <TransactionsList />}
       </div>
 
       <Fullscreen />

--- a/source/pages/Send/Confirm.tsx
+++ b/source/pages/Send/Confirm.tsx
@@ -3,8 +3,6 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 
-import { getErc20Abi } from '@pollum-io/sysweb3-utils';
-
 import {
   Layout,
   DefaultModal,
@@ -43,10 +41,6 @@ export const SendConfirm = () => {
     (state: RootState) => state.vault.activeAccount
   );
 
-  const mnemonic = useSelector(
-    (state: RootState) => state.vault.encryptedMnemonic
-  );
-
   // when using the default routing, state will have the tx data
   // when using createPopup (DApps), the data comes from route params
   const { state }: { state: any } = useLocation();
@@ -75,8 +69,6 @@ export const SendConfirm = () => {
   const validateCustomGasLimit = Boolean(
     customFee.isCustom && customFee.gasLimit > 0
   );
-
-  console.log('basicTx', basicTxValues);
 
   const handleConfirm = async () => {
     const {

--- a/source/pages/Send/Confirm.tsx
+++ b/source/pages/Send/Confirm.tsx
@@ -9,6 +9,7 @@ import {
   Button,
   Icon,
   LoadingComponent,
+  NeutralButton,
 } from 'components/index';
 import { useQueryData, useUtils } from 'hooks/index';
 import { saveTransaction } from 'scripts/Background/controllers/account/evm';
@@ -92,7 +93,6 @@ export const SendConfirm = () => {
             const response = await sysTxsController.sendTransaction(
               basicTxValues
             );
-
             setConfirmed(true);
             setLoading(false);
 
@@ -182,7 +182,7 @@ export const SendConfirm = () => {
             //HANDLE ERC20 TRANSACTION
             case false:
               try {
-                const responseSendErc20 = ethereumTxsController
+                ethereumTxsController
                   .sendSignedErc20Transaction({
                     networkUrl: activeNetwork.url,
                     receiver: txObjectState.to,
@@ -217,10 +217,7 @@ export const SendConfirm = () => {
                   })
                   .then(async (response) => {
                     if (isExternal)
-                      dispatchBackgroundEvent(
-                        `txSend.${host}`,
-                        responseSendErc20
-                      );
+                      dispatchBackgroundEvent(`txSend.${host}`, response);
 
                     const provider = new ethers.providers.JsonRpcProvider(
                       activeNetwork.url
@@ -245,6 +242,8 @@ export const SendConfirm = () => {
                         basicTxValues.token.isNft,
                         basicTxValues.token.decimals
                       );
+
+                      setConfirmedTx(response);
                     }
                   });
 
@@ -299,6 +298,8 @@ export const SendConfirm = () => {
                         basicTxValues.token.chainId,
                         basicTxValues.token.isNft
                       );
+
+                      setConfirmedTx(response);
                     }
                   });
 
@@ -437,7 +438,7 @@ export const SendConfirm = () => {
             </span>
 
             <span>
-              {!basicTxValues.token.isNft ? (
+              {!basicTxValues.token?.isNft ? (
                 <>
                   {`${basicTxValues.amount} ${' '} ${
                     basicTxValues.token
@@ -477,7 +478,7 @@ export const SendConfirm = () => {
                       )} ${activeNetwork.currency?.toUpperCase()}`}
                 </span>
               </p>
-              {!isBitcoinBased && !basicTxValues.token.isNft ? (
+              {!isBitcoinBased && !basicTxValues.token?.isNft ? (
                 <span
                   className="w-fit relative bottom-1 hover:text-brand-deepPink100 text-brand-royalblue text-xs cursor-pointer"
                   onClick={() => setIsOpenEditFeeModal(true)}
@@ -515,7 +516,7 @@ export const SendConfirm = () => {
           <div className="flex items-center justify-around py-8 w-full">
             <Button
               type="button"
-              className="xl:p-18 flex items-center justify-center text-brand-white text-base bg-button-secondary hover:bg-button-secondaryhover border border-button-secondary rounded-full transition-all duration-300 xl:flex-none"
+              className="xl:p-18 flex items-center justify-center h-8 text-brand-white text-base bg-button-secondary hover:bg-button-secondaryhover border border-button-secondary rounded-full transition-all duration-300 xl:flex-none"
               id="send-btn"
               onClick={() => {
                 if (isExternal) {
@@ -526,8 +527,8 @@ export const SendConfirm = () => {
             >
               <Icon
                 name="arrow-up"
-                className="w-4"
-                wrapperClassname="mb-2 mr-2"
+                className="w-5"
+                wrapperClassname="mr-2 flex items-center"
                 rotate={45}
               />
               Cancel
@@ -535,16 +536,29 @@ export const SendConfirm = () => {
 
             <Button
               type="button"
-              className="xl:p-18 flex items-center justify-center text-brand-white text-base bg-button-primary hover:bg-button-primaryhover border border-button-primary rounded-full transition-all duration-300 xl:flex-none"
+              className={`${
+                loading
+                  ? 'opacity-60 cursor-not-allowed'
+                  : 'opacity-100 hover:opacity-90'
+              } xl:p-18 h-8 flex items-center justify-center text-brand-white text-base bg-button-primary hover:bg-button-primaryhover border border-button-primary rounded-full transition-all duration-300 xl:flex-none`}
               id="receive-btn"
               loading={loading}
               onClick={handleConfirm}
             >
-              <Icon
-                name="arrow-down"
-                className="w-4"
-                wrapperClassname="mb-2 mr-2"
-              />
+              {!loading ? (
+                <Icon
+                  name="arrow-down"
+                  className="w-5"
+                  wrapperClassname="flex items-center mr-2"
+                />
+              ) : (
+                <Icon
+                  name="loading"
+                  color="#fff"
+                  className="w-5 animate-spin-slow"
+                  wrapperClassname="mr-2 flex items-center"
+                />
+              )}
               Confirm
             </Button>
           </div>

--- a/source/pages/Send/Confirm.tsx
+++ b/source/pages/Send/Confirm.tsx
@@ -6,7 +6,6 @@ import { useLocation } from 'react-router-dom';
 import {
   Layout,
   DefaultModal,
-  NeutralButton,
   Button,
   Icon,
   LoadingComponent,
@@ -122,44 +121,11 @@ export const SendConfirm = () => {
           try {
             const { chainId, ...restTx } = txObjectState;
 
-            console.log('CONFIRM ETHEREUM OBJECT', {
-              ...restTx,
-              value: ethereumTxsController.toBigNumber(
-                Number(ethers.utils.parseEther(basicTxValues.amount))
-              ),
-
-              maxPriorityFeePerGas: ethers.utils.parseUnits(
-                String(
-                  Boolean(
-                    customFee.isCustom && customFee.maxPriorityFeePerGas > 0
-                  )
-                    ? customFee.maxPriorityFeePerGas.toFixed(9)
-                    : fee.maxPriorityFeePerGas.toFixed(9)
-                ),
-                9
-              ),
-              maxFeePerGas: ethers.utils.parseUnits(
-                String(
-                  Boolean(customFee.isCustom && customFee.maxFeePerGas > 0)
-                    ? customFee.maxFeePerGas.toFixed(9)
-                    : fee.maxFeePerGas.toFixed(9)
-                ),
-                9
-              ),
-              gasLimit: ethereumTxsController.toBigNumber(
-                validateCustomGasLimit
-                  ? customFee.gasLimit * 10 ** 9 // Multiply gasLimit to reach correctly decimal value
-                  : fee.gasLimit
-              ),
-            });
-
             const response =
               await ethereumTxsController.sendFormattedTransaction({
                 ...restTx,
-                value: ethers.utils.hexlify(
-                  ethereumTxsController.toBigNumber(
-                    Number(ethers.utils.parseEther(basicTxValues.amount))
-                  )
+                value: ethereumTxsController.toBigNumber(
+                  Number(basicTxValues.amount) * 10 ** 18 // Calculate amount in correctly way to send in WEI
                 ),
                 maxPriorityFeePerGas: ethers.utils.parseUnits(
                   String(
@@ -245,7 +211,7 @@ export const SendConfirm = () => {
 
         setFee(finalFeeDetails as any);
       } catch (error) {
-        console.log('ERROR', error);
+        logError('error getting fees', 'Transaction', error);
       }
     };
 

--- a/source/pages/Send/Confirm.tsx
+++ b/source/pages/Send/Confirm.tsx
@@ -1,12 +1,21 @@
-import React, { useState } from 'react';
+import { ethers } from 'ethers';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 
 import { Layout, DefaultModal, NeutralButton } from 'components/index';
 import { useQueryData, useUtils } from 'hooks/index';
 import { RootState } from 'state/store';
+import { ICustomFeeParams, IFeeState } from 'types/transactions';
 import { dispatchBackgroundEvent, getController } from 'utils/browser';
-import { truncate, logError, ellipsis } from 'utils/index';
+import {
+  truncate,
+  logError,
+  ellipsis,
+  removeScientificNotation,
+} from 'utils/index';
+
+import { EditPriorityModal } from './EditPriorityModal';
 
 export const SendConfirm = () => {
   const {
@@ -30,11 +39,29 @@ export const SendConfirm = () => {
   // when using createPopup (DApps), the data comes from route params
   const { state }: { state: any } = useLocation();
   const { host, ...externalTx } = useQueryData();
-  const isExternal = Boolean(externalTx.amount);
-  const tx = isExternal ? externalTx : state.tx;
 
   const [confirmed, setConfirmed] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(false);
+  const [customFee, setCustomFee] = useState<ICustomFeeParams>({
+    isCustom: false,
+    gasLimit: 0,
+    maxPriorityFeePerGas: 0,
+    maxFeePerGas: 0,
+    gasPrice: 0,
+  });
+  const [fee, setFee] = useState<IFeeState>();
+  const [txObjectState, setTxObjectState] = useState<any>();
+  const [isOpenEditFeeModal, setIsOpenEditFeeModal] = useState<boolean>(false);
+  const [haveError, setHaveError] = useState<boolean>(false);
+
+  const isExternal = Boolean(externalTx.amount);
+  const basicTxValues = isExternal ? externalTx : state.tx;
+
+  const ethereumTxsController = account.eth.tx;
+
+  const validateCustomGasLimit = Boolean(
+    customFee.isCustom && customFee.gasLimit > 0
+  );
 
   const handleConfirm = async () => {
     const {
@@ -46,10 +73,39 @@ export const SendConfirm = () => {
     if (activeAccount && balance > 0) {
       setLoading(true);
 
-      const txs = isBitcoinBased ? account.sys.tx : account.eth.tx;
+      // const txs = isBitcoinBased ? account.sys.tx : account.eth.tx;
 
       try {
-        const response = await txs.sendTransaction(tx);
+        const response = await ethereumTxsController.sendFormattedTransaction({
+          ...txObjectState,
+          value: ethereumTxsController.toBigNumber(basicTxValues.amount),
+          nonce: ethereumTxsController.toBigNumber(
+            await ethereumTxsController.getTransactionCount('pending')
+          ),
+          maxPriorityFeePerGas: ethers.utils.parseUnits(
+            String(
+              Boolean(customFee.isCustom && customFee.maxPriorityFeePerGas > 0)
+                ? customFee.maxPriorityFeePerGas.toFixed(9)
+                : fee.maxPriorityFeePerGas.toFixed(9)
+            ),
+            9
+          ),
+          maxFeePerGas: ethers.utils.parseUnits(
+            String(
+              Boolean(customFee.isCustom && customFee.maxFeePerGas > 0)
+                ? customFee.maxFeePerGas.toFixed(9)
+                : fee.maxFeePerGas.toFixed(9)
+            ),
+            9
+          ),
+          gasLimit: ethereumTxsController.toBigNumber(
+            validateCustomGasLimit
+              ? customFee.gasLimit * 10 ** 9 // Multiply gasLimit to reach correctly decimal value
+              : fee.gasLimit
+          ),
+        });
+
+        //INCLUDE VALUE AND NONCE AT TX OBJECT
 
         setConfirmed(true);
         setLoading(false);
@@ -60,7 +116,7 @@ export const SendConfirm = () => {
       } catch (error: any) {
         logError('error', 'Transaction', error);
 
-        if (isBitcoinBased && error && tx.fee > 0.00001) {
+        if (isBitcoinBased && error && basicTxValues.fee > 0.00001) {
           alert.removeAll();
           alert.error(
             `${truncate(
@@ -79,8 +135,73 @@ export const SendConfirm = () => {
     }
   };
 
+  console.log('basicTx', basicTxValues);
+
+  useEffect(() => {
+    const abortController = new AbortController();
+
+    const getFeeRecomendation = async () => {
+      try {
+        const { maxFeePerGas, maxPriorityFeePerGas } =
+          await ethereumTxsController.getFeeDataWithDynamicMaxPriorityFeePerGas();
+
+        const initialFeeDetails = {
+          maxFeePerGas: Number(maxFeePerGas) / 10 ** 9,
+          baseFee:
+            (Number(maxFeePerGas) - Number(maxPriorityFeePerGas)) / 10 ** 9,
+          maxPriorityFeePerGas: Number(maxPriorityFeePerGas) / 10 ** 9,
+          gasLimit: ethereumTxsController.toBigNumber(0),
+        };
+
+        const formattedTxObject = {
+          from: basicTxValues.sender,
+          to: basicTxValues.receivingAddress,
+
+          chainId: activeNetwork.chainId,
+          maxFeePerGas,
+          maxPriorityFeePerGas,
+        };
+
+        console.log('formattedTxObject', formattedTxObject);
+
+        setTxObjectState(formattedTxObject);
+
+        const getGasLimit = await ethereumTxsController.getTxGasLimit(
+          formattedTxObject
+        );
+
+        const finalFeeDetails = {
+          ...initialFeeDetails,
+          gasLimit: Number(getGasLimit),
+        };
+
+        console.log('finalFeeDetails', finalFeeDetails);
+
+        setFee(finalFeeDetails);
+      } catch (error) {
+        console.log('ERROR', error);
+      }
+    };
+
+    getFeeRecomendation();
+
+    return () => {
+      abortController.abort();
+    };
+  }, [basicTxValues]);
+
+  const getCalculatedFee = useMemo(() => {
+    if (!fee?.gasLimit || !fee?.maxFeePerGas || !fee?.baseFee) return;
+
+    return (
+      (Number(customFee.isCustom ? customFee.maxFeePerGas : fee?.maxFeePerGas) *
+        Number(validateCustomGasLimit ? customFee.gasLimit : fee?.gasLimit)) /
+      10 ** 9
+    );
+  }, [fee?.maxPriorityFeePerGas, fee?.gasLimit, fee?.maxFeePerGas, customFee]);
+
   return (
-    <Layout title="SEND" canGoBack={!isExternal}>
+    <Layout title="CONFIRM" canGoBack={!isExternal}>
       <DefaultModal
         show={confirmed}
         title="Transaction successful"
@@ -91,7 +212,23 @@ export const SendConfirm = () => {
           else navigate('/home');
         }}
       />
-      {tx && (
+
+      <DefaultModal
+        show={haveError}
+        title="Verify Fields"
+        description="Change fields values and try again."
+        onClose={() => setHaveError(false)}
+      />
+
+      <EditPriorityModal
+        showModal={isOpenEditFeeModal}
+        setIsOpen={setIsOpenEditFeeModal}
+        customFee={customFee}
+        setCustomFee={setCustomFee}
+        setHaveError={setHaveError}
+        fee={fee}
+      />
+      {basicTxValues && fee ? (
         <div className="flex flex-col items-center justify-center w-full">
           <p className="flex flex-col items-center justify-center text-center font-rubik">
             <span className="text-brand-royalblue font-poppins font-thin">
@@ -99,9 +236,9 @@ export const SendConfirm = () => {
             </span>
 
             <span>
-              {`${tx.amount} ${' '} ${
-                tx.token
-                  ? tx.token.symbol
+              {`${basicTxValues.amount} ${' '} ${
+                basicTxValues.token
+                  ? basicTxValues.token.symbol
                   : activeNetwork.currency?.toUpperCase()
               }`}
             </span>
@@ -111,33 +248,50 @@ export const SendConfirm = () => {
             <p className="flex flex-col pt-2 w-full text-brand-white font-poppins font-thin">
               From
               <span className="text-brand-royalblue text-xs">
-                {ellipsis(tx.sender, 7, 15)}
+                {ellipsis(basicTxValues.sender, 7, 15)}
               </span>
             </p>
 
             <p className="flex flex-col pt-2 w-full text-brand-white font-poppins font-thin">
               To
               <span className="text-brand-royalblue text-xs">
-                {ellipsis(tx.receivingAddress, 7, 15)}
+                {ellipsis(basicTxValues.receivingAddress, 7, 15)}
               </span>
             </p>
 
+            <div className="flex flex-row items-center justify-between w-full">
+              <p className="flex flex-col pt-2 w-full text-brand-white font-poppins font-thin">
+                Estimated GasFee
+                <span className="text-brand-royalblue text-xs">
+                  Max Fee: {removeScientificNotation(getCalculatedFee)}{' '}
+                  {activeNetwork.currency?.toUpperCase()}
+                </span>
+              </p>
+              <span
+                className="w-fit relative bottom-1 hover:text-brand-deepPink100 text-brand-royalblue text-xs cursor-pointer"
+                onClick={() => setIsOpenEditFeeModal(true)}
+              >
+                EDIT
+              </span>
+            </div>
+
             <p className="flex flex-col pt-2 w-full text-brand-white font-poppins font-thin">
+              Total (Amount + gas fee)
+              <span className="text-brand-royalblue text-xs">
+                {`${
+                  Number(basicTxValues.amount) + getCalculatedFee
+                } ${activeNetwork.currency?.toLocaleUpperCase()}`}
+              </span>
+            </p>
+
+            {/* <p className="flex flex-col pt-2 w-full text-brand-white font-poppins font-thin">
               Fee
               <span className="text-brand-royalblue text-xs">
                 {!isBitcoinBased
-                  ? `${tx.fee * 10 ** 9} GWEI`
-                  : `${tx.fee} ${activeNetwork.currency}`}
+                  ? `${basicTxValues.fee * 10 ** 9} GWEI`
+                  : `${getCalculatedFee} GWEI ${activeNetwork.currency.toUpperCase()}`}
               </span>
-            </p>
-
-            <p className="flex flex-col pt-2 w-full text-brand-white font-poppins font-thin">
-              Max total
-              <span className="text-brand-royalblue text-xs">
-                {Number(tx.fee) + Number(tx.amount)}
-                {`${activeNetwork.currency?.toUpperCase()}`}
-              </span>
-            </p>
+            </p> */}
           </div>
 
           <div className="absolute bottom-12 md:static md:mt-10">
@@ -151,7 +305,7 @@ export const SendConfirm = () => {
             </NeutralButton>
           </div>
         </div>
-      )}
+      ) : null}
     </Layout>
   );
 };

--- a/source/pages/Send/SendEth.tsx
+++ b/source/pages/Send/SendEth.tsx
@@ -11,6 +11,7 @@ import { isValidEthereumAddress } from '@pollum-io/sysweb3-utils';
 import { Layout, NeutralButton } from 'components/index';
 import { useUtils } from 'hooks/index';
 import { RootState } from 'state/store';
+import { ITokenEthProps } from 'types/tokens';
 import { getController } from 'utils/browser';
 import { truncate, getAssetBalance } from 'utils/index';
 
@@ -31,8 +32,8 @@ export const SendEth = () => {
     activeAccount && activeAccount.assets.ethereum?.length > 0;
 
   const handleSelectedAsset = (item: string) => {
-    if (activeAccount.assets) {
-      const getAsset = activeAccount.assets.find(
+    if (activeAccount.assets.ethereum?.length > 0) {
+      const getAsset = activeAccount.assets.ethereum.find(
         (asset: any) => asset.contractAddress === item
       );
 
@@ -172,7 +173,7 @@ export const SendEth = () => {
                         leaveFrom="transform opacity-100 scale-100"
                         leaveTo="transform opacity-0 scale-95"
                       >
-                        {hasAccountAssets && (
+                        {hasAccountAssets ? (
                           <Menu.Items
                             as="div"
                             className="scrollbar-styled absolute z-10 left-0 mt-2 py-3 w-44 h-56 text-brand-white font-poppins bg-bkg-3 border border-fields-input-border focus:border-fields-input-borderfocus rounded-2xl shadow-2xl overflow-auto origin-top-right"
@@ -188,27 +189,33 @@ export const SendEth = () => {
                             </Menu.Item>
 
                             {hasAccountAssets &&
-                              Object.values(activeAccount.assets).map(
-                                (item: any) => (
-                                  <Menu.Item as="div" key={uniqueId()}>
-                                    <Menu.Item>
-                                      <button
-                                        onClick={() =>
-                                          handleSelectedAsset(item.assetGuid)
-                                        }
-                                        className="group flex items-center justify-between px-2 py-2 w-full hover:text-brand-royalblue text-brand-white font-poppins text-sm border-0 border-transparent transition-all duration-300"
-                                      >
-                                        <p>{item.tokenSymbol}</p>
-                                        <small>
-                                          {item.isNft ? 'NFT' : 'Token'}
-                                        </small>
-                                      </button>
-                                    </Menu.Item>
-                                  </Menu.Item>
+                              Object.values(activeAccount.assets.ethereum).map(
+                                (item: ITokenEthProps) => (
+                                  <>
+                                    {item.chainId === activeNetwork.chainId ? (
+                                      <Menu.Item as="div" key={uniqueId()}>
+                                        <Menu.Item>
+                                          <button
+                                            onClick={() =>
+                                              handleSelectedAsset(
+                                                item.contractAddress
+                                              )
+                                            }
+                                            className="group flex items-center justify-between px-2 py-2 w-full hover:text-brand-royalblue text-brand-white font-poppins text-sm border-0 border-transparent transition-all duration-300"
+                                          >
+                                            <p>{item.tokenSymbol}</p>
+                                            <small>
+                                              {item.isNft ? 'NFT' : 'Token'}
+                                            </small>
+                                          </button>
+                                        </Menu.Item>
+                                      </Menu.Item>
+                                    ) : null}
+                                  </>
                                 )
                               )}
                           </Menu.Items>
-                        )}
+                        ) : null}
                       </Transition>
                     </div>
                   </Menu>

--- a/source/pages/Send/SendEth.tsx
+++ b/source/pages/Send/SendEth.tsx
@@ -149,8 +149,8 @@ export const SendEth = () => {
                         {truncate(
                           String(
                             selectedAsset?.tokenSymbol
-                              ? selectedAsset?.tokenSymbol
-                              : activeNetwork.currency
+                              ? selectedAsset?.tokenSymbol.toUpperCase()
+                              : activeNetwork.currency.toUpperCase()
                           ),
                           2
                         )}
@@ -180,7 +180,7 @@ export const SendEth = () => {
                                 onClick={() => handleSelectedAsset('-1')}
                                 className="group flex items-center justify-between p-2 w-full hover:text-brand-royalblue text-brand-white font-poppins text-sm border-0 border-transparent transition-all duration-300"
                               >
-                                <p>MATIC</p>
+                                <p>{activeNetwork.currency.toUpperCase()}</p>
                                 <small>Native</small>
                               </button>
                             </Menu.Item>

--- a/source/pages/Send/SendEth.tsx
+++ b/source/pages/Send/SendEth.tsx
@@ -91,9 +91,6 @@ export const SendEth = () => {
           id="send-form"
           labelCol={{ span: 8 }}
           wrapperCol={{ span: 8 }}
-          initialValues={{
-            amount: 0,
-          }}
           onFinish={nextStep}
           autoComplete="off"
           className="flex flex-col gap-3 items-center justify-center mt-4 text-center md:w-full"
@@ -238,7 +235,15 @@ export const SendEth = () => {
                       ? selectedAsset.balance
                       : Number(activeAccount?.balances.ethereum);
 
-                    if (parseFloat(value) <= parseFloat(balance)) {
+                    if (
+                      selectedAsset &&
+                      !selectedAsset.isNft &&
+                      parseFloat(value) <= parseFloat(balance)
+                    ) {
+                      return Promise.resolve();
+                    }
+
+                    if (selectedAsset && selectedAsset.isNft && value >= 0) {
                       return Promise.resolve();
                     }
 
@@ -254,7 +259,9 @@ export const SendEth = () => {
                     hasAccountAssets ? 'mixed-border-input' : 'input-medium'
                   } flex items-center`}
                 type="number"
-                placeholder="Amount"
+                placeholder={`${
+                  selectedAsset && selectedAsset?.isNft ? 'Token ID' : 'Amount'
+                }`}
               />
             </Form.Item>
           </div>

--- a/source/pages/Send/SendEth.tsx
+++ b/source/pages/Send/SendEth.tsx
@@ -27,11 +27,6 @@ export const SendEth = () => {
   const [selectedAsset, setSelectedAsset] = useState<any | null>(null);
   const [form] = Form.useForm();
 
-  useEffect(() => {}, [
-    form.getFieldValue('receiver'),
-    controller.wallet.account,
-  ]);
-
   const hasAccountAssets =
     activeAccount && activeAccount.assets.ethereum?.length > 0;
 

--- a/source/pages/Send/SendEth.tsx
+++ b/source/pages/Send/SendEth.tsx
@@ -236,14 +236,22 @@ export const SendEth = () => {
                       : Number(activeAccount?.balances.ethereum);
 
                     if (
-                      selectedAsset &&
-                      !selectedAsset.isNft &&
+                      !selectedAsset &&
                       parseFloat(value) <= parseFloat(balance)
                     ) {
                       return Promise.resolve();
                     }
 
-                    if (selectedAsset && selectedAsset.isNft && value >= 0) {
+                    if (
+                      Boolean(
+                        selectedAsset && selectedAsset.isNft && value >= 0
+                      ) ||
+                      Boolean(
+                        selectedAsset &&
+                          !selectedAsset.isNft &&
+                          parseFloat(value) <= parseFloat(selectedAsset.balance)
+                      )
+                    ) {
                       return Promise.resolve();
                     }
 

--- a/source/pages/Send/SendEth.tsx
+++ b/source/pages/Send/SendEth.tsx
@@ -188,9 +188,9 @@ export const SendEth = () => {
                             {hasAccountAssets &&
                               Object.values(activeAccount.assets.ethereum).map(
                                 (item: ITokenEthProps) => (
-                                  <>
+                                  <div key={uniqueId()}>
                                     {item.chainId === activeNetwork.chainId ? (
-                                      <Menu.Item as="div" key={uniqueId()}>
+                                      <Menu.Item as="div">
                                         <Menu.Item>
                                           <button
                                             onClick={() =>
@@ -208,7 +208,7 @@ export const SendEth = () => {
                                         </Menu.Item>
                                       </Menu.Item>
                                     ) : null}
-                                  </>
+                                  </div>
                                 )
                               )}
                           </Menu.Items>

--- a/source/pages/Send/SendNTokenTransaction.tsx
+++ b/source/pages/Send/SendNTokenTransaction.tsx
@@ -255,7 +255,7 @@ export const SendNTokenTransaction = () => {
               <p className="flex flex-col pt-2 w-full text-brand-white font-poppins font-thin">
                 Estimated GasFee
                 <span className="text-brand-royalblue text-xs">
-                  Max Fee: {removeScientificNotation(getCalculatedFee)}{' '}
+                  {removeScientificNotation(getCalculatedFee)}{' '}
                   {activeNetwork.currency?.toUpperCase()}
                 </span>
               </p>

--- a/source/pages/Send/SendSys.tsx
+++ b/source/pages/Send/SendSys.tsx
@@ -182,7 +182,7 @@ export const SendSys = () => {
           </Form.Item>
 
           <div className="flex items-center justify-center w-full md:max-w-md">
-            {hasAccountAssets && (
+            {hasAccountAssets ? (
               <Form.Item
                 name="asset"
                 className=""
@@ -263,7 +263,7 @@ export const SendSys = () => {
                   </div>
                 </Menu>
               </Form.Item>
-            )}
+            ) : null}
 
             <div className="flex gap-x-0.5 items-center justify-center w-full">
               <Form.Item

--- a/source/pages/Send/components/TransactionDetails.tsx
+++ b/source/pages/Send/components/TransactionDetails.tsx
@@ -61,7 +61,6 @@ export const TransactionDetailsComponent = (
           <p className="flex flex-col pt-2 w-full text-brand-white font-poppins font-thin">
             Estimated GasFee
             <span className="text-brand-royalblue text-xs">
-              Max Fee:{' '}
               {removeScientificNotation(
                 customFee.isCustom ? customFee.maxFeePerGas : fee.maxFeePerGas
               )}{' '}

--- a/source/pages/Tokens/CustomToken.tsx
+++ b/source/pages/Tokens/CustomToken.tsx
@@ -75,6 +75,7 @@ export const CustomToken = () => {
         tokenSymbol: metadata.tokenSymbol.toUpperCase(),
         contractAddress,
         decimals,
+        isNft: false,
         balance: formattedBalance,
       });
 
@@ -133,6 +134,7 @@ export const CustomToken = () => {
             tokenSymbol: treatedSymbol,
             contractAddress,
             decimals,
+            isNft: true,
             balance: balanceToNumber,
           });
 

--- a/source/pages/Tokens/CustomToken.tsx
+++ b/source/pages/Tokens/CustomToken.tsx
@@ -13,7 +13,7 @@ import {
   ISupportsInterfaceProps,
 } from '@pollum-io/sysweb3-utils';
 
-import { DefaultModal, NeutralButton } from 'components/index';
+import { DefaultModal, Icon, NeutralButton } from 'components/index';
 import { useUtils } from 'hooks/index';
 import { RootState } from 'state/store';
 import { getController } from 'utils/browser';
@@ -27,6 +27,7 @@ export const CustomToken = () => {
   const { navigate } = useUtils();
 
   const [added, setAdded] = useState(false);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
   const [ercError, setErcError] = useState({
     errorType: '',
     message: '',
@@ -80,7 +81,7 @@ export const CustomToken = () => {
       });
 
       setAdded(true);
-
+      setIsLoading(false);
       return;
     }
   };
@@ -94,6 +95,7 @@ export const CustomToken = () => {
     decimals: number;
     symbol: string;
   }) => {
+    setIsLoading(true);
     setActiveNetwork(activeNetwork);
 
     const contractResponse = (await contractChecker(
@@ -107,6 +109,8 @@ export const CustomToken = () => {
         message:
           'Invalid contract address. Verify the current contract address or the current network!',
       });
+
+      setIsLoading(false);
 
       return;
     }
@@ -137,11 +141,12 @@ export const CustomToken = () => {
             isNft: true,
             balance: balanceToNumber,
           });
-
+          setIsLoading(false);
           setAdded(true);
 
           return;
         } catch (_erc721Error) {
+          setIsLoading(false);
           setErcError({
             errorType: 'Undefined',
             message: '',
@@ -149,6 +154,7 @@ export const CustomToken = () => {
         }
         break;
       case 'ERC-1155':
+        setIsLoading(false);
         setErcError({
           errorType: 'ERC-1155',
           message: contractResponse.message,
@@ -158,8 +164,11 @@ export const CustomToken = () => {
         // Default will be for cases when contract type will come as Undefined. This type is for ERC-20 cases or contracts that type
         // has not been founded
         try {
-          return await handleERC20Tokens(contractAddress, decimals);
+          await handleERC20Tokens(contractAddress, decimals);
+          setIsLoading(false);
+          return;
         } catch (_ercUndefinedError) {
+          setIsLoading(false);
           setErcError({
             errorType: 'Undefined',
             message: '',
@@ -253,7 +262,13 @@ export const CustomToken = () => {
 
         <div className="flex flex-col items-center justify-center w-full">
           <div className="absolute bottom-12 md:static">
-            <NeutralButton type="submit">Next</NeutralButton>
+            <NeutralButton
+              type="submit"
+              disabled={isLoading}
+              loading={isLoading}
+            >
+              Next
+            </NeutralButton>
           </div>
         </div>
       </Form>

--- a/source/pages/Tokens/ImportToken.tsx
+++ b/source/pages/Tokens/ImportToken.tsx
@@ -7,6 +7,7 @@ import { getTokenJson } from '@pollum-io/sysweb3-utils';
 
 import { DefaultModal, ErrorModal, NeutralButton } from 'components/index';
 import { useUtils } from 'hooks/index';
+import { ITokenEthProps } from 'types/tokens';
 import { getController } from 'utils/browser';
 
 export const ImportToken: FC = () => {
@@ -65,7 +66,7 @@ export const ImportToken: FC = () => {
     ));
   };
 
-  const addToken = async (token: any) => {
+  const addToken = async (token: ITokenEthProps) => {
     try {
       await controller.wallet.account.eth.saveTokenInfo(token);
 

--- a/source/pages/Transactions/TransactionConfirmation.tsx
+++ b/source/pages/Transactions/TransactionConfirmation.tsx
@@ -41,11 +41,14 @@ const callbackResolver = (txType: string) => {
       break;
 
     case 'MintNft':
-      callbackName = 'confirmMintNFT';
+      callbackName = 'confirmTokenMint';
       break;
 
     case 'UpdateToken':
       callbackName = 'confirmUpdateToken';
+      break;
+    case 'TransferToken':
+      callbackName = 'transferAssetOwnership';
       break;
 
     default:

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -1,4 +1,6 @@
+import { ethers } from 'ethers';
 import { ethErrors } from 'helpers/errors';
+import lodash from 'lodash';
 
 import {
   KeyringManager,
@@ -10,7 +12,7 @@ import {
   web3Provider,
   setActiveNetwork as _sysweb3SetActiveNetwork,
 } from '@pollum-io/sysweb3-network';
-import { INetwork } from '@pollum-io/sysweb3-utils';
+import { INetwork, getErc20Abi, getErc21Abi } from '@pollum-io/sysweb3-utils';
 
 import store from 'state/store';
 import {
@@ -30,9 +32,11 @@ import {
   setIsBitcoinBased,
   setChangingConnectedAccount,
   setIsNetworkChanging,
+  setUpdatedTokenBalace,
 } from 'state/vault';
 import { IOmmitedAccount } from 'state/vault/types';
 import { IMainController } from 'types/controllers';
+import { ITokenEthProps } from 'types/tokens';
 import { ICustomRpcParams } from 'types/transactions';
 import cleanErrorStack from 'utils/cleanErrorStack';
 import { isBitcoinBasedNetwork, networkChain } from 'utils/network';
@@ -385,6 +389,70 @@ const MainController = (): IMainController => {
     return tx.getRecommendedGasPrice(true).gwei;
   };
 
+  const updateErcTokenBalances = async (
+    accountId: number,
+    tokenAddress: string,
+    tokenChain: number,
+    isNft: boolean,
+    decimals?: number
+  ) => {
+    const { activeNetwork, accounts, activeAccount } = store.getState().vault;
+    const findAccount = accounts[accountId];
+
+    if (!Boolean(findAccount.address === activeAccount.address)) return;
+
+    const provider = new ethers.providers.JsonRpcProvider(activeNetwork.url);
+
+    const _contract = new ethers.Contract(
+      tokenAddress,
+      isNft ? getErc21Abi() : getErc20Abi(),
+      provider
+    );
+
+    const balanceMethodCall = await _contract.balanceOf(findAccount.address);
+
+    const balance = !isNft
+      ? `${balanceMethodCall / 10 ** Number(decimals)}`
+      : Number(balanceMethodCall);
+
+    const formattedBalance = !isNft
+      ? lodash.floor(parseFloat(balance as string), 4)
+      : balance;
+
+    const newAccountsAssets = accounts[accountId].assets.ethereum.map(
+      (vaultAssets: ITokenEthProps) => {
+        if (
+          Number(vaultAssets.chainId) === tokenChain &&
+          vaultAssets.contractAddress === tokenAddress
+        ) {
+          return { ...vaultAssets, balance: formattedBalance };
+        }
+
+        return vaultAssets;
+      }
+    );
+
+    const newActiveAccountAssets = activeAccount.assets.ethereum.map(
+      (activeAssets: ITokenEthProps) => {
+        if (
+          Number(activeAssets.chainId) === tokenChain &&
+          activeAssets.contractAddress === tokenAddress
+        ) {
+          return { ...activeAssets, balance: formattedBalance };
+        }
+        return activeAssets;
+      }
+    );
+
+    store.dispatch(
+      setUpdatedTokenBalace({
+        accountId: findAccount.id,
+        newAccountsAssets,
+        newActiveAccountAssets,
+      })
+    );
+  };
+
   return {
     createWallet,
     forgetWallet,
@@ -403,6 +471,7 @@ const MainController = (): IMainController => {
     resolveError,
     getRecommendedFee,
     getNetworkData,
+    updateErcTokenBalances,
     ...keyringManager,
   };
 };

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -33,6 +33,7 @@ import {
   setChangingConnectedAccount,
   setIsNetworkChanging,
   setUpdatedTokenBalace,
+  setUpdatedNativeTokenBalance,
 } from 'state/vault';
 import { IOmmitedAccount } from 'state/vault/types';
 import { IMainController } from 'types/controllers';
@@ -393,6 +394,33 @@ const MainController = (): IMainController => {
     return tx.getRecommendedGasPrice(true).gwei;
   };
 
+  const updateNativeTokenBalance = async (accountId: number) => {
+    const { accounts, activeAccount, activeNetwork } = store.getState().vault;
+
+    const findAccount = accounts[accountId];
+
+    if (!Boolean(findAccount.address === activeAccount.address)) return;
+
+    const provider = new ethers.providers.JsonRpcProvider(activeNetwork.url);
+
+    const callBalance = await provider.getBalance(findAccount.address);
+
+    const balance = ethers.utils.formatEther(callBalance);
+
+    const formattedBalance = lodash.floor(parseFloat(balance), 4);
+
+    console.log('callBalance', callBalance);
+    console.log('balance', balance);
+    console.log('formattedBalance', formattedBalance);
+
+    store.dispatch(
+      setUpdatedNativeTokenBalance({
+        accountId: findAccount.id,
+        balance: formattedBalance,
+      })
+    );
+  };
+
   const updateErcTokenBalances = async (
     accountId: number,
     tokenAddress: string,
@@ -477,6 +505,7 @@ const MainController = (): IMainController => {
     getRecommendedFee,
     getNetworkData,
     updateErcTokenBalances,
+    updateNativeTokenBalance,
     ...keyringManager,
   };
 };

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -43,7 +43,7 @@ import { isBitcoinBasedNetwork, networkChain } from 'utils/network';
 
 import WalletController from './account';
 import ControllerUtils from './ControllerUtils';
-import { PaliEvents } from './message-handler/types';
+import { PaliEvents, PaliSyscoinEvents } from './message-handler/types';
 
 const MainController = (): IMainController => {
   const keyringManager = KeyringManager();
@@ -186,12 +186,6 @@ const MainController = (): IMainController => {
 
     keyringManager.setActiveAccount(id);
     store.dispatch(setActiveAccount(accounts[id]));
-    // if (isBitcoinBased) {
-    //   window.controller.dapp.dispatchEvent(
-    //     DAppEvents.accountsChanged,
-    //     removeXprv(accounts[id])
-    //   );
-    // } // TODO: check if this is relevant in any form to syscoin events
   };
 
   const setActiveNetwork = async (
@@ -287,6 +281,13 @@ const MainController = (): IMainController => {
                 networkVersion: activeNetwork.chainId,
               },
             });
+            window.controller.dapp.handleBlockExplorerChange(
+              PaliSyscoinEvents.blockExplorerChanged,
+              {
+                method: PaliSyscoinEvents.blockExplorerChanged,
+                params: isBitcoinBased ? network.url : null,
+              }
+            );
 
             const { assets } = activeAccount;
 
@@ -376,6 +377,9 @@ const MainController = (): IMainController => {
 
     store.dispatch(removeNetworkFromStore({ prefix: chain, chainId }));
   };
+
+  const getChangeAddress = (accountId: number) =>
+    keyringManager.getChangeAddress(accountId);
 
   const getRecommendedFee = () => {
     const { isBitcoinBased, activeNetwork } = store.getState().vault;
@@ -469,6 +473,7 @@ const MainController = (): IMainController => {
     removeKeyringNetwork,
     resolveAccountConflict,
     resolveError,
+    getChangeAddress,
     getRecommendedFee,
     getNetworkData,
     updateErcTokenBalances,

--- a/source/scripts/Background/controllers/account/evm.ts
+++ b/source/scripts/Background/controllers/account/evm.ts
@@ -9,6 +9,7 @@ import { getSearch } from '@pollum-io/sysweb3-utils';
 import PaliLogo from 'assets/icons/favicon-32.png';
 import store from 'state/store';
 import { setAccountTransactions, setActiveAccountProperty } from 'state/vault';
+import { ITokenEthProps } from 'types/tokens';
 
 export interface IEthTransactions extends IEthereumTransactions {
   saveTransaction: (tx: any) => void;
@@ -16,7 +17,7 @@ export interface IEthTransactions extends IEthereumTransactions {
 }
 
 export interface IEthAccountController extends IWeb3Accounts {
-  saveTokenInfo: (token: any) => Promise<void>;
+  saveTokenInfo: (token: ITokenEthProps) => Promise<void>;
   tx: IEthTransactions;
 }
 
@@ -24,18 +25,19 @@ const EthAccountController = (): IEthAccountController => {
   const txs = EthereumTransactions();
   const web3Accounts = Web3Accounts();
 
-  const saveTokenInfo = async (token: any) => {
+  const saveTokenInfo = async (token: ITokenEthProps) => {
     try {
       const { activeAccount, activeNetwork } = store.getState().vault;
       const { chainId } = activeNetwork;
 
       const tokenExists = activeAccount.assets.ethereum?.find(
-        (asset: any) => asset.contractAddress === token.contractAddress
+        (asset: ITokenEthProps) =>
+          asset.contractAddress === token.contractAddress
       );
 
       if (tokenExists) throw new Error('Token already exists');
 
-      let web3Token: any;
+      let web3Token: ITokenEthProps;
 
       const { coins } = await getSearch(token.tokenSymbol);
 
@@ -48,7 +50,7 @@ const EthAccountController = (): IEthAccountController => {
           name,
           id: token.contractAddress,
           logo: thumb,
-          isNft: false,
+          isNft: token.isNft,
           chainId,
         };
       } else {
@@ -58,7 +60,7 @@ const EthAccountController = (): IEthAccountController => {
           name: token.tokenSymbol,
           id: token.contractAddress,
           logo: PaliLogo,
-          isNft: false,
+          isNft: token.isNft,
           chainId,
         };
       }

--- a/source/scripts/Background/controllers/account/syscoin.ts
+++ b/source/scripts/Background/controllers/account/syscoin.ts
@@ -17,10 +17,11 @@ import {
   setIsNetworkChanging,
   setIsPendingBalances,
 } from 'state/vault';
+import { ITokenSysProps } from 'types/tokens';
 
 export interface ISysAccountController {
   getLatestUpdate: (silent?: boolean) => Promise<void>;
-  saveTokenInfo: (token: any) => Promise<void>;
+  saveTokenInfo: (token: ITokenSysProps) => Promise<void>;
   setAddress: () => Promise<string>;
   trezor: ISysTrezorController;
   tx: ISyscoinTransactions;
@@ -190,12 +191,12 @@ const SysAccountController = (): ISysAccountController => {
     return address;
   };
 
-  const saveTokenInfo = async (token: any) => {
+  const saveTokenInfo = async (token: ITokenSysProps) => {
     try {
       const { activeAccount } = store.getState().vault;
 
       const tokenExists = activeAccount.assets.find(
-        (asset: any) => asset.assetGuid === token.assetGuid
+        (asset: ITokenSysProps) => asset.assetGuid === token.assetGuid
       );
 
       if (tokenExists) throw new Error('Token already exists');

--- a/source/scripts/Background/controllers/account/syscoin.ts
+++ b/source/scripts/Background/controllers/account/syscoin.ts
@@ -7,7 +7,7 @@ import {
   SyscoinTransactions,
 } from '@pollum-io/sysweb3-keyring';
 
-import { PaliEvents } from '../message-handler/types';
+import { PaliEvents, PaliSyscoinEvents } from '../message-handler/types';
 import SysTrezorController, { ISysTrezorController } from '../trezor/syscoin';
 import store from 'state/store';
 import {
@@ -45,8 +45,8 @@ const SysAccountController = (): ISysAccountController => {
     store.dispatch(setIsLoadingTxs(true));
 
     const { accountLatestUpdate, walleAccountstLatestUpdate } =
-      await keyringManager.getLatestUpdateForAccount();
-
+      await keyringManager.getLatestUpdateForAccount(); //TODO: validate whats breaking on this function
+    //TODO: after calling createToken from syscoin UTXO getLatestUpdate breaks and gets to a infinite loop with setPendingTxs
     store.dispatch(setIsPendingBalances(false));
 
     const hash = isBitcoinBased ? 'txid' : 'hash';
@@ -112,12 +112,42 @@ const SysAccountController = (): ISysAccountController => {
             i === self.findIndex((tx) => tx[hash] === value[hash])
         ); // to get array with unique txs.
 
-        return {
-          ...account,
-          label: accounts[index].label,
-          assets: accounts[index].assets,
-          transactions: [...allTxs],
-        };
+        if (index === accountId) {
+          if (isBitcoinBased)
+            return {
+              ...account,
+              label: accounts[index].label,
+              transactions: [...filteredTxs],
+              assets: {
+                ethereum: accounts[index].assets.ethereum,
+                syscoin: account.assets,
+              },
+            };
+          else
+            return {
+              ...account,
+              label: accounts[index].label,
+              assets: accounts[index].assets,
+              transactions: [...filteredTxs],
+            };
+        }
+        if (isBitcoinBased)
+          return {
+            ...account,
+            label: accounts[index].label,
+            transactions: [...filteredTxs],
+            assets: {
+              ethereum: accounts[index].assets.ethereum,
+              syscoin: account.assets,
+            },
+          };
+        else
+          return {
+            ...account,
+            label: accounts[index].label,
+            assets: accounts[index].assets,
+            transactions: [...allTxs],
+          };
       })
     );
 
@@ -128,21 +158,14 @@ const SysAccountController = (): ISysAccountController => {
     );
     resolve();
 
-    // if (isBitcoinBased)
-    //   window.controller.dapp.dispatchEvent(
-    //     DAppEvents.accountUpdate,
-    //     removeXprv(accounts[accountId])
-    //   );
-    // else {
-    // window.controller.dapp.handleStateChange(PaliEvents.chainChanged, {
-    //   method: PaliEvents.chainChanged,
-    //   params: {
-    //     chainId: `0x${activeNetwork.chainId.toString(16)}`,
-    //     networkVersion: activeNetwork.chainId,
-    //   },
-    // });
-    // } //This flow would consider the need for syscoin UTXO events of accountUpdate, if possible remove it. If not refactor to use paliEvents
     const isUpdating = store.getState().vault.isNetworkChanging;
+    window.controller.dapp.handleBlockExplorerChange(
+      PaliSyscoinEvents.blockExplorerChanged,
+      {
+        method: PaliSyscoinEvents.blockExplorerChanged,
+        params: isBitcoinBased ? activeNetwork.url : null,
+      }
+    );
     if (!isUpdating)
       window.controller.dapp.handleStateChange(PaliEvents.chainChanged, {
         method: PaliEvents.chainChanged,

--- a/source/scripts/Background/controllers/message-handler/popup-promise.ts
+++ b/source/scripts/Background/controllers/message-handler/popup-promise.ts
@@ -34,11 +34,13 @@ export const popupPromise = async ({
     !dapp.isConnected(host)
   )
     return;
-  if (dapp.hasWindow(host)) return;
-
+  if (dapp.hasWindow(host))
+    throw cleanErrorStack(
+      ethErrors.provider.unauthorized('Dapp already has a open window')
+    );
+  dapp.setHasWindow(host, true);
   data = JSON.parse(JSON.stringify(data).replace(/#(?=\S)/g, ''));
   const popup = await createPopup(route, { ...data, host, eventName });
-  dapp.setHasWindow(host, true);
   return new Promise((resolve) => {
     window.addEventListener(
       `${eventName}.${host}`,

--- a/source/scripts/Background/controllers/message-handler/types.ts
+++ b/source/scripts/Background/controllers/message-handler/types.ts
@@ -10,6 +10,11 @@ export enum PaliEvents {
   chainChanged = 'pali_chainChanged',
   lockStateChanged = 'pali_unlockStateChanged',
 }
+export enum PaliSyscoinEvents {
+  blockExplorerChanged = 'pali_blockExplorerChanged',
+  lockStateChanged = 'pali_unlockStateChanged',
+  xpubChanged = 'pali_xpubChanged',
+}
 
 // TODO review dapp methods
 export enum DAppMethods {

--- a/source/scripts/ContentScript/index.ts
+++ b/source/scripts/ContentScript/index.ts
@@ -1,7 +1,10 @@
 import { EventEmitter } from 'events';
 import { browser } from 'webextension-polyfill-ts';
 
-import { PaliEvents } from 'scripts/Background/controllers/message-handler/types';
+import {
+  PaliEvents,
+  PaliSyscoinEvents,
+} from 'scripts/Background/controllers/message-handler/types';
 const emitter = new EventEmitter();
 
 // Connect to pali
@@ -55,9 +58,17 @@ const start = () => {
 const startEventEmitter = () => {
   for (const ev in PaliEvents) {
     emitter.on(PaliEvents[ev], (result) => {
-      // console.log('Checking event emission PaliEmitter:', ev, result);
       window.dispatchEvent(
         new CustomEvent('notification', { detail: JSON.stringify(result) })
+      );
+    });
+  }
+
+  for (const ev in PaliSyscoinEvents) {
+    console.log('Subscribing to Syscoin event ', PaliSyscoinEvents[ev]);
+    emitter.on(PaliSyscoinEvents[ev], (result) => {
+      window.dispatchEvent(
+        new CustomEvent('sys_notification', { detail: JSON.stringify(result) })
       );
     });
   }
@@ -65,6 +76,11 @@ const startEventEmitter = () => {
 
 // Every message from pali emits an event
 backgroundPort.onMessage.addListener(({ id, data }) => {
+  console.log(
+    'Pali Content Background: Received message from backgroung',
+    id,
+    data
+  );
   emitter.emit(id, data);
 });
 

--- a/source/scripts/ContentScript/inject/BaseProvider.ts
+++ b/source/scripts/ContentScript/inject/BaseProvider.ts
@@ -1,0 +1,252 @@
+import { EventEmitter } from 'events';
+
+import messages from './messages';
+import { getRpcPromiseCallback } from './utils';
+export type Maybe<T> = Partial<T> | null | undefined;
+export declare type JsonRpcVersion = '2.0';
+export type WarningEventName = keyof SentWarningsState['events'];
+// eslint-disable-next-line @typescript-eslint/naming-convention
+interface SentWarningsState {
+  // methods
+  disable: boolean;
+  enable: boolean;
+  // events
+  events: {
+    close: boolean;
+    data: boolean;
+    networkChanged: boolean;
+    notification: boolean;
+  };
+  // methods
+  experimentalMethods: boolean;
+  send: boolean;
+}
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export interface RequestArguments {
+  /** The RPC method to request. */
+  method: string;
+
+  /** The params of the RPC method, if any. */
+  params?: unknown[] | Record<string, unknown>;
+}
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export interface JsonRpcSuccessStruct {
+  id: number;
+  jsonrpc: JsonRpcVersion;
+  result: any;
+}
+
+/**
+ * A successful JSON-RPC response object.
+ */
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export interface UnvalidatedJsonRpcRequest {
+  id?: number;
+  method: string;
+  params?: unknown;
+}
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export interface EnableLegacyPali {
+  chain: string;
+  chainId?: unknown;
+}
+//TODO: switch to SafeEventEmitter
+export class BaseProvider extends EventEmitter {
+  public wallet: string;
+  public chainType: string;
+  protected _sentWarnings: SentWarningsState = {
+    // methods
+    enable: false,
+    disable: false,
+    experimentalMethods: false,
+    send: false,
+    // events
+    events: {
+      close: false,
+      data: false,
+      networkChanged: false,
+      notification: false,
+    },
+  };
+
+  /**
+   * Indicating that this provider is a MetaMask provider.
+   */
+  constructor(chainType, maxEventListeners = 100, wallet = 'pali-v2') {
+    super();
+    this.setMaxListeners(maxEventListeners);
+    // Public state
+    this.chainType = chainType;
+    this._rpcRequest = this._rpcRequest.bind(this);
+    this.request = this.request.bind(this);
+    this.wallet = wallet;
+    // this.isUnlocked = this.isUnlocked.bind(this);
+  }
+
+  //====================
+  // Public Methods
+  //====================
+
+  /**
+   * Submits an RPC request for the given method, with the given params.
+   * Resolves with the result of the method call, or rejects on error.
+   *
+   * @param args - The RPC request arguments.
+   * @param args.method - The RPC method name.
+   * @param args.params - The parameters for the RPC method.
+   * @returns A Promise that resolves with the result of the RPC method,
+   * or rejects if an error is encountered.
+   */
+  public async request<T>(args: RequestArguments): Promise<Maybe<T>> {
+    if (!args || typeof args !== 'object' || Array.isArray(args)) {
+      throw messages.errors.invalidRequestArgs();
+    }
+
+    const { method, params } = args;
+
+    if (typeof method !== 'string' || method.length === 0) {
+      throw messages.errors.invalidRequestMethod();
+    }
+
+    if (
+      params !== undefined &&
+      !Array.isArray(params) &&
+      (typeof params !== 'object' || params === null)
+    ) {
+      throw messages.errors.invalidRequestParams();
+    }
+
+    return new Promise<T>((resolve, reject) => {
+      this._rpcRequest(
+        { method, params },
+        getRpcPromiseCallback(resolve, reject, false)
+      );
+    });
+  }
+  //TODO: properly deprecate enable and change implementation on background of it
+  /**
+   * Equivalent to: ethereum.request('eth_requestAccounts')
+   *
+   * @deprecated
+   * @returns A promise that resolves to an array of addresses.
+   */
+  public async enable(): Promise<string[]> {
+    if (!this._sentWarnings.enable) {
+      console.warn(messages.warnings.enableDeprecation);
+      this._sentWarnings.enable = true;
+    }
+
+    return new Promise<string[]>(async (resolve, reject) => {
+      try {
+        const acc: string[] = (await this.proxy('ENABLE', {
+          chain: this.chainType,
+          chainId: this.chainType === 'ethereum' ? '0x01' : '0x57',
+        })) as string[];
+        resolve(acc);
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+  /**
+   * TODO: properly deprecate disable and change implementation on background of it
+   * @deprecated
+   * @returns A promise that resolves to an array of addresses.
+   */
+  public async disable(): Promise<string[]> {
+    if (!this._sentWarnings.disable) {
+      console.warn(messages.warnings.enableDeprecation);
+      this._sentWarnings.enable = true;
+    }
+    return new Promise<string[]>(async (resolve, reject) => {
+      try {
+        const acc: string[] = (await this.proxy('DISABLE', {
+          chain: this.chainType,
+          chainId: this.chainType === 'ethereum' ? '0x01' : '0x57',
+        })) as string[];
+        resolve(acc);
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+
+  //====================
+  // Private Methods
+  //====================
+  protected _warnOfDeprecation(eventName: string): void {
+    if (this._sentWarnings?.events[eventName as WarningEventName] === false) {
+      console.warn(messages.warnings.events[eventName as WarningEventName]);
+      this._sentWarnings.events[eventName as WarningEventName] = true;
+    }
+  }
+  protected async _rpcRequest(
+    payload: UnvalidatedJsonRpcRequest | UnvalidatedJsonRpcRequest[], //TODO: refactor to accept incoming batched requests
+    callback: (...args: any[]) => void
+  ) {
+    let error = null;
+    let result = null;
+    let formatedResult = null;
+    if (!Array.isArray(payload)) {
+      try {
+        result = await this.proxy('METHOD_REQUEST', payload);
+        formatedResult = {
+          id: payload.id || 1,
+          jsonrpc: '2.0' as JsonRpcVersion,
+          result: result,
+        };
+      } catch (_error) {
+        // A request handler error, a re-thrown middleware error, or something
+        // unexpected.
+        error = _error;
+      }
+      return callback(error, formatedResult);
+    }
+    error = {
+      code: 123,
+      message: messages.errors.invalidBatchRequest(),
+      data: null,
+    };
+    return callback(error, result);
+  }
+  private proxy = (
+    type: string,
+    data: UnvalidatedJsonRpcRequest | EnableLegacyPali
+  ) =>
+    new Promise((resolve, reject) => {
+      const id = Date.now() + '.' + Math.random();
+
+      window.addEventListener(
+        id,
+        (event: any) => {
+          if (event.detail === undefined) {
+            resolve(undefined);
+            return;
+          } else if (event.detail === null) {
+            resolve(null);
+            return;
+          }
+
+          const response = JSON.parse(event.detail);
+          if (response.error) {
+            reject(response.error);
+          }
+          resolve(response);
+        },
+        {
+          once: true,
+          passive: true,
+        }
+      );
+      window.postMessage(
+        {
+          id,
+          type,
+          data,
+        },
+        '*'
+      );
+    });
+}

--- a/source/scripts/ContentScript/inject/inpage.ts
+++ b/source/scripts/ContentScript/inject/inpage.ts
@@ -1,4 +1,5 @@
-import { PaliInpageProvider } from './paliProvider';
+import { PaliInpageProviderEth } from './paliProviderEthereum';
+import { PaliInpageProviderSys } from './paliProviderSyscoin';
 import { shimWeb3 } from './shimWeb3';
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
@@ -11,14 +12,13 @@ declare global {
     pali: Readonly<any>;
   }
 }
-const ethereumProvider = new PaliInpageProvider('ethereum');
+const ethereumProvider = new PaliInpageProviderEth();
 const proxiedProvider = new Proxy(ethereumProvider, {
   // some common libraries, e.g. web3@1.x, mess with our API
   deleteProperty: () => true,
 });
-window.pali = new PaliInpageProvider('syscoin');
+window.pali = new PaliInpageProviderSys();
 window.ethereum = proxiedProvider;
 shimWeb3(proxiedProvider);
-// window.beterraba = new PaliInpageProvider('ethereum');
 
 export const { SUPPORTED_WALLET_METHODS } = window;

--- a/source/scripts/ContentScript/inject/paliProvider.ts
+++ b/source/scripts/ContentScript/inject/paliProvider.ts
@@ -1,4 +1,3 @@
-import { ConsoleSqlOutlined } from '@ant-design/icons';
 import { EventEmitter } from 'events';
 import dequal from 'fast-deep-equal';
 

--- a/source/scripts/ContentScript/inject/paliProviderSyscoin.ts
+++ b/source/scripts/ContentScript/inject/paliProviderSyscoin.ts
@@ -1,1 +1,320 @@
-export class PaliInpageProviderSys {}
+import { isNFT as _isNFT, getAsset } from '@pollum-io/sysweb3-utils';
+
+import { BaseProvider, Maybe, RequestArguments } from './BaseProvider';
+import messages from './messages';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+interface SysProviderState {
+  blockExplorerURL: string | null;
+  initialized: boolean;
+  isPermanentlyDisconnected: boolean;
+  isUnlocked: boolean;
+  xpub: string | null;
+}
+
+export class PaliInpageProviderSys extends BaseProvider {
+  public readonly _sys: ReturnType<PaliInpageProviderSys['_getSysAPI']>;
+  private static _defaultState: SysProviderState = {
+    blockExplorerURL: null,
+    xpub: null,
+    isUnlocked: false,
+    initialized: false,
+    isPermanentlyDisconnected: false,
+  };
+  private _sysState: SysProviderState;
+  public readonly version: number = 2;
+  constructor(maxEventListeners = 100, wallet = 'pali-v2') {
+    super('syscoin', maxEventListeners, wallet);
+    this._sys = this._getSysAPI();
+    // Private state
+    this._sysState = {
+      ...PaliInpageProviderSys._defaultState,
+    };
+    this.request({ method: 'wallet_getSysProviderState' })
+      .then((state) => {
+        const initialState = state as Parameters<
+          PaliInpageProviderSys['_initializeState']
+        >[0];
+        this._initializeState(initialState);
+      })
+      .catch((error) =>
+        console.error(
+          'Pali: Failed to get initial state. Please report this bug.',
+          error
+        )
+      );
+    window.addEventListener(
+      'sys_notification',
+      (event: any) => {
+        const { method, params } = JSON.parse(event.detail);
+        this.emit('walletUpdate');
+        switch (method) {
+          case 'pali_xpubChanged':
+            this._handleConnectedXpub(params);
+            break;
+          case 'pali_unlockStateChanged':
+            this._handleUnlockStateChanged(params);
+            break;
+          case 'pali_blockExplorerChanged':
+            this._handleActiveBlockExplorer(params);
+            break;
+          default:
+            this._handleDisconnect(
+              false,
+              messages.errors.permanentlyDisconnected()
+            );
+        }
+      },
+      {
+        passive: true,
+      }
+    );
+  }
+  private _initializeState(initialState?: {
+    blockExplorerURL: string | null;
+    isUnlocked: boolean;
+    xpub: string;
+  }) {
+    if (this._sysState.initialized === true) {
+      throw new Error('Pali SyscoinProvider: Provider already initialized.');
+    }
+
+    if (initialState) {
+      const { xpub, blockExplorerURL, isUnlocked } = initialState;
+
+      // EIP-1193 connect
+      this._handleConnectedXpub(xpub);
+      this._handleActiveBlockExplorer(blockExplorerURL);
+      this._handleUnlockStateChanged({ xpub, isUnlocked });
+    }
+
+    // Mark provider as initialized regardless of whether initial state was
+    // retrieved.
+    this._sysState.initialized = true;
+    this.emit('_sysInitialized');
+  }
+  // private initializesysState() {
+  //   //TODO: create sysInitialized event, fetch actual active blockexplorer and create state updates only for sys
+  //   const blockExplorerURL = 'https://blockbook-dev.elint.services/'; //Hardcoded to mainnet just for testing porpuses
+  //   this._sysState = {
+  //     blockExplorerURL,
+  //     initialized: true,
+  //   };
+  // }
+  public async isUnlocked(): Promise<boolean> {
+    if (!this._sysState.initialized) {
+      await new Promise<void>((resolve) => {
+        this.on('_sysInitialized', () => resolve());
+      });
+    }
+    return this._sysState.isUnlocked;
+  }
+
+  // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+  public async request<T>(args: RequestArguments): Promise<Maybe<T>> {
+    if (args.method !== 'wallet_getSysProviderState') {
+      const isSyscoinChain = await this._isSyscoinChain;
+      if (!isSyscoinChain)
+        throw new Error(
+          'UTXO Content only are valid for syscoin chain for now'
+        );
+    }
+    return super.request(args);
+  }
+
+  /**
+   * Upon receipt of a new isUnlocked state, sets relevant public state.
+   * Calls the accounts changed handler with the received accounts, or an empty
+   * array.
+   *
+   * Does nothing if the received value is equal to the existing value.
+   * There are no lock/unlock events.
+   *
+   * @param opts - Options bag.
+   * @param opts.accounts - The exposed accounts, if any.
+   * @param opts.isUnlocked - The latest isUnlocked value.
+   */
+  private _handleUnlockStateChanged({
+    xpub,
+    isUnlocked,
+  }: { isUnlocked?: boolean; xpub?: string | null } = {}) {
+    if (typeof isUnlocked !== 'boolean') {
+      console.error(
+        'Pali: Received invalid isUnlocked parameter. Please report this bug.'
+      );
+      return;
+    }
+
+    if (isUnlocked !== this._sysState.isUnlocked) {
+      this._sysState.isUnlocked = isUnlocked;
+      this._handleConnectedXpub(xpub);
+    }
+  }
+
+  /**
+   * Upon receipt of a new connectedAccountXpub state.
+   *
+   *
+   * @param opts - Options bag.
+   * @param opts.accounts - The exposed accounts, if any.
+   * @param opts.isUnlocked - The latest isUnlocked value.
+   */
+  private _handleConnectedXpub(xpub: string | null) {
+    this._sysState.xpub = xpub;
+  }
+
+  private _handleActiveBlockExplorer(blockExplorerURL: string | null) {
+    this._sysState.blockExplorerURL = blockExplorerURL;
+  }
+  private async _isSyscoinChain(): Promise<boolean> {
+    let checkExplorer = false;
+    try {
+      //Only trezor blockbooks are accepted as endpoint for UTXO chains for now
+      const rpcoutput = await (
+        await fetch(this._sysState.blockExplorerURL + 'api/v2')
+      ).json();
+      checkExplorer = rpcoutput.blockbook.coin
+        .toLowerCase()
+        .includes('syscoin');
+    } catch (e) {
+      //Its not a blockbook, so it might be a ethereum RPC
+      checkExplorer = false;
+    }
+    return checkExplorer;
+  }
+
+  /**
+   * When the provider becomes disconnected, updates internal state and emits
+   * required events. Idempotent with respect to the isRecoverable parameter.
+   *
+   * Error codes per the CloseEvent status codes as required by EIP-1193:
+   * https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent#Status_codes
+   *
+   * @param isRecoverable - Whether the disconnection is recoverable.
+   * @param errorMessage - A custom error message.
+   * @emits BaseProvider#disconnect
+   */
+  private _handleDisconnect(isRecoverable: boolean, errorMessage?: string) {
+    if (!this._sysState.isPermanentlyDisconnected && !isRecoverable) {
+      let error;
+      if (isRecoverable) {
+        error = {
+          code: 1013, // Try again later
+          message: errorMessage || messages.errors.disconnected(),
+        };
+        console.debug(error);
+      } else {
+        error = {
+          code: 1011, // Internal error
+          message: errorMessage || messages.errors.permanentlyDisconnected(),
+        };
+        console.error(error);
+        this._sysState.blockExplorerURL = null;
+        this._sysState.xpub = null;
+        this._sysState.isUnlocked = false;
+      }
+
+      this.emit('Sys_disconnect', error);
+    }
+  }
+
+  private _getSysAPI() {
+    return new Proxy(
+      {
+        /**
+         * Determines if asset is a NFT on syscoin UTXO.
+         *
+         * @returns Promise resolving to true if asset isNFT
+         */
+        isNFT: (guid: number) => {
+          const validated = _isNFT(guid);
+          return validated;
+        },
+        /**
+         * Get the minted tokens by the current connected Xpub on UTXO chain.
+         *
+         * @returns Promise send back tokens data
+         */
+        getUserMintedTokens: async () => {
+          const account = await this.request({ method: 'wallet_getAccount' });
+          if (account) {
+            const { transactions } = account as any;
+
+            const filteredTxs = transactions?.filter(
+              (tx: any) => tx.tokenType === 'SPTAssetActivate'
+            );
+
+            const allTokens = [];
+
+            for (const txs of filteredTxs) {
+              for (const tokens of txs.tokenTransfers) {
+                if (tokens) {
+                  allTokens.push(tokens);
+                }
+              }
+            }
+
+            const txs = await Promise.all(
+              allTokens.map(async (t: any) => {
+                const assetInfo = await getAsset(
+                  this._sysState.blockExplorerURL,
+                  t.token
+                );
+                const formattedAssetInfo = {
+                  ...assetInfo,
+                  symbol: Buffer.from(
+                    String(assetInfo.symbol),
+                    'base64'
+                  ).toString('utf-8'),
+                };
+                if (formattedAssetInfo.assetGuid) return formattedAssetInfo;
+              })
+            );
+
+            return txs.filter((item) => item !== undefined);
+          }
+          return [];
+        },
+        /**
+         * Get held assets by current connected account on UTXO chain.
+         *
+         * @returns Promise send back tokens data
+         */
+        getHoldingsData: async () => {
+          const { syscoin }: { syscoin: any[] } = (await this.request({
+            method: 'wallet_getTokens',
+          })) as any;
+
+          if (syscoin.length) {
+            return syscoin;
+          }
+
+          return [];
+        },
+        //Get current connected Xpub
+        getConnectedAccountXpub: () => this._sysState.xpub,
+
+        //Get changeAddress
+        getChangeAddress: async () =>
+          this.request({ method: 'wallet_getChangeAddress' }),
+        /**
+         * Get the minted tokens by the current connected Xpub on UTXO chain.
+         *
+         * @returns Promise send back tokens data
+         */
+        getDataAsset: async (assetGuid: any) => {
+          if (this._sysState) {
+            //TODO: create sysInitialized event
+            await new Promise<void>((resolve) => {
+              this.on('_sysInitialized', () => resolve());
+            });
+          }
+          return getAsset(this._sysState.blockExplorerURL, assetGuid);
+        },
+      },
+      {
+        get: (obj, prop, ...args) => Reflect.get(obj, prop, ...args),
+      }
+    );
+  }
+}

--- a/source/scripts/ContentScript/inject/shimWeb3.ts
+++ b/source/scripts/ContentScript/inject/shimWeb3.ts
@@ -1,4 +1,4 @@
-import { PaliInpageProvider } from './paliProvider';
+import { PaliInpageProviderEth } from './paliProviderEthereum';
 
 /**
  * If no existing window.web3 is found, this function injects a web3 "shim" to
@@ -7,7 +7,7 @@ import { PaliInpageProvider } from './paliProvider';
  * @param provider - The provider to set as window.web3.currentProvider.
  * @param log - The logging API to use.
  */
-export function shimWeb3(provider: PaliInpageProvider): void {
+export function shimWeb3(provider: PaliInpageProviderEth): void {
   let loggedCurrentProvider = false;
   let loggedMissingProperty = false;
 

--- a/source/scripts/Provider/SysProvider.ts
+++ b/source/scripts/Provider/SysProvider.ts
@@ -1,5 +1,8 @@
-import { popupPromise } from 'scripts/Background/controllers/message-handler/popup-promise';
+import { isValidSYSAddress as _isValidSYSAddress } from '@pollum-io/sysweb3-utils';
 
+import { popupPromise } from 'scripts/Background/controllers/message-handler/popup-promise';
+import { isNFT as _isNFT } from 'scripts/Background/controllers/utils';
+import store from 'state/store';
 export const SysProvider = (host: string) => {
   const sendTransaction = (data: {
     amount: number;
@@ -28,6 +31,13 @@ export const SysProvider = (host: string) => {
       data,
       route: 'tx/asset/create',
       eventName: 'txCreateToken',
+    });
+  const transferAssetOwnership = (data) =>
+    popupPromise({
+      host,
+      data,
+      route: 'tx/asset/transfer',
+      eventName: 'txTransferAssetOwnership',
     });
 
   const updateToken = (data) =>
@@ -84,14 +94,25 @@ export const SysProvider = (host: string) => {
       eventName: 'txSignAndSend',
     });
 
+  const isNFT = (data) => _isNFT(data[0] as number);
+
+  const isValidSYSAddress = (data) => {
+    const { activeNetwork } = store.getState().vault;
+    const isValid = _isValidSYSAddress(data, activeNetwork); //Validate by coinType inside sysweb3
+    return isValid;
+  };
+
   return {
     sendTransaction,
     createToken,
     updateToken,
     mintToken,
+    transferAssetOwnership,
     createNft,
     mintNft,
     sign,
     signAndSend,
+    isNFT,
+    isValidSYSAddress,
   };
 };

--- a/source/state/vault/index.ts
+++ b/source/state/vault/index.ts
@@ -1,5 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { ethers } from 'ethers';
+import loadsh from 'lodash';
 
 import {
   initialNetworksState,
@@ -209,34 +210,17 @@ const VaultState = createSlice({
     },
     setUpdatedTokenBalace(
       state: IVaultState,
-      action: PayloadAction<{ accountId: number; tokenAddress: string }>
+      action: PayloadAction<{
+        accountId: number;
+        newAccountsAssets: any;
+        newActiveAccountAssets: any;
+      }>
     ) {
-      const { accountId, tokenAddress } = action.payload;
-      const { activeNetwork, accounts, activeAccount } = state;
+      const { newAccountsAssets, newActiveAccountAssets, accountId } =
+        action.payload;
 
-      const findAccount = accounts[accountId];
-
-      if (findAccount.address === activeAccount.address) {
-        const getCurrentToken: ITokenEthProps =
-          activeAccount.assets.ethereum.find(
-            (token: ITokenEthProps) => token.contractAddress === tokenAddress
-          );
-
-        const provider = new ethers.providers.JsonRpcProvider(
-          activeNetwork.url
-        );
-
-        const _contract = new ethers.Contract(
-          tokenAddress,
-          getCurrentToken.isNft ? getErc21Abi() : getErc20Abi(),
-          provider
-        );
-
-        _contract
-          .balanceOf(findAccount.address)
-          .then((response) => console.log('response balance', response))
-          .catch((error) => console.log('error balance', error));
-      }
+      state.accounts[accountId].assets.ethereum = newAccountsAssets;
+      state.activeAccount.assets.ethereum = newActiveAccountAssets;
     },
   },
 });

--- a/source/state/vault/index.ts
+++ b/source/state/vault/index.ts
@@ -222,6 +222,26 @@ const VaultState = createSlice({
       state.accounts[accountId].assets.ethereum = newAccountsAssets;
       state.activeAccount.assets.ethereum = newActiveAccountAssets;
     },
+    setUpdatedNativeTokenBalance(
+      state: IVaultState,
+      action: PayloadAction<{
+        accountId: number;
+        balance: number;
+      }>
+    ) {
+      const { accountId, balance } = action.payload;
+      const { isBitcoinBased } = state;
+
+      if (isBitcoinBased) {
+        state.accounts[accountId].balances.syscoin = balance;
+        state.activeAccount.balances.syscoin = balance;
+
+        return;
+      }
+
+      state.accounts[accountId].balances.ethereum = balance;
+      state.activeAccount.balances.ethereum = balance;
+    },
   },
 });
 
@@ -248,6 +268,7 @@ export const {
   setStoreError,
   setIsBitcoinBased,
   setUpdatedTokenBalace,
+  setUpdatedNativeTokenBalance,
 } = VaultState.actions;
 
 export default VaultState.reducer;

--- a/source/types/controllers.ts
+++ b/source/types/controllers.ts
@@ -47,6 +47,13 @@ export interface IMainController extends IKeyringManager {
   setActiveNetwork: (network: INetwork, chain: string) => Promise<any>;
   setAutolockTimer: (minutes: number) => void;
   unlock: (pwd: string) => Promise<void>;
+  updateErcTokenBalances: (
+    accountId: number,
+    tokenAddress: string,
+    tokenChain: number,
+    isNft: boolean,
+    decimals?: number
+  ) => Promise<void>;
 }
 
 export interface IEthTokenDetails {

--- a/source/types/controllers.ts
+++ b/source/types/controllers.ts
@@ -13,7 +13,10 @@ import {
 
 import { IEthAccountController } from 'scripts/Background/controllers/account/evm';
 import { ISysAccountController } from 'scripts/Background/controllers/account/syscoin';
-import { PaliEvents } from 'scripts/Background/controllers/message-handler/types';
+import {
+  PaliEvents,
+  PaliSyscoinEvents,
+} from 'scripts/Background/controllers/message-handler/types';
 import { IDApp } from 'state/dapp/types';
 import { IOmmitedAccount } from 'state/vault/types';
 
@@ -32,6 +35,7 @@ export interface IMainController extends IKeyringManager {
     oldRpc: ICustomRpcParams
   ) => Promise<INetwork>;
   forgetWallet: (pwd: string) => void;
+  getChangeAddress: (accountId: number) => string;
   getNetworkData: () => Promise<{ chainId: string; networkVersion: string }>;
   getRecommendedFee: (data?: string | boolean) => Promise<number>;
   getRpc: (data: ICustomRpcParams) => Promise<INetwork>;
@@ -146,6 +150,19 @@ export interface IDAppController {
   getAll: () => { [host: string]: IDApp };
   getNetwork: () => INetwork;
   getState: () => any;
+  /**
+   * Changes the active network
+   */
+  // changeActiveBlockExplorer: (blockExplorer: string) => void;
+  /**
+   * Update state and emit events to all connected dApps
+   * @emits PaliSyscoinEvents
+   */
+  handleBlockExplorerChange: (
+    id: PaliSyscoinEvents,
+    data: { method: string; params: any }
+  ) => Promise<void>;
+
   /**
    * Changes the active network
    */

--- a/source/types/controllers.ts
+++ b/source/types/controllers.ts
@@ -58,6 +58,7 @@ export interface IMainController extends IKeyringManager {
     isNft: boolean,
     decimals?: number
   ) => Promise<void>;
+  updateNativeTokenBalance: (accountId: number) => Promise<void>;
 }
 
 export interface IEthTokenDetails {

--- a/source/types/tokens.ts
+++ b/source/types/tokens.ts
@@ -1,0 +1,31 @@
+export interface ITokenEthProps {
+  balance: number;
+  chainId?: number;
+  contractAddress: string;
+  decimals: string | number;
+  id?: string;
+  isNft: boolean;
+  logo?: string;
+  name?: string;
+  tokenSymbol: string;
+}
+
+export interface ITokenSysProps {
+  assetGuid?: string;
+  balance?: number;
+  contract?: string;
+  decimals?: number;
+  description?: string;
+  image?: string;
+  maxSupply?: string;
+  name?: string;
+  path?: string;
+  pubData?: any;
+  symbol?: string;
+  totalReceived?: string;
+  totalSent?: string;
+  totalSupply?: string;
+  transfers?: number;
+  type?: string;
+  updateCapabilityFlags?: number;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1943,29 +1943,7 @@
     syscointx-js "^1.0.101"
     web3 "^1.7.1"
 
-"@pollum-io/sysweb3-utils@^1.1.217":
-  version "1.1.217"
-  resolved "https://registry.yarnpkg.com/@pollum-io/sysweb3-utils/-/sysweb3-utils-1.1.217.tgz#3b9ffac2031225fdf51ab7505d153f33dc203f69"
-  integrity sha512-IQC/UTae9rI1d1OcKzlgwGixBC2rlVl/YwdzUTBt7Bb4ysqA/62RXYNZ2+g+M+rKKtWM9UsPgtbx3tJUGnATHw==
-  dependencies:
-    "@ethersproject/contracts" "^5.6.2"
-    "@pollum-io/sysweb3-core" "^1.0.19"
-    "@pollum-io/sysweb3-network" "^1.0.84"
-    axios "^0.26.1"
-    bech32 "^2.0.0"
-    bip32 "^3.0.1"
-    bip44-constants "^114.0.0"
-    bip84 "^0.2.7"
-    bitcoinjs-lib "^6.0.1"
-    camelcase-keys "^7.0.2"
-    coinselectsyscoin "^1.0.77"
-    crypto-js "^4.1.1"
-    ethers "^5.6.4"
-    syscoinjs-lib "^1.0.214"
-    syscointx-js "^1.0.101"
-    web3 "^1.7.1"
-
-"@pollum-io/sysweb3-utils@^1.1.218":
+"@pollum-io/sysweb3-utils@^1.1.217", "@pollum-io/sysweb3-utils@^1.1.218":
   version "1.1.218"
   resolved "https://registry.yarnpkg.com/@pollum-io/sysweb3-utils/-/sysweb3-utils-1.1.218.tgz#941d78049e0fe56cfc5c95d05e0860352377ad8d"
   integrity sha512-hCDA6oyLQaGLWX0JJMm7toWu+SBd3wcErWYW/iatyv90ivRFAhLrAqWG3k/5RyDCHE+g+R3SonA3tOQWJLcoCA==
@@ -14304,10 +14282,23 @@ web3-shh@1.7.5:
     web3-core-subscriptions "1.7.5"
     web3-net "1.7.5"
 
-web3-utils@1.7.5, web3-utils@^1.7.1:
+web3-utils@1.7.5:
   version "1.7.5"
   resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.7.5.tgz#081a952ac6e0322e25ac97b37358a43c7372ef6a"
   integrity sha512-9AqNOziQky4wNQadEwEfHiBdOZqopIHzQQVzmvvv6fJwDSMhP+khqmAZC7YTiGjs0MboyZ8tWNivqSO1699XQw==
+  dependencies:
+    bn.js "^5.2.1"
+    ethereum-bloom-filters "^1.0.6"
+    ethereumjs-util "^7.1.0"
+    ethjs-unit "0.1.6"
+    number-to-bn "1.7.0"
+    randombytes "^2.1.0"
+    utf8 "3.0.0"
+
+web3-utils@^1.7.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.8.1.tgz#f2f7ca7eb65e6feb9f3d61056d0de6bbd57125ff"
+  integrity sha512-LgnM9p6V7rHHUGfpMZod+NST8cRfGzJ1BTXAyNo7A9cJX9LczBfSRxJp+U/GInYe9mby40t3v22AJdlELibnsQ==
   dependencies:
     bn.js "^5.2.1"
     ethereum-bloom-filters "^1.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1849,10 +1849,10 @@
   dependencies:
     rimraf "^3.0.2"
 
-"@pollum-io/sysweb3-keyring@^1.0.434":
-  version "1.0.434"
-  resolved "https://registry.yarnpkg.com/@pollum-io/sysweb3-keyring/-/sysweb3-keyring-1.0.434.tgz#691be344aa3270ea83296b1ffd54039817fb9e0e"
-  integrity sha512-lMNi2JPnM3T/4MNHrKZgtbbRsNi6waLrZZ/O1k8GnbSlBEa+R1jWaIC1TXLLNQIdNldDeVKAKrAEGKOyt1Iufg==
+"@pollum-io/sysweb3-keyring@^1.0.438":
+  version "1.0.438"
+  resolved "https://registry.yarnpkg.com/@pollum-io/sysweb3-keyring/-/sysweb3-keyring-1.0.438.tgz#022e0df1783afee0921fed143308af6757d987a9"
+  integrity sha512-+uz83y4XMDJ68UVtKkJDx7icmWSEEL36F/cc1gMb+9v8L1ZMhO2j3W9/0Z/pjvUwEYaK4mef0Pz9UTjH4jU8kw==
   dependencies:
     "@metamask/obs-store" "^7.0.0"
     "@metamask/safe-event-emitter" "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1849,10 +1849,10 @@
   dependencies:
     rimraf "^3.0.2"
 
-"@pollum-io/sysweb3-keyring@^1.0.432":
-  version "1.0.432"
-  resolved "https://registry.yarnpkg.com/@pollum-io/sysweb3-keyring/-/sysweb3-keyring-1.0.432.tgz#84cc55835b6fff4a6454a0a0e99908dc3973325c"
-  integrity sha512-Fs/wnszr9CHTqrhZueE34cbTeL0U+ABZUL83/r039tOVkRartLf5MyvPHUhJ+OuYII/rPjCYjhjynbcQgeHpFg==
+"@pollum-io/sysweb3-keyring@^1.0.434":
+  version "1.0.434"
+  resolved "https://registry.yarnpkg.com/@pollum-io/sysweb3-keyring/-/sysweb3-keyring-1.0.434.tgz#691be344aa3270ea83296b1ffd54039817fb9e0e"
+  integrity sha512-lMNi2JPnM3T/4MNHrKZgtbbRsNi6waLrZZ/O1k8GnbSlBEa+R1jWaIC1TXLLNQIdNldDeVKAKrAEGKOyt1Iufg==
   dependencies:
     "@metamask/obs-store" "^7.0.0"
     "@metamask/safe-event-emitter" "^2.0.0"


### PR DESCRIPTION
- [x] Refactor SendEth component to only have the Receiver and Amount values and fix the validation on this inputs
- [x] Make the Confirm component show the fees and transaction value, also implement new fees values if the transaction will be on some ETH Network
- [x] Implement Edit Fee Modal at Confirm component for ETH Transactions
- [x] Change Confirm UI to adapt when SYS or ETH transaction
- [x] Fix Input icon validators style
- [x] Test SYS Transaction
- [x] Test ETH Transactions
- [x] Test Edit Fee Modal on Confirm component for ETH Transactions
- [x] Fix Amount value that is sent into the ETH transactions converting it to WEI 
- [x] Fix fiat price at SendSys component and variable names
- [x] Fix an error that was happening because of empty assetGuid values in the map function around the SYS Assets. 
- [x] Clear some lint warnings.
- [x] Create types for saveTokenInfo functions at SYS and ETH
- [x] Validate correctly the ETH Assets at SendETH to prevent empty values and tokens from another networks.
- [x] Change handleConfirm function structure to handle all type of token transactions at Confirm component
- [x] Implement the sendErc20SignedTransfer and SendErc721SignedTransfer from sysweb3 at Pali