### PR TITLE
fix/copy-paste-transaction-details

### DIFF
--- a/source/components/Tooltip/Tooltip.tsx
+++ b/source/components/Tooltip/Tooltip.tsx
@@ -27,7 +27,9 @@ export const Tooltip: React.FC<ITooltip> = ({
       interactive
       content={
         <div
-          className={`p-3 text-xs bg-bkg-1 border border-bkg-3 rounded-lg leading-5 shadow-md text-brand-white outline-none focus:outline-none ${className}`}
+          className={`p-3 text-xs bg-bkg-1 border border-bkg-3 rounded-lg leading-5 shadow-md text-brand-white outline-none focus:outline-none 
+          ${className} 
+          ${String(content).length >= 20 && 'max-w-full text-clip break-all'}`}
         >
           {content}
         </div>

--- a/source/pages/Home/Panel/components/Transactions/EvmDetails.tsx
+++ b/source/pages/Home/Panel/components/Transactions/EvmDetails.tsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 
 import { Icon } from 'components/Icon';
 import { IconButton } from 'components/IconButton';
+import { Tooltip } from 'components/Tooltip';
 import { useUtils } from 'hooks/index';
 import { RootState } from 'state/store';
 import { camelCaseToText, truncate } from 'utils/index';
@@ -39,7 +40,6 @@ export const EvmTransactionDetails = ({ hash }: { hash: string }) => {
       };
 
       if (String(value).length >= 20 && key !== 'image') {
-        formattedValue.value = truncate(String(value), 20);
         formattedValue.canCopy = true;
       }
 
@@ -59,15 +59,21 @@ export const EvmTransactionDetails = ({ hash }: { hash: string }) => {
             <li className="flex items-center justify-between my-1 pl-0 pr-3 py-2 w-full text-xs border-b border-dashed border-bkg-2 cursor-default transition-all duration-300">
               <p>{label}</p>
               <span>
-                <b>{value}</b>
-
-                {canCopy && (
-                  <IconButton onClick={() => copy(value ?? '')}>
-                    <Icon
-                      name="copy"
-                      className="px-1 text-brand-white hover:text-fields-input-borderfocus"
-                    />
-                  </IconButton>
+                {value.length >= 20 ? (
+                  <Tooltip content={value} childrenClassName="flex">
+                    <b>{truncate(value, 20)}</b>
+                    {canCopy && (
+                      <IconButton onClick={() => copy(value ?? '')}>
+                        <Icon
+                          wrapperClassname="flex items-center justify-center"
+                          name="copy"
+                          className="px-1 text-brand-white hover:text-fields-input-borderfocus"
+                        />
+                      </IconButton>
+                    )}
+                  </Tooltip>
+                ) : (
+                  <b>{value}</b>
                 )}
               </span>
             </li>


### PR DESCRIPTION
fix: Prevent to truncate the big values from transaction details and truncate it only when is showing in UI and add a tooltip 
around the value to user can hover it and see / copy the full value