### PR TITLE
Refresh balances before send flows

### DIFF
--- a/source/pages/Send/Confirm.tsx
+++ b/source/pages/Send/Confirm.tsx
@@ -311,9 +311,19 @@ export const SendConfirm = () => {
   }, [navigate, alert, t, getLegacyGasPrice]);
 
   const handleConfirm = async () => {
-    const balance = isBitcoinBased
+    let balance = isBitcoinBased
       ? activeAccount.balances[INetworkType.Syscoin]
       : activeAccount.balances[INetworkType.Ethereum];
+
+    try {
+      const refreshedBalance = (await controllerEmitter(
+        ['wallet', 'refreshActiveAccountBalances'],
+        [{ includeAssets: false }]
+      )) as { nativeBalance: string };
+      balance = Number(refreshedBalance.nativeBalance || 0);
+    } catch (error) {
+      console.error('Failed to refresh balance before confirming:', error);
+    }
 
     if (activeAccount && balance >= 0) {
       setLoading(true);

--- a/source/pages/Send/Confirm.tsx
+++ b/source/pages/Send/Confirm.tsx
@@ -311,7 +311,7 @@ export const SendConfirm = () => {
   }, [navigate, alert, t, getLegacyGasPrice]);
 
   const handleConfirm = async () => {
-    let balance = isBitcoinBased
+    let balance: string | number = isBitcoinBased
       ? activeAccount.balances[INetworkType.Syscoin]
       : activeAccount.balances[INetworkType.Ethereum];
 
@@ -320,12 +320,12 @@ export const SendConfirm = () => {
         ['wallet', 'refreshActiveAccountBalances'],
         [{ includeAssets: false }]
       )) as { nativeBalance: string };
-      balance = Number(refreshedBalance.nativeBalance || 0);
+      balance = refreshedBalance.nativeBalance || '0';
     } catch (error) {
       console.error('Failed to refresh balance before confirming:', error);
     }
 
