### PR TITLE
fix/edit-networks-rpcs

### DIFF
--- a/source/components/Header/Menus/NetworkMenu.tsx
+++ b/source/components/Header/Menus/NetworkMenu.tsx
@@ -43,6 +43,13 @@ export const NetworkMenu: React.FC<INetworkComponent> = (
       ]
   );
 
+  const activeNetworkValidator = (currentNetwork: INetwork): boolean =>
+    Boolean(
+      activeNetwork.chainId === currentNetwork.chainId &&
+        activeNetwork.url === currentNetwork.url &&
+        activeNetwork.label === currentNetwork.label
+    );
+
   const { navigate } = useUtils();
 
   const handleChangeNetwork = async (network: INetwork, chain: string) => {
@@ -179,8 +186,7 @@ export const NetworkMenu: React.FC<INetworkComponent> = (
                                   </span>
 
                                   {isBitcoinBased &&
-                                    activeNetwork.chainId ===
-                                      currentNetwork.chainId && (
+                                    activeNetworkValidator(currentNetwork) && (
                                       <Icon
                                         name="check"
                                         className="mb-1 w-4"
@@ -239,8 +245,7 @@ export const NetworkMenu: React.FC<INetworkComponent> = (
                                 </span>
 
                                 {!isBitcoinBased &&
-                                  activeNetwork.chainId ===
-                                    currentNetwork.chainId && (
+                                  activeNetworkValidator(currentNetwork) && (
                                     <Icon
                                       name="check"
                                       className="right-0 mb-1 w-4"

--- a/source/pages/Send/Confirm.tsx
+++ b/source/pages/Send/Confirm.tsx
@@ -200,7 +200,6 @@ export const SendConfirm = () => {
                 return;
               } catch (legacyError: any) {
                 logError('error', 'Transaction', legacyError);
-                console.log({ legacyError });
                 alert.removeAll();
                 alert.error("Can't complete transaction. Try again later.");
 

--- a/source/pages/Settings/CustomRPC.tsx
+++ b/source/pages/Settings/CustomRPC.tsx
@@ -73,9 +73,9 @@ const CustomRPCView = () => {
     explorer: (state && state.selected && state.selected.explorer) ?? '',
   };
 
-  const canDisableInputWhenEdit = state ? state.isDefault : false;
+  const isInputDisableByEditMode = state ? state.isDefault : false;
 
-  const canDisableDecimalsInput = Boolean(
+  const isInputDisabled = Boolean(
     !form.getFieldValue('url') ||
       isUrlValid ||
       (state && state.selected && state.selected.chainId)
@@ -154,7 +154,7 @@ const CustomRPCView = () => {
         >
           <Input
             type="text"
-            disabled={canDisableInputWhenEdit}
+            disabled={isInputDisableByEditMode}
             placeholder={`Label ${isSyscoinRpc ? '(optional)' : ''}`}
             className="input-small relative"
           />
@@ -236,7 +236,7 @@ const CustomRPCView = () => {
         >
           <Input
             type="text"
-            disabled={canDisableDecimalsInput}
+            disabled={isInputDisabled}
             placeholder="Chain ID"
             className={`${isSyscoinRpc ? 'hidden' : 'relative'} input-small`}
           />
@@ -275,7 +275,7 @@ const CustomRPCView = () => {
         >
           <Input
             type="text"
-            disabled={canDisableInputWhenEdit}
+            disabled={isInputDisabled}
             placeholder="Explorer"
             className={`${isSyscoinRpc ? 'hidden' : 'relative'} input-small`}
           />

--- a/source/pages/Settings/CustomRPC.tsx
+++ b/source/pages/Settings/CustomRPC.tsx
@@ -4,7 +4,6 @@ import { useForm } from 'antd/lib/form/Form';
 import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
-import { CustomJsonRpcProvider } from '@pollum-io/sysweb3-keyring';
 import { validateEthRpc, validateSysRpc } from '@pollum-io/sysweb3-network';
 
 import { Layout, NeutralButton, Tooltip } from 'components/index';
@@ -23,8 +22,6 @@ const CustomRPCView = () => {
 
   const { alert, navigate } = useUtils();
   const controller = getController();
-  const { isInCooldown }: CustomJsonRpcProvider =
-    controller.wallet.ethereumTransaction.web3Provider;
 
   const [form] = useForm();
 
@@ -75,6 +72,14 @@ const CustomRPCView = () => {
     symbol: (state && state.selected && state.selected.currency) ?? '',
     explorer: (state && state.selected && state.selected.explorer) ?? '',
   };
+
+  const canDisableInputWhenEdit = state ? state.isDefault : false;
+
+  const canDisableDecimalsInput = Boolean(
+    !form.getFieldValue('url') ||
+      isUrlValid ||
+      (state && state.selected && state.selected.chainId)
+  );
 
   useEffect(() => {
     const fieldErrors = form.getFieldError('url');
@@ -149,7 +154,7 @@ const CustomRPCView = () => {
         >
           <Input
             type="text"
-            disabled={state ? state.isDefault : false}
+            disabled={canDisableInputWhenEdit}
             placeholder={`Label ${isSyscoinRpc ? '(optional)' : ''}`}
             className="input-small relative"
           />
@@ -231,7 +236,7 @@ const CustomRPCView = () => {
         >
           <Input
             type="text"
-            disabled={!form.getFieldValue('url') || isUrlValid}
+            disabled={canDisableDecimalsInput}
             placeholder="Chain ID"
             className={`${isSyscoinRpc ? 'hidden' : 'relative'} input-small`}
           />
@@ -270,6 +275,7 @@ const CustomRPCView = () => {
         >
           <Input
             type="text"
+            disabled={canDisableInputWhenEdit}
             placeholder="Explorer"
             className={`${isSyscoinRpc ? 'hidden' : 'relative'} input-small`}
           />

--- a/source/pages/Settings/ManageNetwork.tsx
+++ b/source/pages/Settings/ManageNetwork.tsx
@@ -55,7 +55,11 @@ const ManageNetworkView = () => {
         </p>
         {Object.values(networks.syscoin).map((network: INetwork) => (
           <li
-            key={network.chainId}
+            key={
+              network.key
+                ? network.key
+                : `${network.label.trim()}-${network.chainId}`
+            }
             className={`my-3 w-full flex justify-between items-center transition-all duration-300 border-b border-dashed border-dashed-light cursor-default`}
           >
             <div className="flex flex-col gap-x-3 items-start justify-start text-xs">
@@ -137,7 +141,11 @@ const ManageNetworkView = () => {
         </p>
         {Object.values(networks.ethereum).map((network: any) => (
           <li
-            key={network.chainId}
+            key={
+              network.key
+                ? network.key
+                : `${network.label.trim()}-${network.chainId}`
+            }
             className={`my-3 w-full flex justify-between items-center transition-all duration-300 border-b border-dashed border-dashed-light cursor-default`}
           >
             <div className="flex flex-col gap-x-3 items-start justify-start text-xs">

--- a/source/pages/Settings/ManageNetwork.tsx
+++ b/source/pages/Settings/ManageNetwork.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 
-import { INetwork } from '@pollum-io/sysweb3-network';
+import { INetwork, INetworkType } from '@pollum-io/sysweb3-network';
 
 import {
   IconButton,
@@ -25,15 +25,20 @@ const ManageNetworkView = () => {
   const { navigate } = useUtils();
   const { wallet } = getController();
 
-  const removeNetwork = (chain: string, chainId: number, key?: string) =>
-    wallet.removeKeyringNetwork(chain, chainId, key);
+  const removeNetwork = (
+    chain: INetworkType,
+    chainId: number,
+    rpcUrl: string,
+    label: string,
+    key?: string
+  ) => wallet.removeKeyringNetwork(chain, chainId, rpcUrl, label, key);
 
   const editNetwork = ({
     selected,
     chain,
     isDefault,
   }: {
-    chain: string;
+    chain: INetworkType;
     isDefault: boolean;
     selected: INetwork;
   }) => {
@@ -68,7 +73,7 @@ const ManageNetworkView = () => {
                   onClick={() =>
                     editNetwork({
                       selected: network,
-                      chain: 'syscoin',
+                      chain: INetworkType.Syscoin,
                       isDefault: network.default,
                     })
                   }
@@ -92,7 +97,13 @@ const ManageNetworkView = () => {
                 >
                   <IconButton
                     onClick={() =>
-                      removeNetwork('syscoin', network.chainId, network?.key)
+                      removeNetwork(
+                        INetworkType.Syscoin,
+                        network.chainId,
+                        network.url,
+                        network.label,
+                        network?.key
+                      )
                     }
                     type="primary"
                     shape="circle"
@@ -143,7 +154,7 @@ const ManageNetworkView = () => {
                 onClick={() =>
                   editNetwork({
                     selected: network,
-                    chain: 'ethereum',
+                    chain: INetworkType.Ethereum,
                     isDefault: network.default,
                   })
                 }
@@ -166,7 +177,15 @@ const ManageNetworkView = () => {
                   }
                 >
                   <IconButton
-                    onClick={() => removeNetwork('ethereum', network.chainId)}
+                    onClick={() =>
+                      removeNetwork(
+                        INetworkType.Ethereum,
+                        network.chainId,
+                        network.url,
+                        network.label,
+                        network?.key
+                      )
+                    }
                     type="primary"
                     shape="circle"
                     disabled={

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -591,6 +591,7 @@ const MainController = (walletState): IMainController => {
         chainId:
           newRpc.chainId === oldRpc.chainId ? oldRpc.chainId : newRpc.chainId,
         default: oldRpc.default,
+        ...(oldRpc?.key && { key: oldRpc.key }),
       } as INetwork;
       if (changedChainId) {
         throw new Error('RPC from a different chainId');

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -543,6 +543,7 @@ const MainController = (walletState): IMainController => {
 
     const networkWithCustomParams = {
       ...network,
+      default: false, // We only have RPCs with default as true in our initialNetworksState value
       apiUrl: data.apiUrl ? data.apiUrl : network.apiUrl,
       explorer: data.apiUrl ? data.apiUrl : network.apiUrl,
       currency: data.symbol ? data.symbol : network.currency,

--- a/source/state/vault/index.ts
+++ b/source/state/vault/index.ts
@@ -1,4 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import cloneDeep from 'lodash/cloneDeep';
 
 import {
   initialNetworksState,
@@ -223,17 +224,40 @@ const VaultState = createSlice({
     },
     removeNetwork(
       state: IVaultState,
-      action: PayloadAction<{ chainId: number; key?: string; prefix: string }>
+      action: PayloadAction<{
+        chain: INetworkType;
+        chainId: number;
+        key?: string;
+        label: string;
+        rpcUrl: string;
+      }>
     ) {
-      const { prefix, chainId } = action.payload;
+      const { chain, chainId, rpcUrl, label, key } = action.payload;
 
-      const updatedNetworks = Object.fromEntries(
-        Object.entries(state.networks[prefix]).filter(
-          ([chainKey]) => Number(chainKey) !== chainId
-        )
+      const cloneNetworkState = cloneDeep(state.networks);
+
+      const updatedNetworks = Object.entries(cloneNetworkState[chain]).reduce(
+        (result, [index, networkValue]) => {
+          const networkTyped = networkValue as INetwork;
+
+          if (key && networkTyped.key === key) {
+            return result; // Skip the network with the provided key
+          }
+
+          if (
+            networkTyped.url === rpcUrl &&
+            networkTyped.chainId === chainId &&
+            networkTyped.label === label
+          ) {
+            return result; // Skip the network that matches the criteria
+          }
+
+          return { ...result, [index]: networkValue }; // Keep the network in the updated object
+        },
+        {}
       );
 
-      state.networks[prefix] = updatedNetworks;
+      state.networks[chain] = updatedNetworks;
     },
     setTimer(state: IVaultState, action: PayloadAction<number>) {
       state.timer = action.payload;

--- a/source/state/vault/index.ts
+++ b/source/state/vault/index.ts
@@ -178,9 +178,9 @@ const VaultState = createSlice({
         .replace(/\s/g, '')
         .toLocaleLowerCase()}-${network.chainId}`;
 
-      const alreadyExist = Boolean(
-        state.networks[chain][Number(network.chainId)]
-      );
+      const networkKeyIdentifier = network.key ? network.key : network.chainId;
+
+      const alreadyExist = Boolean(state.networks[chain][networkKeyIdentifier]);
 
       if (alreadyExist && !isEdit) {
         const verifyIfRpcOrNameExists = Object.values(
@@ -209,13 +209,15 @@ const VaultState = createSlice({
       }
       state.networks[chain] = {
         ...state.networks[chain],
-        [network.chainId]: network,
+        [networkKeyIdentifier]: network,
       };
 
       if (
         chain === state.activeChain &&
-        state.networks[chain][network.chainId].chainId ===
-          state.activeNetwork.chainId
+        state.networks[chain][networkKeyIdentifier].chainId ===
+          state.activeNetwork.chainId &&
+        state.networks[chain][networkKeyIdentifier].url ===
+          state.activeNetwork.url
       ) {
         state.activeNetwork = network;
       }

--- a/source/types/controllers.ts
+++ b/source/types/controllers.ts
@@ -74,7 +74,13 @@ export interface IMainController extends IKeyringManager {
   //   index: string
   // ) => Promise<IKeyringAccountState>;
   lock: () => void;
-  removeKeyringNetwork: (chain: string, chainId: number, key?: string) => void;
+  removeKeyringNetwork: (
+    chain: string,
+    chainId: number,
+    rpcUrl: string,
+    label: string,
+    key?: string
+  ) => void;
   removeWindowEthProperty: () => void;
   resolveAccountConflict: () => void;
   resolveError: () => void;

--- a/tests/unit/vaultStore.spec.ts
+++ b/tests/unit/vaultStore.spec.ts
@@ -4,6 +4,7 @@ import {
   initialActiveTrezorAccountState,
   KeyringAccountType,
 } from '@pollum-io/sysweb3-keyring'; //todo: initialActiveAccountState does not exist anymore we should adjust it
+import { INetworkType } from '@pollum-io/sysweb3-network';
 
 import { MOCK_ACCOUNT, STATE_W_ACCOUNT } from '../mocks';
 import reducer, {
@@ -205,7 +206,12 @@ describe('Vault store actions', () => {
 
   //* removeNetwork
   it('should remove a network)', () => {
-    const payload = { prefix: 'ethereum', chainId: 4 };
+    const payload = {
+      chain: INetworkType.Ethereum,
+      chainId: 4,
+      label: '',
+      rpcUrl: '',
+    };
     const newState = reducer(initialState, removeNetwork(payload));
 
     expect(newState.networks.ethereum).toBeDefined();


### PR DESCRIPTION
fix: Remove unecessary console.log and implement some new validations for the Custom RPC form when is used for edit some existent network. Also add a prop to addCustomRpc with default as false looking that our RPCs with default as true only come from the initialNetworksState now