### PR TITLE
fix: sys asset labels

### DIFF
--- a/source/scripts/Background/controllers/assets/index.ts
+++ b/source/scripts/Background/controllers/assets/index.ts
@@ -21,9 +21,21 @@ const AssetsManager = (): IAssetsManager => {
             networkChainId
           );
 
+          const decodedSysAssets = getSysAssets.map((asset) => ({
+            ...asset,
+            symbol: decodeURIComponent(
+              Array.prototype.map
+                .call(
+                  atob(asset.symbol),
+                  (c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+                )
+                .join('')
+            ),
+          }));
+
           return {
             ...currentAccount.assets,
-            syscoin: getSysAssets,
+            syscoin: decodedSysAssets,
           };
         } catch (sysUpdateError) {
           return sysUpdateError;


### PR DESCRIPTION
# Ticket 
- [Asset Label for SYSX not being shown properly](https://app.clickup.com/t/864ef8rhp)

## What was done?
-  convert the sys assets symbol from base64

## Screenshot
![Screenshot 2023-04-19 at 20 33 48](https://user-images.githubusercontent.com/43351983/233221557-201a1c7f-b9ac-4261-aa0d-47fc58db372a.png)