-    if (activeAccount && balance >= 0) {
+    if (activeAccount && Number(balance) >= 0) {
       setLoading(true);
 
       // Enforce ENS resolution: if user provided an ENS name and it couldn't be resolved, block

--- a/source/pages/Send/SendEth.tsx
+++ b/source/pages/Send/SendEth.tsx
@@ -163,6 +163,47 @@ export const SendEth = () => {
   const formValuesRef = useRef<any>({});
   const tokenIdVerificationTimeoutRef = useRef<NodeJS.Timeout>();
 
+  useEffect(() => {
+    const refreshBalances = async () => {
+      try {
+        await controllerEmitter(
+          ['wallet', 'refreshActiveAccountBalances'],
+          [{ includeAssets: true }]
+        );
+      } catch (error) {
+        console.error('Failed to refresh send balances:', error);
+      }
+    };
+
+    refreshBalances();
+  }, [activeAccount?.address, activeNetwork.chainId]);
+
+  useEffect(() => {
+    if (!selectedAsset || !activeAccountAssets?.ethereum) return;
+
+    const refreshedAsset = activeAccountAssets.ethereum.find((asset) => {
+      const sameContract =
+        asset.contractAddress?.toLowerCase() ===
+        selectedAsset.contractAddress?.toLowerCase();
+      const sameTokenId =
+        String(asset.tokenId || '') === String(selectedAsset.tokenId || '');
+
+      return sameContract && sameTokenId;
+    });
+
+    if (
+      refreshedAsset &&
+      Number(refreshedAsset.balance) !== Number(selectedAsset.balance)
+    ) {
+      setSelectedAsset(refreshedAsset);
+    }
+  }, [
+    activeAccountAssets?.ethereum,
+    selectedAsset?.balance,
+    selectedAsset?.contractAddress,
+    selectedAsset?.tokenId,
+  ]);
+
   // Save navigation state when user completes interaction
   const saveCurrentState = useCallback(async () => {
     // Prefer live form values to avoid races when setFieldValue was just called

--- a/source/pages/Send/SendEth.tsx
+++ b/source/pages/Send/SendEth.tsx
@@ -187,8 +187,12 @@ export const SendEth = () => {
         selectedAsset.contractAddress?.toLowerCase();
       const sameTokenId =
         String(asset.tokenId || '') === String(selectedAsset.tokenId || '');
+      const sameChain =
+        (asset.chainId || activeNetwork.chainId) === activeNetwork.chainId &&
+        (selectedAsset.chainId || activeNetwork.chainId) ===
+          activeNetwork.chainId;
 
-      return sameContract && sameTokenId;
+      return sameContract && sameTokenId && sameChain;
     });
 
     if (
@@ -200,8 +204,10 @@ export const SendEth = () => {
   }, [
     activeAccountAssets?.ethereum,
     selectedAsset?.balance,
+    selectedAsset?.chainId,
     selectedAsset?.contractAddress,
     selectedAsset?.tokenId,
+    activeNetwork.chainId,
   ]);
 
   // Save navigation state when user completes interaction

--- a/source/pages/Send/SendSys.tsx
+++ b/source/pages/Send/SendSys.tsx
@@ -72,6 +72,40 @@ export const SendSys = () => {
   // Track form value changes using a ref to avoid dependency issues
   const formValuesRef = useRef<any>({});
 
+  useEffect(() => {
+    const refreshBalances = async () => {
+      try {
+        await controllerEmitter(
+          ['wallet', 'refreshActiveAccountBalances'],
+          [{ includeAssets: true }]
+        );
+      } catch (error) {
+        console.error('Failed to refresh send balances:', error);
+      }
+    };
+
+    refreshBalances();
+  }, [activeAccount?.address, activeNetwork.chainId]);
+
+  useEffect(() => {
+    if (!selectedAsset || !accountAssets?.syscoin) return;
+
+    const refreshedAsset = Object.values(accountAssets.syscoin).find(
+      (asset) => String(asset.assetGuid) === String(selectedAsset.assetGuid)
+    );
+
+    if (
+      refreshedAsset &&
+      Number(refreshedAsset.balance || 0) !== Number(selectedAsset.balance || 0)
+    ) {
+      setSelectedAsset(refreshedAsset);
+    }
+  }, [
+    accountAssets?.syscoin,
+    selectedAsset?.assetGuid,
+    selectedAsset?.balance,
+  ]);
+
   // Save navigation state when user completes interaction
   const saveCurrentState = useCallback(async () => {
     const state = {

--- a/source/pages/Send/SendTransaction.tsx
+++ b/source/pages/Send/SendTransaction.tsx
@@ -100,6 +100,30 @@ export const SendTransaction = () => {
   const approvalType = txMetadata.approvalType;
   const tokenStandard = txMetadata.tokenStandard;
 
+  const targetedErc20ContractAddress = useMemo(() => {
+    if (!dataTx?.to) return null;
+
+    const method = String(decodedTxData?.method || '').toLowerCase();
+    const normalizedTokenStandard = String(tokenStandard || '').toUpperCase();
+    const isErc20Approval = isApproval && approvalType === 'erc20-amount';
+    const isErc20LikeStandard = ['ERC-20', 'ERC-777', 'ERC-4626'].includes(
+      normalizedTokenStandard
+    );
+    const isErc20LikeMethod = ['approve', 'transfer', 'transferfrom'].includes(
+      method
+    );
+
+    return isErc20Approval || isErc20LikeStandard || isErc20LikeMethod
+      ? dataTx.to
+      : null;
+  }, [
+    dataTx?.to,
+    decodedTxData?.method,
+    tokenStandard,
+    isApproval,
+    approvalType,
+  ]);
+
   const [confirmed, setConfirmed] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(false);
   const [initialLoading, setInitialLoading] = useState<boolean>(true);
@@ -515,7 +539,12 @@ export const SendTransaction = () => {
         }
         await controllerEmitter(
           ['wallet', 'refreshActiveAccountBalances'],
-          [{ includeAssets: true }]
+          [
+            {
+              includeAssets: false,
+              targetEvmTokenContractAddress: targetedErc20ContractAddress,
+            },
+          ]
         );
         const { feeDetails, formTx, nonce, isInvalidTxData, gasLimitError } =
           await fetchGasAndDecodeFunction(txForEstimation, activeNetwork);
@@ -569,6 +598,7 @@ export const SendTransaction = () => {
     toRaw,
     activeNetwork.chainId,
     ensResolutionFailed,
+    targetedErc20ContractAddress,
   ]); // ensure we wait for resolved address
 
   // Check for contract interaction with non-contract address

--- a/source/pages/Send/SendTransaction.tsx
+++ b/source/pages/Send/SendTransaction.tsx
@@ -279,15 +279,21 @@ export const SendTransaction = () => {
   }, [toRaw, ensCache]);
 
   const handleConfirm = async () => {
-    const {
-      balances: { ethereum },
-    } = activeAccount;
+    setLoading(true);
 
-    const balance = ethereum;
+    let balance = Number(activeAccount?.balances?.ethereum || 0);
+
+    try {
+      const refreshedBalance = (await controllerEmitter(
+        ['wallet', 'refreshActiveAccountBalances'],
+        [{ includeAssets: false }]
+      )) as { nativeBalance: string };
+      balance = Number(refreshedBalance.nativeBalance || 0);
+    } catch (error) {
+      console.error('Failed to refresh balance before sending:', error);
+    }
 
     if (activeAccount && balance > 0) {
-      setLoading(true);
-
       let txToSend = tx;
 
       // Handle approval-specific data encoding
@@ -487,6 +493,7 @@ export const SendTransaction = () => {
         return error;
       }
     } else {
+      setLoading(false);
       alert.error(t('send.enoughFunds'));
       if (isExternal) {
         clearNavigationState();
@@ -506,6 +513,10 @@ export const SendTransaction = () => {
         if (!toAddressForProvider && toRaw.toLowerCase().endsWith('.eth')) {
           return; // wait until resolvedTo is ready
         }
+        await controllerEmitter(
+          ['wallet', 'refreshActiveAccountBalances'],
+          [{ includeAssets: true }]
+        );
         const { feeDetails, formTx, nonce, isInvalidTxData, gasLimitError } =
           await fetchGasAndDecodeFunction(txForEstimation, activeNetwork);
 

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -4172,6 +4172,59 @@ class MainController {
     return balancePromise;
   }
 
+  public async refreshActiveAccountBalances({
+    includeAssets = false,
+    isPolling = false,
+  }: {
+    includeAssets?: boolean;
+    isPolling?: boolean;
+  } = {}): Promise<{ assetsUpdated: boolean; nativeBalance: string }> {
+    const { accounts, activeAccount, isBitcoinBased, activeNetwork } =
+      store.getState().vault;
+    const currentAccount = accounts[activeAccount.type]?.[activeAccount.id];
+
+    if (!currentAccount) {
+      throw new Error('Active account not found');
+    }
+
+    await this.updateUserNativeBalance({
+      activeAccount,
+      activeNetwork,
+      isBitcoinBased,
+      isPolling,
+    });
+
+    let assetsUpdated = false;
+    if (includeAssets) {
+      try {
+        await this.updateAssetsFromCurrentAccount({
+          activeAccount,
+          activeNetwork,
+          isBitcoinBased,
+          isPolling,
+        });
+        assetsUpdated = true;
+      } catch (error) {
+        console.warn(
+          '[MainController] Asset refresh failed during balance preflight:',
+          error
+        );
+      }
+    }
+
+    const latestState = store.getState().vault;
+    const latestAccount =
+      latestState.accounts[activeAccount.type]?.[activeAccount.id];
+    const networkType = isBitcoinBased
+      ? INetworkType.Syscoin
+      : INetworkType.Ethereum;
+
+    return {
+      assetsUpdated,
+      nativeBalance: String(latestAccount?.balances?.[networkType] ?? '0'),
+    };
+  }
+
   public async getLatestUpdateForCurrentAccount(
     isPolling = false,
     forceUpdate = false, // Force update even if just unlocked

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -2,6 +2,7 @@
 
 import { Contract } from '@ethersproject/contracts';
 import { namehash } from '@ethersproject/hash';
+import { formatUnits } from '@ethersproject/units';
 import {
   KeyringManager,
   IKeyringAccountState,
@@ -4175,9 +4176,11 @@ class MainController {
   public async refreshActiveAccountBalances({
     includeAssets = false,
     isPolling = false,
+    targetEvmTokenContractAddress,
   }: {
     includeAssets?: boolean;
     isPolling?: boolean;
+    targetEvmTokenContractAddress?: string;
   } = {}): Promise<{ assetsUpdated: boolean; nativeBalance: string }> {
     const { accounts, activeAccount, isBitcoinBased, activeNetwork } =
       store.getState().vault;
@@ -4207,6 +4210,18 @@ class MainController {
       } catch (error) {
         console.warn(
           '[MainController] Asset refresh failed during balance preflight:',
+          error
+        );
+      }
+    }
+
+    if (!isBitcoinBased && targetEvmTokenContractAddress) {
+      try {
+        await this.refreshActiveEvmTokenBalance(targetEvmTokenContractAddress);
+        assetsUpdated = true;
+      } catch (error) {
+        console.warn(
+          '[MainController] Target token refresh failed during balance preflight:',
           error
         );
       }
@@ -5010,6 +5025,72 @@ class MainController {
       accountAddress,
       this.ethereumTransaction.web3Provider
     );
+  }
+
+  public async refreshActiveEvmTokenBalance(contractAddress: string) {
+    const { accounts, accountAssets, activeAccount, activeNetwork } =
+      store.getState().vault;
+    const currentAccount = accounts[activeAccount.type]?.[activeAccount.id];
+
+    if (!currentAccount?.address || !contractAddress) {
+      throw new Error('Active account or token contract not found');
+    }
+
+    const tokenInfo = await this.getERC20TokenInfo(
+      contractAddress,
+      currentAccount.address
+    );
+    const currentAssets = accountAssets[activeAccount.type]?.[
+      activeAccount.id
+    ] || {
+      ethereum: [],
+      syscoin: [],
+    };
+    const contractLower = contractAddress.toLowerCase();
+    const formattedBalance = parseFloat(
+      formatUnits(tokenInfo.balance || '0', tokenInfo.decimals)
+    );
+    const existingAsset = currentAssets.ethereum.find(
+      (asset) =>
+        !asset.isNft &&
+        asset.contractAddress?.toLowerCase() === contractLower &&
+        (!asset.chainId || asset.chainId === activeNetwork.chainId)
+    );
+
+    const refreshedAsset: ITokenEthProps = {
+      ...existingAsset,
+      chainId: existingAsset?.chainId || activeNetwork.chainId,
+      contractAddress: existingAsset?.contractAddress || contractAddress,
+      isNft: false,
+      tokenStandard: existingAsset?.tokenStandard || 'ERC-20',
+      balance: formattedBalance,
+      decimals: tokenInfo.decimals,
+      name: tokenInfo.name,
+      tokenSymbol: tokenInfo.symbol,
+    };
+
+    if (!existingAsset) {
+      return refreshedAsset;
+    }
+
+    const ethereumAssets = currentAssets.ethereum.map((asset) =>
+      !asset.isNft &&
+      asset.contractAddress?.toLowerCase() === contractLower &&
+      (!asset.chainId || asset.chainId === activeNetwork.chainId)
+        ? refreshedAsset
+        : asset
+    );
+
+    store.dispatch(
+      setAccountAssets({
+        accountId: activeAccount.id,
+        accountType: activeAccount.type,
+        property: 'ethereum',
+        value: ethereumAssets,
+      })
+    );
+
+    return refreshedAsset;
   }
 
   // Direct transaction EVM method for UI access


### PR DESCRIPTION
## Summary
- Refresh the active account's native balance on demand before dapp transaction review and final send/confirm flows.
- Refresh token/asset balances when opening ETH and SYS send screens, and keep the selected asset synced with refreshed store data.
- Add a controller-level balance refresh helper so send flows do not depend on the polling timer for spendability checks.

## Test plan
- yarn type-check
- ./node_modules/.bin/eslint "source/scripts/Background/controllers/MainController.ts" "source/pages/Send/SendTransaction.tsx" "source/pages/Send/SendEth.tsx" "source/pages/Send/SendSys.tsx" "source/pages/Send/Confirm.tsx"

Made with [Cursor](https://cursor.com)