### PR TITLE
Bug fix: Can't submit any UTXO transaction due to CSP

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -26,7 +26,7 @@
     "http://localhost:8545/"
   ],
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'"
+    "extension_pages": "script-src 'self' 'unsafe-eval'; object-src 'self'"
   },
   "author": "pollum labs",
   "minimum_chrome_version": "88",

--- a/source/config/consts.js
+++ b/source/config/consts.js
@@ -99,7 +99,7 @@ const MV3_OPTIONS = {
     'http://localhost:8545/',
   ],
   content_security_policy: {
-    extension_pages: "script-src 'self'; object-src 'self'",
+    extension_pages: "script-src 'self' 'unsafe-eval'; object-src 'self'",
   },
   author: 'pollum labs',
   minimum_chrome_version: '88',


### PR DESCRIPTION
Can only send txs when adding 'unsafe-eval' to the CSP. Something is doing eval instead of running the hardcode? In any case, seen that bug to appear and disappear in the past