### PR TITLE
feat(passkey): add passkey smart accounts

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Pali Wallet",
-  "version": "4.0.14",
+  "version": "4.0.15",
   "icons": {
     "16": "assets/all_assets/favicon-16.png",
     "32": "assets/all_assets/favicon-32.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paliwallet",
-  "version": "4.0.14",
+  "version": "4.0.15",
   "description": "A Non-Custodial Crypto Wallet",
   "private": true,
   "repository": {
@@ -55,13 +55,14 @@
     "@ethersproject/hash": "^5.8.0",
     "@ethersproject/providers": "^5.8.0",
     "@ethersproject/strings": "^5.8.0",
+    "@ethersproject/transactions": "^5.8.0",
     "@ethersproject/units": "^5.8.0",
     "@ethersproject/wallet": "^5.8.0",
     "@headlessui/react": "^1.7.17",
     "@heroicons/react": "^1.0.6",
     "@reduxjs/toolkit": "^2.8.2",
     "@sidhujag/sysweb3-core": "^1.0.28",
-    "@sidhujag/sysweb3-keyring": "^1.0.587",
+    "@sidhujag/sysweb3-keyring": "^1.0.588",
     "@sidhujag/sysweb3-network": "^1.0.107",
     "@sidhujag/sysweb3-utils": "^1.1.272",
     "@tippyjs/react": "^4.2.6",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@heroicons/react": "^1.0.6",
     "@reduxjs/toolkit": "^2.8.2",
     "@sidhujag/sysweb3-core": "^1.0.28",
-    "@sidhujag/sysweb3-keyring": "^1.0.587",
+    "@sidhujag/sysweb3-keyring": "^1.0.588",
     "@sidhujag/sysweb3-network": "^1.0.107",
     "@sidhujag/sysweb3-utils": "^1.1.272",
     "@tippyjs/react": "^4.2.6",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@heroicons/react": "^1.0.6",
     "@reduxjs/toolkit": "^2.8.2",
     "@sidhujag/sysweb3-core": "^1.0.28",
-    "@sidhujag/sysweb3-keyring": "^1.0.588",
+    "@sidhujag/sysweb3-keyring": "^1.0.587",
     "@sidhujag/sysweb3-network": "^1.0.107",
     "@sidhujag/sysweb3-utils": "^1.1.272",
     "@tippyjs/react": "^4.2.6",

--- a/source/assets/locales/de.json
+++ b/source/assets/locales/de.json
@@ -310,8 +310,6 @@
     "loadingAccounts": "Konten werden geladen...",
     "dappFallback": "Diese App",
     "passkeyDefaultLabel": "{{host}} Passkey",
-    "userRejectedPasskeyCreation": "Der Benutzer hat die Erstellung des Passkey-Kontos abgelehnt",
-    "unableToCreatePasskeyAccount": "Passkey-Konto konnte nicht erstellt werden",
     "createPasskeyAccountTitle": "Passkey-Konto erstellen",
     "createPasskeyAccountDescription": "{{host}} möchte, dass Pali ein zkSYS-Smart-Konto erstellt, das durch den Passkey deines Geräts kontrolliert wird. Pali speichert nur öffentliche Metadaten; der private Schlüssel bleibt in deinem Authenticator.",
     "sponsorPolicy": "Sponsor-Richtlinie: {{policy}}",

--- a/source/assets/locales/de.json
+++ b/source/assets/locales/de.json
@@ -216,7 +216,6 @@
     "activeAccountNotFound": "Fehler: Aktives Konto nicht gefunden",
     "paliWalletBrowserExtension": "Pali Wallet Browser-Erweiterung",
     "addressType": "Adresstyp",
-    "passkey": "Passkey",
     "passkeyAccount": "Passkey-Konto",
     "createPasskeyAccount": "Passkey-Konto erstellen",
     "createPasskeyAccountDescription": "Verwende Touch ID, Face ID, Windows Hello, Android-Biometrie oder einen Sicherheitsschlüssel, um Smart-Account-Transaktionen auf zkSYS zu genehmigen."

--- a/source/assets/locales/de.json
+++ b/source/assets/locales/de.json
@@ -215,7 +215,11 @@
     "closeAndReopenPali": "Schließen Sie dieses Fenster und öffnen Sie Pali erneut, um sich zu authentifizieren und Ihre Hardware-Wallet zu verbinden",
     "activeAccountNotFound": "Fehler: Aktives Konto nicht gefunden",
     "paliWalletBrowserExtension": "Pali Wallet Browser-Erweiterung",
-    "addressType": "Adresstyp"
+    "addressType": "Adresstyp",
+    "passkey": "Passkey",
+    "passkeyAccount": "Passkey-Konto",
+    "createPasskeyAccount": "Passkey-Konto erstellen",
+    "createPasskeyAccountDescription": "Verwende Touch ID, Face ID, Windows Hello, Android-Biometrie oder einen Sicherheitsschlüssel, um Smart-Account-Transaktionen auf zkSYS zu genehmigen."
   },
   "components": {
     "newPassword": "Neues Passwort (min. 12 Zeichen)",
@@ -304,7 +308,20 @@
     "selectAccountToConnect": "Wählen Sie das Konto aus, das Sie mit dieser Seite verbinden möchten",
     "currentlyConnected": "Aktuell verbunden",
     "noAddress": "Keine Adresse",
-    "loadingAccounts": "Konten werden geladen..."
+    "loadingAccounts": "Konten werden geladen...",
+    "dappFallback": "Diese App",
+    "passkeyDefaultLabel": "{{host}} Passkey",
+    "userRejectedPasskeyCreation": "Der Benutzer hat die Erstellung des Passkey-Kontos abgelehnt",
+    "unableToCreatePasskeyAccount": "Passkey-Konto konnte nicht erstellt werden",
+    "createPasskeyAccountTitle": "Passkey-Konto erstellen",
+    "createPasskeyAccountDescription": "{{host}} möchte, dass Pali ein zkSYS-Smart-Konto erstellt, das durch den Passkey deines Geräts kontrolliert wird. Pali speichert nur öffentliche Metadaten; der private Schlüssel bleibt in deinem Authenticator.",
+    "sponsorPolicy": "Sponsor-Richtlinie: {{policy}}",
+    "sponsorGasOnly": "Gas-Sponsor optional",
+    "sponsorRequired": "Sponsor-Genehmigung erforderlich",
+    "sponsorDisabled": "Kein Sponsor",
+    "sponsorUrl": "Sponsor-URL: {{url}}",
+    "sponsorSigner": "Sponsor-Signierer: {{signer}}",
+    "sponsorRequiredWarning": "Dieses Konto erfordert eine Mitautorisierung des Sponsors, bevor Pali Transaktionen davon ausführen kann."
   },
   "titles": {
     "assetDetails": "ASSET-DETAILS",
@@ -534,7 +551,13 @@
     "invalidEthSignFormat": "Ungültiges eth_sign-Nachrichtenformat. 32-Byte-Hex-String (64 Zeichen) erwartet, erhalten: \"{{message}}\". Für die Signierung beliebigen Texts sollte die dApp personal_sign verwenden.",
     "unableToResolveEns": "ENS-Name kann nicht aufgelöst werden",
     "invalidDestination": "Ungültiges Ziel",
-    "verifyEnsOrUseAddress": "Bitte den ENS des Empfängers prüfen oder eine 0x-Adresse verwenden."
+    "verifyEnsOrUseAddress": "Bitte den ENS des Empfängers prüfen oder eine 0x-Adresse verwenden.",
+    "passkeyContractDeploymentUnsupported": "Passkey-Konten unterstützen noch keine Vertragsbereitstellung.",
+    "passkeyMulticallUnsupported": "Passkey-Konten unterstützen noch keine Multi-Call-Batches.",
+    "passkeyActiveAccountRequired": "Das aktive Konto ist kein Passkey-Konto",
+    "passkeyEthSignHashRequired": "Passkey eth_sign erfordert einen 32-Byte-Hash, damit EIP-1271-Prüfer ihn reproduzieren können",
+    "passkeyLegacyTypedDataUnsupported": "Passkey-Konten unterstützen noch keine Legacy-typed-data-V1-Signaturen",
+    "passkeyUnsupportedSigningRequest": "Nicht unterstützte Passkey-Signaturanfrage"
   },
   "start": {
     "paliDoesnt": "Pali speichert Ihr Passwort nicht. Die Wiederherstellung des Zugriffs erfordert ein Zurücksetzen der Wallet mit Ihrer geheimen Wiederherstellungsphrase.",

--- a/source/assets/locales/en.json
+++ b/source/assets/locales/en.json
@@ -139,8 +139,6 @@
     "loadingAccounts": "Loading accounts...",
     "dappFallback": "This app",
     "passkeyDefaultLabel": "{{host}} Passkey",
-    "userRejectedPasskeyCreation": "User rejected passkey account creation",
-    "unableToCreatePasskeyAccount": "Unable to create passkey account",
     "createPasskeyAccountTitle": "Create Passkey Account",
     "createPasskeyAccountDescription": "{{host}} wants Pali to create a zkSYS smart account controlled by your device passkey. Pali stores public metadata only; the private key stays with your authenticator.",
     "sponsorPolicy": "Sponsor policy: {{policy}}",

--- a/source/assets/locales/en.json
+++ b/source/assets/locales/en.json
@@ -554,7 +554,6 @@
     "activeAccountNotFound": "Error: Active account not found",
     "paliWalletBrowserExtension": "Pali Wallet Browser Extension",
     "addressType": "Address type",
-    "passkey": "Passkey",
     "passkeyAccount": "Passkey Account",
     "createPasskeyAccount": "Create Passkey Account",
     "createPasskeyAccountDescription": "Use Touch ID, Face ID, Windows Hello, Android biometrics, or a security key to approve smart-account transactions on zkSYS."

--- a/source/assets/locales/en.json
+++ b/source/assets/locales/en.json
@@ -136,7 +136,20 @@
     "selectAccountToConnect": "Select the account you want to connect with this site",
     "currentlyConnected": "Currently connected",
     "noAddress": "No address",
-    "loadingAccounts": "Loading accounts..."
+    "loadingAccounts": "Loading accounts...",
+    "dappFallback": "This app",
+    "passkeyDefaultLabel": "{{host}} Passkey",
+    "userRejectedPasskeyCreation": "User rejected passkey account creation",
+    "unableToCreatePasskeyAccount": "Unable to create passkey account",
+    "createPasskeyAccountTitle": "Create Passkey Account",
+    "createPasskeyAccountDescription": "{{host}} wants Pali to create a zkSYS smart account controlled by your device passkey. Pali stores public metadata only; the private key stays with your authenticator.",
+    "sponsorPolicy": "Sponsor policy: {{policy}}",
+    "sponsorGasOnly": "Gas sponsor optional",
+    "sponsorRequired": "Sponsor approval required",
+    "sponsorDisabled": "No sponsor",
+    "sponsorUrl": "Sponsor URL: {{url}}",
+    "sponsorSigner": "Sponsor signer: {{signer}}",
+    "sponsorRequiredWarning": "This account will require sponsor co-authorization before Pali can execute transactions from it."
   },
   "home": {
     "importToken": "Import Token",
@@ -387,7 +400,13 @@
     "invalidEthSignFormat": "Invalid eth_sign message format. Expected 32-byte hex string (64 characters), got: \"{{message}}\". For signing arbitrary text, the dapp should use personal_sign instead.",
     "unableToResolveEns": "Unable to resolve ENS name",
     "invalidDestination": "Invalid destination",
-    "verifyEnsOrUseAddress": "Please verify the recipient ENS or use a 0x address."
+    "verifyEnsOrUseAddress": "Please verify the recipient ENS or use a 0x address.",
+    "passkeyContractDeploymentUnsupported": "Passkey accounts do not support contract deployment yet.",
+    "passkeyMulticallUnsupported": "Passkey accounts do not support multi-call batches yet.",
+    "passkeyActiveAccountRequired": "Active account is not a passkey account",
+    "passkeyEthSignHashRequired": "Passkey eth_sign requires a 32-byte hash so EIP-1271 verifiers can reproduce it",
+    "passkeyLegacyTypedDataUnsupported": "Passkey accounts do not support legacy typed-data V1 signing yet",
+    "passkeyUnsupportedSigningRequest": "Unsupported passkey signing request"
   },
   "settings": {
     "bgError": "Background Error",
@@ -534,7 +553,11 @@
     "closeAndReopenPali": "Close this window and reopen Pali to authenticate and connect your hardware wallet",
     "activeAccountNotFound": "Error: Active account not found",
     "paliWalletBrowserExtension": "Pali Wallet Browser Extension",
-    "addressType": "Address type"
+    "addressType": "Address type",
+    "passkey": "Passkey",
+    "passkeyAccount": "Passkey Account",
+    "createPasskeyAccount": "Create Passkey Account",
+    "createPasskeyAccountDescription": "Use Touch ID, Face ID, Windows Hello, Android biometrics, or a security key to approve smart-account transactions on zkSYS."
   },
   "start": {
     "paliDoesnt": "Pali doesn't store your password. Regaining access requires a wallet reset with your Secret Recovery Phrase. This action erases the current wallet, created accounts, custom tokens, and imported accounts from your device, generating a new account tied to the reset phrase.",

--- a/source/assets/locales/es.json
+++ b/source/assets/locales/es.json
@@ -139,8 +139,6 @@
     "loadingAccounts": "Cargando cuentas...",
     "dappFallback": "Esta aplicación",
     "passkeyDefaultLabel": "Passkey de {{host}}",
-    "userRejectedPasskeyCreation": "El usuario rechazó la creación de la cuenta Passkey",
-    "unableToCreatePasskeyAccount": "No se pudo crear la cuenta Passkey",
     "createPasskeyAccountTitle": "Crear cuenta Passkey",
     "createPasskeyAccountDescription": "{{host}} quiere que Pali cree una cuenta inteligente de zkSYS controlada por el passkey de tu dispositivo. Pali solo almacena metadatos públicos; la clave privada permanece en tu autenticador.",
     "sponsorPolicy": "Política de patrocinador: {{policy}}",

--- a/source/assets/locales/es.json
+++ b/source/assets/locales/es.json
@@ -554,7 +554,6 @@
     "activeAccountNotFound": "Error: Cuenta activa no encontrada",
     "paliWalletBrowserExtension": "Extensión del Navegador Pali Wallet",
     "addressType": "Tipo de dirección",
-    "passkey": "Passkey",
     "passkeyAccount": "Cuenta Passkey",
     "createPasskeyAccount": "Crear cuenta Passkey",
     "createPasskeyAccountDescription": "Usa Touch ID, Face ID, Windows Hello, biometría de Android o una llave de seguridad para aprobar transacciones de cuenta inteligente en zkSYS."

--- a/source/assets/locales/es.json
+++ b/source/assets/locales/es.json
@@ -136,7 +136,20 @@
     "selectAccountToConnect": "Seleccione la cuenta que desea conectar con este sitio",
     "currentlyConnected": "Actualmente conectado",
     "noAddress": "Sin dirección",
-    "loadingAccounts": "Cargando cuentas..."
+    "loadingAccounts": "Cargando cuentas...",
+    "dappFallback": "Esta aplicación",
+    "passkeyDefaultLabel": "Passkey de {{host}}",
+    "userRejectedPasskeyCreation": "El usuario rechazó la creación de la cuenta Passkey",
+    "unableToCreatePasskeyAccount": "No se pudo crear la cuenta Passkey",
+    "createPasskeyAccountTitle": "Crear cuenta Passkey",
+    "createPasskeyAccountDescription": "{{host}} quiere que Pali cree una cuenta inteligente de zkSYS controlada por el passkey de tu dispositivo. Pali solo almacena metadatos públicos; la clave privada permanece en tu autenticador.",
+    "sponsorPolicy": "Política de patrocinador: {{policy}}",
+    "sponsorGasOnly": "Patrocinador de gas opcional",
+    "sponsorRequired": "Aprobación del patrocinador requerida",
+    "sponsorDisabled": "Sin patrocinador",
+    "sponsorUrl": "URL del patrocinador: {{url}}",
+    "sponsorSigner": "Firmante del patrocinador: {{signer}}",
+    "sponsorRequiredWarning": "Esta cuenta requerirá coautorización del patrocinador antes de que Pali pueda ejecutar transacciones desde ella."
   },
   "home": {
     "importToken": "Importar Token",
@@ -387,7 +400,13 @@
     "invalidEthSignFormat": "Formato de mensaje eth_sign inválido. Se esperaba cadena hex de 32 bytes (64 caracteres), se obtuvo: \"{{message}}\". Para firmar texto arbitrario, la dapp debería usar personal_sign.",
     "unableToResolveEns": "No se puede resolver el nombre ENS",
     "invalidDestination": "Destino inválido",
-    "verifyEnsOrUseAddress": "Verifica el ENS del destinatario o usa una dirección 0x."
+    "verifyEnsOrUseAddress": "Verifica el ENS del destinatario o usa una dirección 0x.",
+    "passkeyContractDeploymentUnsupported": "Las cuentas Passkey aún no admiten despliegue de contratos.",
+    "passkeyMulticallUnsupported": "Las cuentas Passkey aún no admiten lotes de múltiples llamadas.",
+    "passkeyActiveAccountRequired": "La cuenta activa no es una cuenta Passkey",
+    "passkeyEthSignHashRequired": "Passkey eth_sign requiere un hash de 32 bytes para que los verificadores EIP-1271 puedan reproducirlo",
+    "passkeyLegacyTypedDataUnsupported": "Las cuentas Passkey aún no admiten la firma de typed-data V1 heredada",
+    "passkeyUnsupportedSigningRequest": "Solicitud de firma Passkey no compatible"
   },
   "settings": {
     "bgError": "Error de Fondo",
@@ -534,7 +553,11 @@
     "closeAndReopenPali": "Cierre esta ventana y reabra Pali para autenticarse y conectar su billetera de hardware",
     "activeAccountNotFound": "Error: Cuenta activa no encontrada",
     "paliWalletBrowserExtension": "Extensión del Navegador Pali Wallet",
-    "addressType": "Tipo de dirección"
+    "addressType": "Tipo de dirección",
+    "passkey": "Passkey",
+    "passkeyAccount": "Cuenta Passkey",
+    "createPasskeyAccount": "Crear cuenta Passkey",
+    "createPasskeyAccountDescription": "Usa Touch ID, Face ID, Windows Hello, biometría de Android o una llave de seguridad para aprobar transacciones de cuenta inteligente en zkSYS."
   },
   "start": {
     "paliDoesnt": "Pali no guarda tu contraseña. Recuperar el acceso requiere un reinicio de la billetera con tu Frase Secreta de Recuperación. Esta acción borra la billetera actual, las cuentas creadas, tokens personalizados y cuentas importadas de tu dispositivo, generando una nueva cuenta vinculada a la frase de reinicio.",

--- a/source/assets/locales/fr.json
+++ b/source/assets/locales/fr.json
@@ -215,7 +215,11 @@
     "closeAndReopenPali": "Fermez cette fenêtre et rouvrez Pali pour vous authentifier et connecter votre portefeuille matériel",
     "activeAccountNotFound": "Erreur: Compte actif non trouvé",
     "paliWalletBrowserExtension": "Extension de Navigateur Pali Wallet",
-    "addressType": "Type d'adresse"
+    "addressType": "Type d'adresse",
+    "passkey": "Passkey",
+    "passkeyAccount": "Compte Passkey",
+    "createPasskeyAccount": "Créer un compte Passkey",
+    "createPasskeyAccountDescription": "Utilisez Touch ID, Face ID, Windows Hello, la biométrie Android ou une clé de sécurité pour approuver les transactions de compte intelligent sur zkSYS."
   },
   "components": {
     "newPassword": "Nouveau mot de passe (12 caractères min.)",
@@ -304,7 +308,20 @@
     "selectAccountToConnect": "Sélectionnez le compte que vous souhaitez connecter avec ce site",
     "currentlyConnected": "Actuellement connecté",
     "noAddress": "Aucune adresse",
-    "loadingAccounts": "Chargement des comptes..."
+    "loadingAccounts": "Chargement des comptes...",
+    "dappFallback": "Cette application",
+    "passkeyDefaultLabel": "Passkey de {{host}}",
+    "userRejectedPasskeyCreation": "L'utilisateur a refusé la création du compte Passkey",
+    "unableToCreatePasskeyAccount": "Impossible de créer le compte Passkey",
+    "createPasskeyAccountTitle": "Créer un compte Passkey",
+    "createPasskeyAccountDescription": "{{host}} souhaite que Pali crée un compte intelligent zkSYS contrôlé par la passkey de votre appareil. Pali ne stocke que des métadonnées publiques ; la clé privée reste dans votre authentificateur.",
+    "sponsorPolicy": "Politique du sponsor : {{policy}}",
+    "sponsorGasOnly": "Sponsor de gas optionnel",
+    "sponsorRequired": "Approbation du sponsor requise",
+    "sponsorDisabled": "Aucun sponsor",
+    "sponsorUrl": "URL du sponsor : {{url}}",
+    "sponsorSigner": "Signataire du sponsor : {{signer}}",
+    "sponsorRequiredWarning": "Ce compte exigera une coautorisation du sponsor avant que Pali puisse exécuter des transactions depuis celui-ci."
   },
   "import": {
     "importModalWordMissing": "Mot manquant !",
@@ -529,7 +546,13 @@
     "invalidEthSignFormat": "Format de message eth_sign invalide. Chaîne hex de 32 octets (64 caractères) attendue, obtenu : \"{{message}}\". Pour signer du texte arbitraire, la dapp devrait utiliser personal_sign.",
     "unableToResolveEns": "Impossible de résoudre le nom ENS",
     "invalidDestination": "Destination invalide",
-    "verifyEnsOrUseAddress": "Veuillez vérifier l’ENS du destinataire ou utiliser une adresse 0x."
+    "verifyEnsOrUseAddress": "Veuillez vérifier l’ENS du destinataire ou utiliser une adresse 0x.",
+    "passkeyContractDeploymentUnsupported": "Les comptes Passkey ne prennent pas encore en charge le déploiement de contrats.",
+    "passkeyMulticallUnsupported": "Les comptes Passkey ne prennent pas encore en charge les lots multi-appels.",
+    "passkeyActiveAccountRequired": "Le compte actif n'est pas un compte Passkey",
+    "passkeyEthSignHashRequired": "Passkey eth_sign nécessite un hash de 32 octets afin que les vérificateurs EIP-1271 puissent le reproduire",
+    "passkeyLegacyTypedDataUnsupported": "Les comptes Passkey ne prennent pas encore en charge la signature typed-data V1 héritée",
+    "passkeyUnsupportedSigningRequest": "Demande de signature Passkey non prise en charge"
   },
   "titles": {
     "assetDetails": "Détails de l'actif",

--- a/source/assets/locales/fr.json
+++ b/source/assets/locales/fr.json
@@ -310,8 +310,6 @@
     "loadingAccounts": "Chargement des comptes...",
     "dappFallback": "Cette application",
     "passkeyDefaultLabel": "Passkey de {{host}}",
-    "userRejectedPasskeyCreation": "L'utilisateur a refusé la création du compte Passkey",
-    "unableToCreatePasskeyAccount": "Impossible de créer le compte Passkey",
     "createPasskeyAccountTitle": "Créer un compte Passkey",
     "createPasskeyAccountDescription": "{{host}} souhaite que Pali crée un compte intelligent zkSYS contrôlé par la passkey de votre appareil. Pali ne stocke que des métadonnées publiques ; la clé privée reste dans votre authentificateur.",
     "sponsorPolicy": "Politique du sponsor : {{policy}}",

--- a/source/assets/locales/fr.json
+++ b/source/assets/locales/fr.json
@@ -216,7 +216,6 @@
     "activeAccountNotFound": "Erreur: Compte actif non trouvé",
     "paliWalletBrowserExtension": "Extension de Navigateur Pali Wallet",
     "addressType": "Type d'adresse",
-    "passkey": "Passkey",
     "passkeyAccount": "Compte Passkey",
     "createPasskeyAccount": "Créer un compte Passkey",
     "createPasskeyAccountDescription": "Utilisez Touch ID, Face ID, Windows Hello, la biométrie Android ou une clé de sécurité pour approuver les transactions de compte intelligent sur zkSYS."

--- a/source/assets/locales/ja.json
+++ b/source/assets/locales/ja.json
@@ -310,8 +310,6 @@
     "loadingAccounts": "アカウントを読み込み中...",
     "dappFallback": "このアプリ",
     "passkeyDefaultLabel": "{{host}} パスキー",
-    "userRejectedPasskeyCreation": "ユーザーがパスキーアカウントの作成を拒否しました",
-    "unableToCreatePasskeyAccount": "パスキーアカウントを作成できません",
     "createPasskeyAccountTitle": "パスキーアカウントを作成",
     "createPasskeyAccountDescription": "{{host}} は、デバイスのパスキーで制御される zkSYS スマートアカウントを Pali に作成させようとしています。Pali が保存するのは公開メタデータのみで、秘密鍵は認証器に残ります。",
     "sponsorPolicy": "スポンサー方針: {{policy}}",

--- a/source/assets/locales/ja.json
+++ b/source/assets/locales/ja.json
@@ -216,7 +216,6 @@
     "activeAccountNotFound": "エラー：アクティブなアカウントが見つかりません",
     "paliWalletBrowserExtension": "Pali Walletブラウザ拡張機能",
     "addressType": "アドレスタイプ",
-    "passkey": "パスキー",
     "passkeyAccount": "パスキーアカウント",
     "createPasskeyAccount": "パスキーアカウントを作成",
     "createPasskeyAccountDescription": "Touch ID、Face ID、Windows Hello、Android 生体認証、またはセキュリティキーを使って、zkSYS 上のスマートアカウント取引を承認します。"

--- a/source/assets/locales/ja.json
+++ b/source/assets/locales/ja.json
@@ -215,7 +215,11 @@
     "closeAndReopenPali": "このウィンドウを閉じてPaliを再度開き、認証してハードウェアウォレットを接続してください",
     "activeAccountNotFound": "エラー：アクティブなアカウントが見つかりません",
     "paliWalletBrowserExtension": "Pali Walletブラウザ拡張機能",
-    "addressType": "アドレスタイプ"
+    "addressType": "アドレスタイプ",
+    "passkey": "パスキー",
+    "passkeyAccount": "パスキーアカウント",
+    "createPasskeyAccount": "パスキーアカウントを作成",
+    "createPasskeyAccountDescription": "Touch ID、Face ID、Windows Hello、Android 生体認証、またはセキュリティキーを使って、zkSYS 上のスマートアカウント取引を承認します。"
   },
   "components": {
     "newPassword": "新しいパスワード（最低12文字）",
@@ -304,7 +308,20 @@
     "selectAccountToConnect": "このサイトに接続したいアカウントを選択してください",
     "currentlyConnected": "現在接続中",
     "noAddress": "アドレスなし",
-    "loadingAccounts": "アカウントを読み込み中..."
+    "loadingAccounts": "アカウントを読み込み中...",
+    "dappFallback": "このアプリ",
+    "passkeyDefaultLabel": "{{host}} パスキー",
+    "userRejectedPasskeyCreation": "ユーザーがパスキーアカウントの作成を拒否しました",
+    "unableToCreatePasskeyAccount": "パスキーアカウントを作成できません",
+    "createPasskeyAccountTitle": "パスキーアカウントを作成",
+    "createPasskeyAccountDescription": "{{host}} は、デバイスのパスキーで制御される zkSYS スマートアカウントを Pali に作成させようとしています。Pali が保存するのは公開メタデータのみで、秘密鍵は認証器に残ります。",
+    "sponsorPolicy": "スポンサー方針: {{policy}}",
+    "sponsorGasOnly": "ガススポンサーは任意",
+    "sponsorRequired": "スポンサー承認が必要",
+    "sponsorDisabled": "スポンサーなし",
+    "sponsorUrl": "スポンサー URL: {{url}}",
+    "sponsorSigner": "スポンサー署名者: {{signer}}",
+    "sponsorRequiredWarning": "このアカウントから Pali が取引を実行するには、スポンサーの共同承認が必要です。"
   },
   "titles": {
     "assetDetails": "資産詳細",
@@ -534,7 +551,13 @@
     "invalidEthSignFormat": "無効なeth_signメッセージ形式。32バイトのhex文字列（64文字）が期待されましたが、\"{{message}}\"を受け取りました。任意のテキストに署名する場合、dappはpersonal_signを使用する必要があります。",
     "unableToResolveEns": "ENS名を解決できません",
     "invalidDestination": "無効な宛先",
-    "verifyEnsOrUseAddress": "受信者のENSを確認するか、0xアドレスを使用してください。"
+    "verifyEnsOrUseAddress": "受信者のENSを確認するか、0xアドレスを使用してください。",
+    "passkeyContractDeploymentUnsupported": "パスキーアカウントはまだコントラクトデプロイに対応していません。",
+    "passkeyMulticallUnsupported": "パスキーアカウントはまだマルチコールバッチに対応していません。",
+    "passkeyActiveAccountRequired": "アクティブなアカウントはパスキーアカウントではありません",
+    "passkeyEthSignHashRequired": "EIP-1271 検証者が再現できるように、Passkey eth_sign には 32 バイトのハッシュが必要です",
+    "passkeyLegacyTypedDataUnsupported": "パスキーアカウントはまだレガシー typed-data V1 署名に対応していません",
+    "passkeyUnsupportedSigningRequest": "対応していないパスキー署名リクエストです"
   },
   "start": {
     "paliDoesnt": "Paliはパスワードを保存しません。アクセスを回復するには、シークレットリカバリーフレーズでウォレットをリセットする必要があります。",

--- a/source/assets/locales/ko.json
+++ b/source/assets/locales/ko.json
@@ -215,7 +215,11 @@
     "closeAndReopenPali": "이 창을 닫고 Pali를 다시 열어서 인증하고 하드웨어 지갑을 연결하세요",
     "activeAccountNotFound": "오류: 활성 계정을 찾을 수 없습니다",
     "paliWalletBrowserExtension": "Pali Wallet 브라우저 확장",
-    "addressType": "주소 유형"
+    "addressType": "주소 유형",
+    "passkey": "패스키",
+    "passkeyAccount": "패스키 계정",
+    "createPasskeyAccount": "패스키 계정 만들기",
+    "createPasskeyAccountDescription": "Touch ID, Face ID, Windows Hello, Android 생체 인증 또는 보안 키를 사용해 zkSYS의 스마트 계정 트랜잭션을 승인하세요."
   },
   "components": {
     "newPassword": "새 비밀번호 (최소 12자)",
@@ -304,7 +308,20 @@
     "selectAccountToConnect": "이 사이트와 연결하고 싶은 계정을 선택하세요",
     "currentlyConnected": "현재 연결됨",
     "noAddress": "주소 없음",
-    "loadingAccounts": "계정 로딩 중..."
+    "loadingAccounts": "계정 로딩 중...",
+    "dappFallback": "이 앱",
+    "passkeyDefaultLabel": "{{host}} 패스키",
+    "userRejectedPasskeyCreation": "사용자가 패스키 계정 생성을 거부했습니다",
+    "unableToCreatePasskeyAccount": "패스키 계정을 만들 수 없습니다",
+    "createPasskeyAccountTitle": "패스키 계정 만들기",
+    "createPasskeyAccountDescription": "{{host}}에서 기기 패스키로 제어되는 zkSYS 스마트 계정을 Pali가 만들도록 요청합니다. Pali는 공개 메타데이터만 저장하며 개인 키는 인증 장치에 남아 있습니다.",
+    "sponsorPolicy": "스폰서 정책: {{policy}}",
+    "sponsorGasOnly": "가스 스폰서 선택 사항",
+    "sponsorRequired": "스폰서 승인 필요",
+    "sponsorDisabled": "스폰서 없음",
+    "sponsorUrl": "스폰서 URL: {{url}}",
+    "sponsorSigner": "스폰서 서명자: {{signer}}",
+    "sponsorRequiredWarning": "이 계정은 Pali가 트랜잭션을 실행하기 전에 스폰서의 공동 승인이 필요합니다."
   },
   "titles": {
     "assetDetails": "자산 상세정보",
@@ -534,7 +551,13 @@
     "invalidEthSignFormat": "유효하지 않은 eth_sign 메시지 형식입니다. 32바이트 hex 문자열(64자)이 예상되었지만 \"{{message}}\"를 받았습니다. 임의의 텍스트에 서명하려면 dapp에서 personal_sign을 사용해야 합니다.",
     "unableToResolveEns": "ENS 이름을 해석할 수 없습니다",
     "invalidDestination": "유효하지 않은 대상",
-    "verifyEnsOrUseAddress": "수신자의 ENS를 확인하거나 0x 주소를 사용하세요."
+    "verifyEnsOrUseAddress": "수신자의 ENS를 확인하거나 0x 주소를 사용하세요.",
+    "passkeyContractDeploymentUnsupported": "패스키 계정은 아직 계약 배포를 지원하지 않습니다.",
+    "passkeyMulticallUnsupported": "패스키 계정은 아직 다중 호출 배치를 지원하지 않습니다.",
+    "passkeyActiveAccountRequired": "활성 계정이 패스키 계정이 아닙니다",
+    "passkeyEthSignHashRequired": "EIP-1271 검증자가 재현할 수 있도록 Passkey eth_sign에는 32바이트 해시가 필요합니다",
+    "passkeyLegacyTypedDataUnsupported": "패스키 계정은 아직 레거시 typed-data V1 서명을 지원하지 않습니다",
+    "passkeyUnsupportedSigningRequest": "지원되지 않는 패스키 서명 요청입니다"
   },
   "start": {
     "paliDoesnt": "Pali는 비밀번호를 저장하지 않습니다. 액세스를 복구하려면 비밀 복구 구문으로 지갑을 재설정해야 합니다.",

--- a/source/assets/locales/ko.json
+++ b/source/assets/locales/ko.json
@@ -216,7 +216,6 @@
     "activeAccountNotFound": "오류: 활성 계정을 찾을 수 없습니다",
     "paliWalletBrowserExtension": "Pali Wallet 브라우저 확장",
     "addressType": "주소 유형",
-    "passkey": "패스키",
     "passkeyAccount": "패스키 계정",
     "createPasskeyAccount": "패스키 계정 만들기",
     "createPasskeyAccountDescription": "Touch ID, Face ID, Windows Hello, Android 생체 인증 또는 보안 키를 사용해 zkSYS의 스마트 계정 트랜잭션을 승인하세요."

--- a/source/assets/locales/ko.json
+++ b/source/assets/locales/ko.json
@@ -310,8 +310,6 @@
     "loadingAccounts": "계정 로딩 중...",
     "dappFallback": "이 앱",
     "passkeyDefaultLabel": "{{host}} 패스키",
-    "userRejectedPasskeyCreation": "사용자가 패스키 계정 생성을 거부했습니다",
-    "unableToCreatePasskeyAccount": "패스키 계정을 만들 수 없습니다",
     "createPasskeyAccountTitle": "패스키 계정 만들기",
     "createPasskeyAccountDescription": "{{host}}에서 기기 패스키로 제어되는 zkSYS 스마트 계정을 Pali가 만들도록 요청합니다. Pali는 공개 메타데이터만 저장하며 개인 키는 인증 장치에 남아 있습니다.",
     "sponsorPolicy": "스폰서 정책: {{policy}}",

--- a/source/assets/locales/pt.json
+++ b/source/assets/locales/pt.json
@@ -139,8 +139,6 @@
     "loadingAccounts": "Carregando contas...",
     "dappFallback": "Este aplicativo",
     "passkeyDefaultLabel": "Passkey de {{host}}",
-    "userRejectedPasskeyCreation": "O usuário rejeitou a criação da conta Passkey",
-    "unableToCreatePasskeyAccount": "Não foi possível criar a conta Passkey",
     "createPasskeyAccountTitle": "Criar conta Passkey",
     "createPasskeyAccountDescription": "{{host}} quer que a Pali crie uma conta inteligente zkSYS controlada pela passkey do seu dispositivo. A Pali armazena apenas metadados públicos; a chave privada permanece no seu autenticador.",
     "sponsorPolicy": "Política do patrocinador: {{policy}}",

--- a/source/assets/locales/pt.json
+++ b/source/assets/locales/pt.json
@@ -549,7 +549,6 @@
     "activeAccountNotFound": "Erro: Conta ativa não encontrada",
     "paliWalletBrowserExtension": "Extensão do Navegador Pali Wallet",
     "addressType": "Tipo de endereço",
-    "passkey": "Passkey",
     "passkeyAccount": "Conta Passkey",
     "createPasskeyAccount": "Criar conta Passkey",
     "createPasskeyAccountDescription": "Use Touch ID, Face ID, Windows Hello, biometria do Android ou uma chave de segurança para aprovar transações de conta inteligente na zkSYS."

--- a/source/assets/locales/pt.json
+++ b/source/assets/locales/pt.json
@@ -136,7 +136,20 @@
     "selectAccountToConnect": "Selecione a conta que você deseja conectar com este site",
     "currentlyConnected": "Atualmente conectado",
     "noAddress": "Nenhum endereço",
-    "loadingAccounts": "Carregando contas..."
+    "loadingAccounts": "Carregando contas...",
+    "dappFallback": "Este aplicativo",
+    "passkeyDefaultLabel": "Passkey de {{host}}",
+    "userRejectedPasskeyCreation": "O usuário rejeitou a criação da conta Passkey",
+    "unableToCreatePasskeyAccount": "Não foi possível criar a conta Passkey",
+    "createPasskeyAccountTitle": "Criar conta Passkey",
+    "createPasskeyAccountDescription": "{{host}} quer que a Pali crie uma conta inteligente zkSYS controlada pela passkey do seu dispositivo. A Pali armazena apenas metadados públicos; a chave privada permanece no seu autenticador.",
+    "sponsorPolicy": "Política do patrocinador: {{policy}}",
+    "sponsorGasOnly": "Patrocinador de gás opcional",
+    "sponsorRequired": "Aprovação do patrocinador obrigatória",
+    "sponsorDisabled": "Sem patrocinador",
+    "sponsorUrl": "URL do patrocinador: {{url}}",
+    "sponsorSigner": "Assinante do patrocinador: {{signer}}",
+    "sponsorRequiredWarning": "Esta conta exigirá coautorização do patrocinador antes que a Pali possa executar transações a partir dela."
   },
   "home": {
     "importToken": "Importar Token",
@@ -382,7 +395,13 @@
     "invalidEthSignFormat": "Formato de mensagem eth_sign inválido. Esperava-se string hex de 32 bytes (64 caracteres), obtido: \"{{message}}\". Para assinar texto arbitrário, o dapp deveria usar personal_sign.",
     "unableToResolveEns": "Não foi possível resolver o nome ENS",
     "invalidDestination": "Destino inválido",
-    "verifyEnsOrUseAddress": "Verifique o ENS do destinatário ou use um endereço 0x."
+    "verifyEnsOrUseAddress": "Verifique o ENS do destinatário ou use um endereço 0x.",
+    "passkeyContractDeploymentUnsupported": "Contas Passkey ainda não oferecem suporte a implantação de contratos.",
+    "passkeyMulticallUnsupported": "Contas Passkey ainda não oferecem suporte a lotes de múltiplas chamadas.",
+    "passkeyActiveAccountRequired": "A conta ativa não é uma conta Passkey",
+    "passkeyEthSignHashRequired": "Passkey eth_sign requer um hash de 32 bytes para que verificadores EIP-1271 possam reproduzi-lo",
+    "passkeyLegacyTypedDataUnsupported": "Contas Passkey ainda não oferecem suporte à assinatura typed-data V1 legada",
+    "passkeyUnsupportedSigningRequest": "Solicitação de assinatura Passkey não suportada"
   },
   "settings": {
     "bgError": "Erro em segundo plano",
@@ -529,7 +548,11 @@
     "closeAndReopenPali": "Feche esta janela e reabra o Pali para autenticar e conectar sua carteira de hardware",
     "activeAccountNotFound": "Erro: Conta ativa não encontrada",
     "paliWalletBrowserExtension": "Extensão do Navegador Pali Wallet",
-    "addressType": "Tipo de endereço"
+    "addressType": "Tipo de endereço",
+    "passkey": "Passkey",
+    "passkeyAccount": "Conta Passkey",
+    "createPasskeyAccount": "Criar conta Passkey",
+    "createPasskeyAccountDescription": "Use Touch ID, Face ID, Windows Hello, biometria do Android ou uma chave de segurança para aprovar transações de conta inteligente na zkSYS."
   },
   "start": {
     "paliDoesnt": "O Pali não armazena sua senha. Para recuperar o acesso, é necessário redefinir a carteira com sua Frase de Recuperação Secreta. Esta ação apaga a carteira atual, contas criadas, tokens personalizados e contas importadas do seu dispositivo, gerando uma nova conta vinculada à frase de redefinição.",

--- a/source/assets/locales/ru.json
+++ b/source/assets/locales/ru.json
@@ -215,7 +215,11 @@
     "closeAndReopenPali": "Закройте это окно и снова откройте Pali для аутентификации и подключения аппаратного кошелька",
     "activeAccountNotFound": "Ошибка: Активный аккаунт не найден",
     "paliWalletBrowserExtension": "Расширение для браузера Pali Wallet",
-    "addressType": "Тип адреса"
+    "addressType": "Тип адреса",
+    "passkey": "Passkey",
+    "passkeyAccount": "Аккаунт Passkey",
+    "createPasskeyAccount": "Создать аккаунт Passkey",
+    "createPasskeyAccountDescription": "Используйте Touch ID, Face ID, Windows Hello, биометрию Android или ключ безопасности для подтверждения транзакций смарт-аккаунта в zkSYS."
   },
   "components": {
     "newPassword": "Новый пароль (мин. 12 символов)",
@@ -304,7 +308,20 @@
     "selectAccountToConnect": "Выберите аккаунт, который вы хотите подключить к этому сайту",
     "currentlyConnected": "В настоящее время подключен",
     "noAddress": "Нет адреса",
-    "loadingAccounts": "Загрузка аккаунтов..."
+    "loadingAccounts": "Загрузка аккаунтов...",
+    "dappFallback": "Это приложение",
+    "passkeyDefaultLabel": "Passkey для {{host}}",
+    "userRejectedPasskeyCreation": "Пользователь отклонил создание аккаунта Passkey",
+    "unableToCreatePasskeyAccount": "Не удалось создать аккаунт Passkey",
+    "createPasskeyAccountTitle": "Создать аккаунт Passkey",
+    "createPasskeyAccountDescription": "{{host}} хочет, чтобы Pali создал смарт-аккаунт zkSYS, управляемый passkey вашего устройства. Pali хранит только публичные метаданные; приватный ключ остается в вашем аутентификаторе.",
+    "sponsorPolicy": "Политика спонсора: {{policy}}",
+    "sponsorGasOnly": "Спонсор газа необязателен",
+    "sponsorRequired": "Требуется одобрение спонсора",
+    "sponsorDisabled": "Без спонсора",
+    "sponsorUrl": "URL спонсора: {{url}}",
+    "sponsorSigner": "Подписант спонсора: {{signer}}",
+    "sponsorRequiredWarning": "Этот аккаунт потребует соавторизации спонсора, прежде чем Pali сможет выполнять транзакции от его имени."
   },
   "titles": {
     "assetDetails": "ДЕТАЛИ АКТИВА",
@@ -534,7 +551,13 @@
     "invalidEthSignFormat": "Неверный формат сообщения eth_sign. Ожидается 32-байтовая hex-строка (64 символа), получено: \"{{message}}\". Для подписи произвольного текста dapp должен использовать personal_sign.",
     "unableToResolveEns": "Не удалось разрешить имя ENS",
     "invalidDestination": "Недопустимый адрес назначения",
-    "verifyEnsOrUseAddress": "Проверьте ENS получателя или используйте адрес 0x."
+    "verifyEnsOrUseAddress": "Проверьте ENS получателя или используйте адрес 0x.",
+    "passkeyContractDeploymentUnsupported": "Аккаунты Passkey пока не поддерживают развертывание контрактов.",
+    "passkeyMulticallUnsupported": "Аккаунты Passkey пока не поддерживают пакеты с несколькими вызовами.",
+    "passkeyActiveAccountRequired": "Активный аккаунт не является аккаунтом Passkey",
+    "passkeyEthSignHashRequired": "Passkey eth_sign требует 32-байтный хэш, чтобы проверяющие EIP-1271 могли его воспроизвести",
+    "passkeyLegacyTypedDataUnsupported": "Аккаунты Passkey пока не поддерживают устаревшую подпись typed-data V1",
+    "passkeyUnsupportedSigningRequest": "Неподдерживаемый запрос подписи Passkey"
   },
   "start": {
     "paliDoesnt": "Pali не хранит ваш пароль. Восстановление доступа требует сброса кошелька с помощью секретной фразы восстановления.",

--- a/source/assets/locales/ru.json
+++ b/source/assets/locales/ru.json
@@ -310,8 +310,6 @@
     "loadingAccounts": "Загрузка аккаунтов...",
     "dappFallback": "Это приложение",
     "passkeyDefaultLabel": "Passkey для {{host}}",
-    "userRejectedPasskeyCreation": "Пользователь отклонил создание аккаунта Passkey",
-    "unableToCreatePasskeyAccount": "Не удалось создать аккаунт Passkey",
     "createPasskeyAccountTitle": "Создать аккаунт Passkey",
     "createPasskeyAccountDescription": "{{host}} хочет, чтобы Pali создал смарт-аккаунт zkSYS, управляемый passkey вашего устройства. Pali хранит только публичные метаданные; приватный ключ остается в вашем аутентификаторе.",
     "sponsorPolicy": "Политика спонсора: {{policy}}",

--- a/source/assets/locales/ru.json
+++ b/source/assets/locales/ru.json
@@ -216,7 +216,6 @@
     "activeAccountNotFound": "Ошибка: Активный аккаунт не найден",
     "paliWalletBrowserExtension": "Расширение для браузера Pali Wallet",
     "addressType": "Тип адреса",
-    "passkey": "Passkey",
     "passkeyAccount": "Аккаунт Passkey",
     "createPasskeyAccount": "Создать аккаунт Passkey",
     "createPasskeyAccountDescription": "Используйте Touch ID, Face ID, Windows Hello, биометрию Android или ключ безопасности для подтверждения транзакций смарт-аккаунта в zkSYS."

--- a/source/assets/locales/zh.json
+++ b/source/assets/locales/zh.json
@@ -310,8 +310,6 @@
     "loadingAccounts": "正在加载账户...",
     "dappFallback": "此应用",
     "passkeyDefaultLabel": "{{host}} 通行密钥",
-    "userRejectedPasskeyCreation": "用户拒绝创建通行密钥账户",
-    "unableToCreatePasskeyAccount": "无法创建通行密钥账户",
     "createPasskeyAccountTitle": "创建通行密钥账户",
     "createPasskeyAccountDescription": "{{host}} 希望 Pali 创建一个由你设备通行密钥控制的 zkSYS 智能账户。Pali 只存储公开元数据；私钥保留在你的认证器中。",
     "sponsorPolicy": "赞助策略：{{policy}}",

--- a/source/assets/locales/zh.json
+++ b/source/assets/locales/zh.json
@@ -215,7 +215,11 @@
     "closeAndReopenPali": "关闭此窗口并重新打开 Pali 以进行身份验证并连接您的硬件钱包",
     "activeAccountNotFound": "错误：未找到活跃账户",
     "paliWalletBrowserExtension": "Pali钱包浏览器扩展",
-    "addressType": "地址类型"
+    "addressType": "地址类型",
+    "passkey": "通行密钥",
+    "passkeyAccount": "通行密钥账户",
+    "createPasskeyAccount": "创建通行密钥账户",
+    "createPasskeyAccountDescription": "使用 Touch ID、Face ID、Windows Hello、Android 生物识别或安全密钥来批准 zkSYS 上的智能账户交易。"
   },
   "components": {
     "newPassword": "新密码（至少12个字符）",
@@ -304,7 +308,20 @@
     "selectAccountToConnect": "选择您想要与此网站连接的账户",
     "currentlyConnected": "当前已连接",
     "noAddress": "无地址",
-    "loadingAccounts": "正在加载账户..."
+    "loadingAccounts": "正在加载账户...",
+    "dappFallback": "此应用",
+    "passkeyDefaultLabel": "{{host}} 通行密钥",
+    "userRejectedPasskeyCreation": "用户拒绝创建通行密钥账户",
+    "unableToCreatePasskeyAccount": "无法创建通行密钥账户",
+    "createPasskeyAccountTitle": "创建通行密钥账户",
+    "createPasskeyAccountDescription": "{{host}} 希望 Pali 创建一个由你设备通行密钥控制的 zkSYS 智能账户。Pali 只存储公开元数据；私钥保留在你的认证器中。",
+    "sponsorPolicy": "赞助策略：{{policy}}",
+    "sponsorGasOnly": "Gas 赞助可选",
+    "sponsorRequired": "需要赞助方批准",
+    "sponsorDisabled": "无赞助方",
+    "sponsorUrl": "赞助方 URL：{{url}}",
+    "sponsorSigner": "赞助方签名者：{{signer}}",
+    "sponsorRequiredWarning": "该账户需要赞助方共同授权后，Pali 才能从该账户执行交易。"
   },
   "start": {
     "paliDoesnt": "Pali不存储您的密码。恢复访问权限需要使用您的秘密恢复短语重置钱包。此操作会从您的设备中删除当前钱包、创建的账户、自定义代币和导入的账户，生成与重置短语绑定的新账户。",
@@ -753,7 +770,13 @@
     "invalidEthSignFormat": "无效的eth_sign消息格式。期望32字节十六进制字符串（64个字符），得到：\"{{message}}\"。要签署任意文本，dapp应使用personal_sign。",
     "unableToResolveEns": "无法解析 ENS 名称",
     "invalidDestination": "无效的目标",
-    "verifyEnsOrUseAddress": "请验证收件人的 ENS 或使用 0x 地址。"
+    "verifyEnsOrUseAddress": "请验证收件人的 ENS 或使用 0x 地址。",
+    "passkeyContractDeploymentUnsupported": "通行密钥账户暂不支持合约部署。",
+    "passkeyMulticallUnsupported": "通行密钥账户暂不支持多调用批处理。",
+    "passkeyActiveAccountRequired": "当前活动账户不是通行密钥账户",
+    "passkeyEthSignHashRequired": "Passkey eth_sign 需要 32 字节哈希，以便 EIP-1271 验证器可以复现",
+    "passkeyLegacyTypedDataUnsupported": "通行密钥账户暂不支持旧版 typed-data V1 签名",
+    "passkeyUnsupportedSigningRequest": "不支持的通行密钥签名请求"
   },
   "nftDetails": {
     "collectionInfo": "收藏信息",

--- a/source/assets/locales/zh.json
+++ b/source/assets/locales/zh.json
@@ -216,7 +216,6 @@
     "activeAccountNotFound": "错误：未找到活跃账户",
     "paliWalletBrowserExtension": "Pali钱包浏览器扩展",
     "addressType": "地址类型",
-    "passkey": "通行密钥",
     "passkeyAccount": "通行密钥账户",
     "createPasskeyAccount": "创建通行密钥账户",
     "createPasskeyAccountDescription": "使用 Touch ID、Face ID、Windows Hello、Android 生物识别或安全密钥来批准 zkSYS 上的智能账户交易。"

--- a/source/components/Header/AccountHeader.tsx
+++ b/source/components/Header/AccountHeader.tsx
@@ -55,15 +55,19 @@ export const AccountHeader: React.FC = () => {
 
   const editAccount = useCallback(
     (account: IKeyringAccountState) => {
+      if (!account || !activeAccount?.type) {
+        return;
+      }
+
       const returnContext = createNavigationContext('/home');
       navigateWithContext(
         navigate,
         '/settings/edit-account',
-        account,
+        { ...account, accountType: activeAccount.type },
         returnContext
       );
     },
-    [navigate]
+    [activeAccount?.type, navigate]
   );
 
   const openAccountInExplorer = useCallback(() => {

--- a/source/components/Header/AccountMenu.tsx
+++ b/source/components/Header/AccountMenu.tsx
@@ -30,7 +30,8 @@ export const AccountMenu: React.FC = () => {
   );
   const isHardwareAccount =
     activeAccountMeta?.type === KeyringAccountType.Ledger ||
-    activeAccountMeta?.type === KeyringAccountType.Trezor;
+    activeAccountMeta?.type === KeyringAccountType.Trezor ||
+    activeAccountMeta?.type === KeyringAccountType.PasskeySmartAccount;
   const setActiveAccount = async (id: number, type: KeyringAccountType) => {
     try {
       await controllerEmitter(['wallet', 'setAccount'], [Number(id), type]);

--- a/source/components/Header/RenderAccountsListByBitcoinBased.tsx
+++ b/source/components/Header/RenderAccountsListByBitcoinBased.tsx
@@ -117,6 +117,9 @@ const RenderAccountsListByBitcoinBased =
     } | null>(null);
 
     const accounts = useSelector((state: RootState) => state.vault.accounts);
+    const activeNetwork = useSelector(
+      (state: RootState) => state.vault.activeNetwork
+    );
     const isBitcoinBased = useSelector(
       (state: RootState) => state.vault.isBitcoinBased
     );
@@ -240,21 +243,26 @@ const RenderAccountsListByBitcoinBased =
     // Memoize the account list computation
     const accountsList = useMemo(
       () =>
-        Object.entries(accounts).flatMap(([accountType, accountsOfType]) => {
-          if (
-            isBitcoinBased &&
-            accountType === KeyringAccountType.PasskeySmartAccount
-          ) {
-            return [];
-          }
+        Object.entries(accounts).flatMap(([accountType, accountsOfType]) =>
+          Object.values(accountsOfType || {})
+            .filter((account: any) => {
+              if (accountType !== KeyringAccountType.PasskeySmartAccount) {
+                return true;
+              }
 
-          return Object.values(accountsOfType || {}).map((account, index) => ({
-            account,
-            accountType: accountType as KeyringAccountType,
-            index,
-          }));
-        }),
-      [accounts, isBitcoinBased]
+              return (
+                !isBitcoinBased &&
+                Number(account?.passkey?.chainId) ===
+                  Number(activeNetwork.chainId)
+              );
+            })
+            .map((account, index) => ({
+              account,
+              accountType: accountType as KeyringAccountType,
+              index,
+            }))
+        ),
+      [accounts, activeNetwork.chainId, isBitcoinBased]
     );
 
     const isAnySwitching = switchingAccount !== null;

--- a/source/components/Header/RenderAccountsListByBitcoinBased.tsx
+++ b/source/components/Header/RenderAccountsListByBitcoinBased.tsx
@@ -6,7 +6,11 @@ import { useSelector } from 'react-redux';
 
 import ledgerLogo from 'assets/all_assets/ledgerLogo.png';
 import trezorLogo from 'assets/all_assets/trezorLogo.png';
-import { PaliWhiteSmallIconSvg, LoadingSvg } from 'components/Icon/Icon';
+import {
+  PaliWhiteSmallIconSvg,
+  LoadingSvg,
+  LockIconSvg,
+} from 'components/Icon/Icon';
 import { Icon } from 'components/index';
 import { RootState } from 'state/store';
 import { selectActiveAccountRef } from 'state/vault';
@@ -36,6 +40,12 @@ const BADGE_INFO_MAP = {
     bgColor: 'bg-orange-500',
     hoverColor: 'group-hover:bg-orange-400',
     loadingColor: 'text-orange-500',
+  },
+  [KeyringAccountType.PasskeySmartAccount]: {
+    label: 'Passkey',
+    bgColor: 'bg-purple-500',
+    hoverColor: 'group-hover:bg-purple-400',
+    loadingColor: 'text-purple-500',
   },
   [KeyringAccountType.HDAccount]: {
     label: 'Pali',
@@ -85,6 +95,10 @@ const getAccountIcon = (accountType: KeyringAccountType, account: any) => {
       // Fallback to Pali icon
       return (
         <PaliWhiteSmallIconSvg className="w-7 h-7 text-brand-gray300 opacity-80 group-hover:opacity-100 group-hover:text-brand-white transition-all duration-300" />
+      );
+    case KeyringAccountType.PasskeySmartAccount:
+      return (
+        <LockIconSvg className="w-6 h-6 text-white opacity-90 group-hover:opacity-100 group-hover:text-brand-white transition-all duration-300" />
       );
     case KeyringAccountType.HDAccount:
     default:

--- a/source/components/Header/RenderAccountsListByBitcoinBased.tsx
+++ b/source/components/Header/RenderAccountsListByBitcoinBased.tsx
@@ -117,6 +117,9 @@ const RenderAccountsListByBitcoinBased =
     } | null>(null);
 
     const accounts = useSelector((state: RootState) => state.vault.accounts);
+    const isBitcoinBased = useSelector(
+      (state: RootState) => state.vault.isBitcoinBased
+    );
     const activeAccount = useSelector(selectActiveAccountRef);
     // When the accounts list is scrollable, a first click can be swallowed by inertial scrolling
     // (common on trackpads) or by focus/blur interactions. Handle selection on mouse pointer-down
@@ -237,14 +240,21 @@ const RenderAccountsListByBitcoinBased =
     // Memoize the account list computation
     const accountsList = useMemo(
       () =>
-        Object.entries(accounts).flatMap(([accountType, accountsOfType]) =>
-          Object.values(accountsOfType || {}).map((account, index) => ({
+        Object.entries(accounts).flatMap(([accountType, accountsOfType]) => {
+          if (
+            isBitcoinBased &&
+            accountType === KeyringAccountType.PasskeySmartAccount
+          ) {
+            return [];
+          }
+
+          return Object.values(accountsOfType || {}).map((account, index) => ({
             account,
             accountType: accountType as KeyringAccountType,
             index,
-          }))
-        ),
-      [accounts]
+          }));
+        }),
+      [accounts, isBitcoinBased]
     );
 
     const isAnySwitching = switchingAccount !== null;

--- a/source/config/consts.js
+++ b/source/config/consts.js
@@ -76,7 +76,7 @@ const MV2_OPTIONS = {
 const MV3_OPTIONS = {
   manifest_version: 3,
   name: 'Pali Wallet',
-  version: '4.0.14',
+  version: '4.0.15',
   icons: {
     16: 'assets/all_assets/favicon-16.png',
     32: 'assets/all_assets/favicon-32.png',

--- a/source/pages/Connections/ChangeAccount.tsx
+++ b/source/pages/Connections/ChangeAccount.tsx
@@ -173,9 +173,8 @@ TokenIconStack.displayName = 'TokenIconStack';
 export const ChangeAccount = () => {
   const { controllerEmitter } = useController();
   const dapp = useSelector((state: RootState) => state.dapp.dapps);
-  const { accounts, isBitcoinBased, activeAccount } = useSelector(
-    (state: RootState) => state.vault
-  );
+  const { accounts, isBitcoinBased, activeAccount, activeNetwork } =
+    useSelector((state: RootState) => state.vault);
   const accountAssets = useSelector(selectAccountAssets);
   const { useCopyClipboard, alert } = useUtils();
   const [, copy] = useCopyClipboard();
@@ -192,8 +191,17 @@ export const ChangeAccount = () => {
   }, [host]);
 
   // Helper to check if account is valid for current network type
-  const isAccountValidForNetwork = (account: any) => {
+  const isAccountValidForNetwork = (
+    account: any,
+    keyringAccountType?: KeyringAccountType
+  ) => {
     if (!account) return false;
+    if (keyringAccountType === KeyringAccountType.PasskeySmartAccount) {
+      return (
+        !isBitcoinBased &&
+        Number(account?.passkey?.chainId) === Number(activeNetwork.chainId)
+      );
+    }
     return isBitcoinBased
       ? !isHexString(account.address)
       : isHexString(account.address);
@@ -208,7 +216,10 @@ export const ChangeAccount = () => {
   if (currentAccountId === undefined && dapp[host]) {
     const dappAccount =
       accounts?.[dapp[host].accountType]?.[dapp[host].accountId];
-    if (dappAccount && isAccountValidForNetwork(dappAccount)) {
+    if (
+      dappAccount &&
+      isAccountValidForNetwork(dappAccount, dapp[host].accountType)
+    ) {
       currentAccountId = dapp[host].accountId;
       currentAccountType = dapp[host].accountType;
     }
@@ -259,10 +270,19 @@ export const ChangeAccount = () => {
 
     return Object.entries(accounts)
       .map(([keyringAccountType, accountList]) => {
-        const isValidAccount = (currentAccount: any) =>
-          isBitcoinBased
+        const isValidAccount = (currentAccount: any) => {
+          if (keyringAccountType === KeyringAccountType.PasskeySmartAccount) {
+            return (
+              !isBitcoinBased &&
+              Number(currentAccount?.passkey?.chainId) ===
+                Number(activeNetwork.chainId)
+            );
+          }
+
+          return isBitcoinBased
             ? !isHexString(currentAccount.address)
             : isHexString(currentAccount.address);
+        };
 
         const validAccounts = Object.values(accountList).filter(isValidAccount);
 
@@ -274,7 +294,7 @@ export const ChangeAccount = () => {
       .filter(
         ({ accounts: keyringAccountsList }) => keyringAccountsList.length > 0
       );
-  }, [accounts, isBitcoinBased]);
+  }, [accounts, activeNetwork.chainId, isBitcoinBased]);
 
   const handleSetAccountId = (id: number, type: KeyringAccountType) => {
     setAccountId(id);

--- a/source/pages/Connections/ChangeAccount.tsx
+++ b/source/pages/Connections/ChangeAccount.tsx
@@ -212,6 +212,14 @@ export const ChangeAccount = () => {
   let currentAccountId = queryData.currentAccountId;
   let currentAccountType = queryData.currentAccountType;
 
+  if (currentAccountId !== undefined && currentAccountType !== undefined) {
+    const queryAccount = accounts?.[currentAccountType]?.[currentAccountId];
+    if (!isAccountValidForNetwork(queryAccount, currentAccountType)) {
+      currentAccountId = undefined;
+      currentAccountType = undefined;
+    }
+  }
+
   // If not in query data, try dapp state
   if (currentAccountId === undefined && dapp[host]) {
     const dappAccount =
@@ -227,8 +235,12 @@ export const ChangeAccount = () => {
 
   // Final fallback to active account
   if (currentAccountId === undefined) {
-    currentAccountId = activeAccount?.id;
-    currentAccountType = activeAccount?.type;
+    const activeAccountData =
+      accounts?.[activeAccount?.type]?.[activeAccount?.id];
+    if (isAccountValidForNetwork(activeAccountData, activeAccount?.type)) {
+      currentAccountId = activeAccount?.id;
+      currentAccountType = activeAccount?.type;
+    }
   }
 
   // Initialize state with null to properly track if user has made a selection

--- a/source/pages/Connections/ConnectWallet.tsx
+++ b/source/pages/Connections/ConnectWallet.tsx
@@ -235,13 +235,13 @@ export const ConnectWallet = () => {
     setIsConnecting(true);
     try {
       await controllerEmitter(
-        ['dapp', 'connect'],
-        [{ host, chain, chainId, accountId, accountType, date }]
+        ['wallet', 'setAccount'],
+        [accountId, accountType, true]
       );
 
       await controllerEmitter(
-        ['wallet', 'setAccount'],
-        [accountId, accountType, true]
+        ['dapp', 'connect'],
+        [{ host, chain, chainId, accountId, accountType, date }]
       );
 
       // Return null - the method handler will return the actual address

--- a/source/pages/Connections/ConnectWallet.tsx
+++ b/source/pages/Connections/ConnectWallet.tsx
@@ -283,13 +283,19 @@ export const ConnectWallet = () => {
         const dapp: any = await controllerEmitter(['dapp', 'get'], [host]);
 
         if (dapp) {
-          setCurrentAccountId(dapp?.accountId);
-          setCurrentAccountType(dapp?.accountType);
+          const dappAccount = accounts?.[dapp.accountType]?.[dapp.accountId];
+          if (isAccountValidForNetwork(dappAccount, dapp.accountType)) {
+            setCurrentAccountId(dapp.accountId);
+            setCurrentAccountType(dapp.accountType);
 
-          // Set the connected account as selected by default
-          setAccountId(dapp?.accountId);
-          setAccountType(dapp?.accountType);
-        } else {
+            // Set the connected account as selected by default
+            setAccountId(dapp.accountId);
+            setAccountType(dapp.accountType);
+          } else if (isAccountValidForNetwork(activeAccountData, type)) {
+            setAccountId(id);
+            setAccountType(type);
+          }
+        } else if (isAccountValidForNetwork(activeAccountData, type)) {
           // If no existing connection, select the active account by default
           setAccountId(id);
           setAccountType(type);
@@ -300,7 +306,7 @@ export const ConnectWallet = () => {
         setIsLoading(false);
       }
     })();
-  }, [host, id, type]);
+  }, [accounts, activeAccountData, host, id, isAccountValidForNetwork, type]);
 
   // Remove the auto-close effect - let user make the choice
 

--- a/source/pages/Connections/ConnectWallet.tsx
+++ b/source/pages/Connections/ConnectWallet.tsx
@@ -146,6 +146,7 @@ export const ConnectWallet = () => {
     (state: RootState) => state.vault
   );
   const { id, type } = activeAccountData;
+  const activeAccount = accounts?.[type]?.[id];
   const isBitcoinBased = useSelector(
     (state: RootState) => state.vault.isBitcoinBased
   );
@@ -291,11 +292,11 @@ export const ConnectWallet = () => {
             // Set the connected account as selected by default
             setAccountId(dapp.accountId);
             setAccountType(dapp.accountType);
-          } else if (isAccountValidForNetwork(activeAccountData, type)) {
+          } else if (isAccountValidForNetwork(activeAccount, type)) {
             setAccountId(id);
             setAccountType(type);
           }
-        } else if (isAccountValidForNetwork(activeAccountData, type)) {
+        } else if (isAccountValidForNetwork(activeAccount, type)) {
           // If no existing connection, select the active account by default
           setAccountId(id);
           setAccountType(type);
@@ -306,7 +307,7 @@ export const ConnectWallet = () => {
         setIsLoading(false);
       }
     })();
-  }, [accounts, activeAccountData, host, id, isAccountValidForNetwork, type]);
+  }, [accounts, activeAccount, host, id, isAccountValidForNetwork, type]);
 
   // Remove the auto-close effect - let user make the choice
 

--- a/source/pages/Connections/ConnectWallet.tsx
+++ b/source/pages/Connections/ConnectWallet.tsx
@@ -142,7 +142,7 @@ export const ConnectWallet = () => {
   const { host, chain, chainId, eventName } = useQueryData();
   const { t } = useTranslation();
   const accounts = useSelector((state: RootState) => state.vault.accounts);
-  const { activeAccount: activeAccountData } = useSelector(
+  const { activeAccount: activeAccountData, activeNetwork } = useSelector(
     (state: RootState) => state.vault
   );
   const { id, type } = activeAccountData;
@@ -197,6 +197,23 @@ export const ConnectWallet = () => {
     [accountAssets, isBitcoinBased]
   );
 
+  const isAccountValidForNetwork = useCallback(
+    (account: any, keyringAccountType?: KeyringAccountType | string) => {
+      if (!account) return false;
+      if (keyringAccountType === KeyringAccountType.PasskeySmartAccount) {
+        return (
+          !isBitcoinBased &&
+          Number(account?.passkey?.chainId) === Number(activeNetwork.chainId)
+        );
+      }
+
+      return isBitcoinBased
+        ? !isHexString(account.address)
+        : isHexString(account.address);
+    },
+    [activeNetwork.chainId, isBitcoinBased]
+  );
+
   const handleConnect = useCallback(async () => {
     // Safety check - ensure we have valid account selection
     if (accountId === null || accountType === null) {
@@ -208,6 +225,10 @@ export const ConnectWallet = () => {
     const selectedAccount = accounts[accountType]?.[accountId];
     if (!selectedAccount) {
       console.error('[ConnectWallet] Selected account not found');
+      return;
+    }
+    if (!isAccountValidForNetwork(selectedAccount, accountType)) {
+      console.error('[ConnectWallet] Selected account is invalid for network');
       return;
     }
 
@@ -231,7 +252,17 @@ export const ConnectWallet = () => {
       console.error('Failed to connect wallet:', error);
       setIsConnecting(false);
     }
-  }, [host, chain, chainId, accountId, accountType, date, accounts, eventName]);
+  }, [
+    host,
+    chain,
+    chainId,
+    accountId,
+    accountType,
+    date,
+    accounts,
+    eventName,
+    isAccountValidForNetwork,
+  ]);
 
   const onConfirm = () => {
     // Check if the host is in the trusted apps list
@@ -286,9 +317,7 @@ export const ConnectWallet = () => {
     return Object.entries(accounts)
       .map(([keyringAccountType, accountList]) => {
         const isValidAccount = (currentAccount: any) =>
-          isBitcoinBased
-            ? !isHexString(currentAccount.address)
-            : isHexString(currentAccount.address);
+          isAccountValidForNetwork(currentAccount, keyringAccountType);
 
         const validAccounts = Object.values(accountList).filter(isValidAccount);
 
@@ -300,7 +329,7 @@ export const ConnectWallet = () => {
       .filter(
         ({ accounts: keyringAccountsList }) => keyringAccountsList.length > 0
       );
-  }, [accounts, isBitcoinBased]);
+  }, [accounts, isAccountValidForNetwork]);
 
   return (
     <div className="flex flex-col w-full h-full">

--- a/source/pages/Connections/CreatePasskeyAccount.tsx
+++ b/source/pages/Connections/CreatePasskeyAccount.tsx
@@ -5,6 +5,7 @@ import { PrimaryButton, SecondaryButton } from 'components/index';
 import { useController } from 'hooks/useController';
 import { useQueryData } from 'hooks/useQuery';
 import { dispatchBackgroundEvent } from 'utils/browser';
+import { logError } from 'utils/logger';
 import { bytesToHex, createPasskeyCredential } from 'utils/passkey';
 
 export const CreatePasskeyAccount = () => {
@@ -25,9 +26,6 @@ export const CreatePasskeyAccount = () => {
       : t('connections.sponsorDisabled');
 
   const reject = () => {
-    dispatchBackgroundEvent(`${eventName}.${host}`, {
-      error: t('connections.userRejectedPasskeyCreation'),
-    });
     window.close();
   };
 
@@ -84,12 +82,7 @@ export const CreatePasskeyAccount = () => {
     } catch (error) {
       const wasHandled = handleWalletLockedError(error);
       if (!wasHandled) {
-        dispatchBackgroundEvent(`${eventName}.${host}`, {
-          error:
-            error instanceof Error
-              ? error.message
-              : t('connections.unableToCreatePasskeyAccount'),
-        });
+        logError('Passkey account creation failed', 'UI', error);
         window.close();
       }
     } finally {
@@ -139,7 +132,7 @@ export const CreatePasskeyAccount = () => {
 
       <div className="flex gap-3">
         <SecondaryButton type="button" fullWidth onClick={reject}>
-          Cancel
+          {t('buttons.cancel')}
         </SecondaryButton>
         <PrimaryButton
           type="button"

--- a/source/pages/Connections/CreatePasskeyAccount.tsx
+++ b/source/pages/Connections/CreatePasskeyAccount.tsx
@@ -37,6 +37,7 @@ export const CreatePasskeyAccount = () => {
       const deploymentSalt = bytesToHex(
         crypto.getRandomValues(new Uint8Array(32))
       );
+      await controllerEmitter(['wallet', 'assertPasskeySmartAccountSupported']);
       const credential = await createPasskeyCredential({
         accountName: requestedLabel,
         challengeHex: bytesToHex(challenge),

--- a/source/pages/Connections/CreatePasskeyAccount.tsx
+++ b/source/pages/Connections/CreatePasskeyAccount.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { PrimaryButton, SecondaryButton } from 'components/index';
 import { useController } from 'hooks/useController';
 import { useQueryData } from 'hooks/useQuery';
+import { KeyringAccountType } from 'types/network';
 import { dispatchBackgroundEvent } from 'utils/browser';
 import { logError } from 'utils/logger';
 import { bytesToHex, createPasskeyCredential } from 'utils/passkey';
@@ -74,6 +75,11 @@ export const CreatePasskeyAccount = () => {
           },
         ]
       )) as any;
+
+      await controllerEmitter(
+        ['dapp', 'changeAccount'],
+        [host, account.id, KeyringAccountType.PasskeySmartAccount]
+      );
 
       dispatchBackgroundEvent(`${eventName}.${host}`, {
         address: account.address,

--- a/source/pages/Connections/CreatePasskeyAccount.tsx
+++ b/source/pages/Connections/CreatePasskeyAccount.tsx
@@ -1,0 +1,155 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { PrimaryButton, SecondaryButton } from 'components/index';
+import { useController } from 'hooks/useController';
+import { useQueryData } from 'hooks/useQuery';
+import { dispatchBackgroundEvent } from 'utils/browser';
+import { bytesToHex, createPasskeyCredential } from 'utils/passkey';
+
+export const CreatePasskeyAccount = () => {
+  const { controllerEmitter, handleWalletLockedError } = useController();
+  const { eventName, host, label, sponsor } = useQueryData();
+  const { t } = useTranslation();
+  const [loading, setLoading] = useState(false);
+  const displayHost = host || t('connections.dappFallback');
+  const requestedLabel =
+    label || t('connections.passkeyDefaultLabel', { host: displayHost });
+  const sponsorMode = sponsor?.mode || 'disabled';
+  const isSponsorRequired = sponsorMode === 'required';
+  const sponsorLabel =
+    sponsorMode === 'gasOnly'
+      ? t('connections.sponsorGasOnly')
+      : isSponsorRequired
+      ? t('connections.sponsorRequired')
+      : t('connections.sponsorDisabled');
+
+  const reject = () => {
+    dispatchBackgroundEvent(`${eventName}.${host}`, {
+      error: t('connections.userRejectedPasskeyCreation'),
+    });
+    window.close();
+  };
+
+  const approve = async () => {
+    setLoading(true);
+
+    try {
+      const challenge = crypto.getRandomValues(new Uint8Array(32));
+      const deploymentSalt = bytesToHex(
+        crypto.getRandomValues(new Uint8Array(32))
+      );
+      const credential = await createPasskeyCredential({
+        accountName: requestedLabel,
+        challengeHex: bytesToHex(challenge),
+        userDisplayName: requestedLabel,
+      });
+      const prepared = (await controllerEmitter(
+        ['wallet', 'preparePasskeySmartAccount'],
+        [
+          {
+            credentialId: credential.credentialId,
+            credentialIdHash: credential.credentialIdHash,
+            deploymentSalt,
+            label: requestedLabel,
+            passkeyName: requestedLabel,
+            publicKey: {
+              originHash: credential.originHash,
+              originLength: credential.originLength,
+              rpIdHash: credential.rpIdHash,
+              x: credential.x,
+              y: credential.y,
+            },
+            sponsor,
+          },
+        ],
+        300000
+      )) as any;
+      const account = (await controllerEmitter(
+        ['wallet', 'createPasskeySmartAccount'],
+        [
+          {
+            address: prepared.address,
+            label: requestedLabel,
+            metadata: prepared.metadata,
+          },
+        ]
+      )) as any;
+
+      dispatchBackgroundEvent(`${eventName}.${host}`, {
+        address: account.address,
+        metadata: account.passkey,
+      });
+      window.close();
+    } catch (error) {
+      const wasHandled = handleWalletLockedError(error);
+      if (!wasHandled) {
+        dispatchBackgroundEvent(`${eventName}.${host}`, {
+          error:
+            error instanceof Error
+              ? error.message
+              : t('connections.unableToCreatePasskeyAccount'),
+        });
+        window.close();
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col min-h-screen px-6 py-8 text-white bg-bkg-3">
+      <div className="flex-1">
+        <h1 className="mb-3 text-xl font-semibold">
+          {t('connections.createPasskeyAccountTitle')}
+        </h1>
+        <p className="mb-6 text-sm text-brand-graylight">
+          {t('connections.createPasskeyAccountDescription', {
+            host: displayHost,
+          })}
+        </p>
+
+        <div className="p-4 rounded-lg bg-brand-blue600">
+          <p className="text-sm font-medium">{requestedLabel}</p>
+          <p className="mt-2 text-xs text-brand-graylight">
+            {t('connections.sponsorPolicy', { policy: sponsorLabel })}
+          </p>
+          {sponsor?.url && (
+            <p className="mt-1 text-xs text-brand-graylight">
+              {t('connections.sponsorUrl', { url: sponsor.url })}
+            </p>
+          )}
+          {sponsor?.signer && (
+            <p className="mt-1 break-all text-xs text-brand-graylight">
+              {t('connections.sponsorSigner', { signer: sponsor.signer })}
+            </p>
+          )}
+          {sponsor?.policyText && (
+            <p className="mt-3 text-xs text-brand-graylight">
+              {sponsor.policyText}
+            </p>
+          )}
+          {isSponsorRequired && (
+            <p className="mt-3 text-xs text-warning-error">
+              {t('connections.sponsorRequiredWarning')}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex gap-3">
+        <SecondaryButton type="button" fullWidth onClick={reject}>
+          Cancel
+        </SecondaryButton>
+        <PrimaryButton
+          type="button"
+          fullWidth
+          loading={loading}
+          onClick={approve}
+        >
+          {t('buttons.create')}
+        </PrimaryButton>
+      </div>
+    </div>
+  );
+};

--- a/source/pages/Connections/index.tsx
+++ b/source/pages/Connections/index.tsx
@@ -1,3 +1,4 @@
 export * from './ConnectWallet';
 export * from './ChangeAccount';
 export * from './ChangeConnectedAccount';
+export * from './CreatePasskeyAccount';

--- a/source/pages/Send/Confirm.tsx
+++ b/source/pages/Send/Confirm.tsx
@@ -42,6 +42,7 @@ import {
   saveNavigationState,
   clearNavigationState,
 } from 'utils/index';
+import { getPasskeyAssertion } from 'utils/passkey';
 import { safeToFixed } from 'utils/safeToFixed';
 import { sanitizeErrorMessage } from 'utils/syscoinErrorSanitizer';
 import { getTokenTypeBadgeColor } from 'utils/tokens';
@@ -394,6 +395,59 @@ export const SendConfirm = () => {
 
         // ETHEREUM TRANSACTIONS FOR NATIVE TOKENS
         case TransactionType.NATIVE_ETH:
+          if (activeAccount.isPasskeySmartAccount && activeAccount.passkey) {
+            try {
+              const amount = parseUnits(
+                String(
+                  removeScientificNotation(String(basicTxValues.amount || '0'))
+                ),
+                18
+              ).toHexString();
+              const prepared = (await controllerEmitter(
+                ['wallet', 'preparePasskeyExecution'],
+                [
+                  {
+                    target: destinationTo,
+                    value: amount,
+                    data: '0x',
+                  },
+                ],
+                300000
+              )) as any;
+              const assertion = await getPasskeyAssertion(
+                activeAccount.passkey.credentialId,
+                prepared.actionHash
+              );
+
+              await controllerEmitter(
+                ['wallet', 'submitPasskeyExecution'],
+                [
+                  {
+                    execution: prepared.execution,
+                    proof: {
+                      authenticatorData: assertion.authenticatorData,
+                      clientDataJSON: assertion.clientDataJSON,
+                      challengeOffset: assertion.challengeOffset,
+                      originOffset: assertion.originOffset,
+                      r: assertion.r,
+                      s: assertion.s,
+                      typeOffset: assertion.typeOffset,
+                    },
+                  },
+                ],
+                300000
+              );
+
+              setConfirmed(true);
+              setLoading(false);
+            } catch (error: any) {
+              logError('error', 'Transaction', error);
+              alert.error(error?.message || t('send.cantCompleteTxs'));
+              setLoading(false);
+            }
+            return;
+          }
+
           const restTx = omitTransactionObjectData(txObjectState, [
             'chainId',
             'maxFeePerGas',

--- a/source/pages/Send/Confirm.tsx
+++ b/source/pages/Send/Confirm.tsx
@@ -1,3 +1,4 @@
+import { Interface } from '@ethersproject/abi';
 import { BigNumber } from '@ethersproject/bignumber';
 import { formatEther, parseUnits } from '@ethersproject/units';
 import { ChevronDoubleDownIcon } from '@heroicons/react/solid';
@@ -46,6 +47,7 @@ import { getPasskeyAssertion } from 'utils/passkey';
 import { safeToFixed } from 'utils/safeToFixed';
 import { sanitizeErrorMessage } from 'utils/syscoinErrorSanitizer';
 import { getTokenTypeBadgeColor } from 'utils/tokens';
+import { getErc20Abi, getErc721Abi, getErc1155Abi } from 'utils/validations';
 
 import { EditPriorityModal } from './EditPriority';
 
@@ -344,6 +346,126 @@ export const SendConfirm = () => {
         basicTxValues.transactionType ||
         (isBitcoinBased ? TransactionType.UTXO : TransactionType.NATIVE_ETH);
 
+      const submitPasskeyExecution = async (
+        target: string,
+        value: string,
+        data: string
+      ) => {
+        const prepared = (await controllerEmitter(
+          ['wallet', 'preparePasskeyExecution'],
+          [
+            {
+              target,
+              value,
+              data,
+            },
+          ],
+          300000
+        )) as any;
+        const assertion = await getPasskeyAssertion(
+          activeAccount.passkey.credentialId,
+          prepared.actionHash
+        );
+
+        await controllerEmitter(
+          ['wallet', 'submitPasskeyExecution'],
+          [
+            {
+              execution: prepared.execution,
+              proof: {
+                authenticatorData: assertion.authenticatorData,
+                clientDataJSON: assertion.clientDataJSON,
+                challengeOffset: assertion.challengeOffset,
+                originOffset: assertion.originOffset,
+                r: assertion.r,
+                s: assertion.s,
+                typeOffset: assertion.typeOffset,
+              },
+            },
+          ],
+          300000
+        );
+      };
+
+      const assertPasskeyTokenRecipientAllowed = async () => {
+        const blacklistResult = (await controllerEmitter(
+          ['wallet', 'checkAddressBlacklist'],
+          [destinationTo]
+        )) as {
+          isBlacklisted: boolean;
+          reason?: string;
+          severity?: string;
+        };
+
+        if (
+          blacklistResult.isBlacklisted &&
+          (blacklistResult.severity === 'critical' ||
+            blacklistResult.severity === 'high')
+        ) {
+          throw new Error(
+            `Token transfer blocked: ${
+              blacklistResult.reason || 'The recipient address is blacklisted'
+            }. Severity: ${
+              blacklistResult.severity
+            }. Please verify the token recipient address before proceeding.`
+          );
+        }
+      };
+
+      const getValidatedTokenId = () => {
+        const tokenId = basicTxValues.token.tokenId;
+        if (tokenId === undefined || tokenId === null || tokenId === '') {
+          throw new Error(t('send.invalidTokenId'));
+        }
+
+        const numericTokenId = Number(tokenId);
+        if (isNaN(numericTokenId) || numericTokenId < 0) {
+          throw new Error(t('send.invalidTokenId'));
+        }
+
+        return BigNumber.from(tokenId);
+      };
+
+      const buildPasskeyTokenTransferData = async () => {
+        switch (transactionType) {
+          case TransactionType.ERC20: {
+            const erc20Interface = new Interface(await getErc20Abi());
+            const amount = parseUnits(
+              String(
+                removeScientificNotation(String(basicTxValues.amount || '0'))
+              ),
+              basicTxValues?.token?.decimals ?? 18
+            );
+            return erc20Interface.encodeFunctionData('transfer', [
+              destinationTo,
+              amount,
+            ]);
+          }
+          case TransactionType.ERC721: {
+            const erc721Interface = new Interface(await getErc721Abi());
+            return erc721Interface.encodeFunctionData(
+              'safeTransferFrom(address,address,uint256)',
+              [activeAccount.address, destinationTo, getValidatedTokenId()]
+            );
+          }
+          case TransactionType.ERC1155: {
+            const erc1155Interface = new Interface(await getErc1155Abi());
+            return erc1155Interface.encodeFunctionData(
+              'safeTransferFrom(address,address,uint256,uint256,bytes)',
+              [
+                activeAccount.address,
+                destinationTo,
+                getValidatedTokenId(),
+                BigNumber.from(String(basicTxValues.amount)),
+                '0x',
+              ]
+            );
+          }
+          default:
+            throw new Error(t('send.cantCompleteTxs'));
+        }
+      };
+
       switch (transactionType) {
         // SYSCOIN/UTXO TRANSACTIONS
         case TransactionType.UTXO:
@@ -403,40 +525,7 @@ export const SendConfirm = () => {
                 ),
                 18
               ).toHexString();
-              const prepared = (await controllerEmitter(
-                ['wallet', 'preparePasskeyExecution'],
-                [
-                  {
-                    target: destinationTo,
-                    value: amount,
-                    data: '0x',
-                  },
-                ],
-                300000
-              )) as any;
-              const assertion = await getPasskeyAssertion(
-                activeAccount.passkey.credentialId,
-                prepared.actionHash
-              );
-
-              await controllerEmitter(
-                ['wallet', 'submitPasskeyExecution'],
-                [
-                  {
-                    execution: prepared.execution,
-                    proof: {
-                      authenticatorData: assertion.authenticatorData,
-                      clientDataJSON: assertion.clientDataJSON,
-                      challengeOffset: assertion.challengeOffset,
-                      originOffset: assertion.originOffset,
-                      r: assertion.r,
-                      s: assertion.s,
-                      typeOffset: assertion.typeOffset,
-                    },
-                  },
-                ],
-                300000
-              );
+              await submitPasskeyExecution(destinationTo, amount, '0x');
 
               setConfirmed(true);
               setLoading(false);
@@ -642,6 +731,38 @@ export const SendConfirm = () => {
         case TransactionType.ERC721:
         // ETHEREUM TRANSACTIONS FOR ERC1155 TOKENS
         case TransactionType.ERC1155:
+          if (activeAccount.isPasskeySmartAccount && activeAccount.passkey) {
+            try {
+              await assertPasskeyTokenRecipientAllowed();
+              const data = await buildPasskeyTokenTransferData();
+              await submitPasskeyExecution(
+                basicTxValues.token.contractAddress,
+                '0x0',
+                data
+              );
+
+              setConfirmed(true);
+              setLoading(false);
+            } catch (error: any) {
+              const wasHandledSpecifically = handleTransactionError(
+                error,
+                alert,
+                t,
+                activeAccount,
+                activeNetwork,
+                basicTxValues
+              );
+
+              if (!wasHandledSpecifically) {
+                logError('error send passkey token', 'Transaction', error);
+                alert.error(error?.message || t('send.cantCompleteTxs'));
+              }
+
+              setLoading(false);
+            }
+            return;
+          }
+
           //HANDLE DIFFERENT TOKEN TRANSACTION TYPES
           switch (transactionType) {
             //HANDLE ERC20 TRANSACTION

--- a/source/pages/Send/SendCalls.tsx
+++ b/source/pages/Send/SendCalls.tsx
@@ -166,7 +166,10 @@ export const SendCalls = () => {
         );
 
       if (activeAccount.isPasskeySmartAccount && callsData.calls.length > 1) {
-        throw new Error(t('send.passkeyMulticallUnsupported'));
+        alert.error(t('send.passkeyMulticallUnsupported'));
+        clearNavigationState();
+        window.close();
+        return;
       }
 
       const receipts: any[] = [];

--- a/source/pages/Send/SendCalls.tsx
+++ b/source/pages/Send/SendCalls.tsx
@@ -19,6 +19,7 @@ import { selectEnsNameToAddress } from 'state/vault/selectors';
 import { dispatchBackgroundEvent } from 'utils/browser';
 import { ellipsis } from 'utils/format';
 import { clearNavigationState } from 'utils/navigationState';
+import { getPasskeyAssertion } from 'utils/passkey';
 
 interface ISendCallsData {
   atomicRequired: boolean;
@@ -115,6 +116,14 @@ export const SendCalls = () => {
     [selectedCalls, transactionStatuses]
   );
 
+  const getPasskeySponsorProofForCall = (
+    call: ISendCallsData['calls'][number]
+  ) =>
+    call.capabilities?.passkeySponsorProof ||
+    call.capabilities?.sponsorProof ||
+    callsData.capabilities?.passkeySponsorProof ||
+    callsData.capabilities?.sponsorProof;
+
   // Watch for when all transactions are completed and dispatch response
   useEffect(() => {
     if (allTransactionsSuccessful && !confirmed && transactionStatuses) {
@@ -155,6 +164,10 @@ export const SendCalls = () => {
             (!transactionStatuses?.[index] ||
               transactionStatuses[index].status !== 'success')
         );
+
+      if (activeAccount.isPasskeySmartAccount && selectedCallsData.length > 1) {
+        throw new Error(t('send.passkeyMulticallUnsupported'));
+      }
 
       const receipts: any[] = [];
       const from = callsData.from || activeAccount.address;
@@ -335,11 +348,54 @@ export const SendCalls = () => {
             return newStatuses;
           });
 
-          // Use the same method as SendTransaction
-          const response = (await controllerEmitter(
-            ['wallet', 'sendAndSaveEthTransaction'],
-            [tx, false] // false = not legacy transaction
-          )) as any;
+          let response: any;
+          if (activeAccount.isPasskeySmartAccount && activeAccount.passkey) {
+            if (!toField) {
+              throw new Error(t('send.passkeyContractDeploymentUnsupported'));
+            }
+
+            const prepared = (await controllerEmitter(
+              ['wallet', 'preparePasskeyExecution'],
+              [
+                {
+                  target: toField,
+                  value: tx.value || '0x0',
+                  data: tx.data || '0x',
+                },
+              ],
+              300000
+            )) as any;
+            const assertion = await getPasskeyAssertion(
+              activeAccount.passkey.credentialId,
+              prepared.actionHash
+            );
+
+            response = await controllerEmitter(
+              ['wallet', 'submitPasskeyExecution'],
+              [
+                {
+                  execution: prepared.execution,
+                  proof: {
+                    authenticatorData: assertion.authenticatorData,
+                    clientDataJSON: assertion.clientDataJSON,
+                    challengeOffset: assertion.challengeOffset,
+                    originOffset: assertion.originOffset,
+                    r: assertion.r,
+                    s: assertion.s,
+                    typeOffset: assertion.typeOffset,
+                  },
+                  sponsorProof: getPasskeySponsorProofForCall(call),
+                },
+              ],
+              300000
+            );
+          } else {
+            // Use the same method as SendTransaction
+            response = (await controllerEmitter(
+              ['wallet', 'sendAndSaveEthTransaction'],
+              [tx, false] // false = not legacy transaction
+            )) as any;
+          }
 
           const txHash = response.hash || response;
 

--- a/source/pages/Send/SendCalls.tsx
+++ b/source/pages/Send/SendCalls.tsx
@@ -165,7 +165,7 @@ export const SendCalls = () => {
               transactionStatuses[index].status !== 'success')
         );
 
-      if (activeAccount.isPasskeySmartAccount && selectedCallsData.length > 1) {
+      if (activeAccount.isPasskeySmartAccount && callsData.calls.length > 1) {
         throw new Error(t('send.passkeyMulticallUnsupported'));
       }
 

--- a/source/pages/Send/SendTransaction.tsx
+++ b/source/pages/Send/SendTransaction.tsx
@@ -35,6 +35,7 @@ import { fetchGasAndDecodeFunction } from 'utils/fetchGasAndDecodeFunction';
 import { ellipsis } from 'utils/format';
 import { logError } from 'utils/logger';
 import { clearNavigationState } from 'utils/navigationState';
+import { getPasskeyAssertion } from 'utils/passkey';
 import removeScientificNotation from 'utils/removeScientificNotation';
 import { safeBigNumber } from 'utils/safeBigNumber';
 import { safeToFixed } from 'utils/safeToFixed';
@@ -89,6 +90,13 @@ export const SendTransaction = () => {
   const txMetadata = isExternal
     ? externalTx.txMetadata
     : state?.txMetadata || {};
+  const passkeySponsorProof =
+    txMetadata?.passkeySponsorProof ||
+    txMetadata?.sponsorProof ||
+    externalTx?.passkeySponsorProof ||
+    externalTx?.sponsorProof ||
+    (dataTx as any)?.passkeySponsorProof ||
+    (dataTx as any)?.sponsorProof;
 
   // Determine legacy transaction explicitly: honor metadata or explicit type 0x0
   const explicitType = (dataTx as any)?.type;
@@ -317,7 +325,13 @@ export const SendTransaction = () => {
       console.error('Failed to refresh balance before sending:', error);
     }
 
-    if (activeAccount && balance > 0) {
+    const requestedValue = dataTx?.value
+      ? BigNumber.from(dataTx.value)
+      : BigNumber.from(0);
+    const canUsePasskeyGasPayer =
+      activeAccount?.isPasskeySmartAccount && requestedValue.isZero();
+
+    if (activeAccount && (balance > 0 || canUsePasskeyGasPayer)) {
       let txToSend = tx;
 
       // Handle approval-specific data encoding
@@ -368,8 +382,62 @@ export const SendTransaction = () => {
 
       try {
         let response;
+        const isPasskeyAccount = Boolean(
+          activeAccount.isPasskeySmartAccount && activeAccount.passkey
+        );
 
-        if (isLegacyTransaction) {
+        if (isPasskeyAccount) {
+          const candidateTo =
+            resolvedTo || (toRaw.startsWith('0x') ? toRaw : undefined);
+          if (!candidateTo) {
+            alert.error(t('send.passkeyContractDeploymentUnsupported'));
+            setLoading(false);
+            return;
+          }
+
+          const passkeyTxValue = txToSend.value
+            ? safeBigNumber(
+                txToSend.value,
+                '0x0',
+                'transaction value'
+              ).toHexString()
+            : '0x0';
+          const prepared = (await controllerEmitter(
+            ['wallet', 'preparePasskeyExecution'],
+            [
+              {
+                target: candidateTo,
+                value: passkeyTxValue,
+                data: validateTransactionDataValue(txToSend.data),
+              },
+            ],
+            300000
+          )) as any;
+          const assertion = await getPasskeyAssertion(
+            activeAccount.passkey.credentialId,
+            prepared.actionHash
+          );
+
+          response = await controllerEmitter(
+            ['wallet', 'submitPasskeyExecution'],
+            [
+              {
+                execution: prepared.execution,
+                proof: {
+                  authenticatorData: assertion.authenticatorData,
+                  clientDataJSON: assertion.clientDataJSON,
+                  challengeOffset: assertion.challengeOffset,
+                  originOffset: assertion.originOffset,
+                  r: assertion.r,
+                  s: assertion.s,
+                  typeOffset: assertion.typeOffset,
+                },
+                sponsorProof: passkeySponsorProof,
+              },
+            ],
+            300000
+          );
+        } else if (isLegacyTransaction) {
           // Legacy transaction handling - MUST remove all EIP-1559 fields
           const txWithoutType = omitTransactionObjectData(txToSend, [
             'type',

--- a/source/pages/Send/SendTransaction.tsx
+++ b/source/pages/Send/SendTransaction.tsx
@@ -408,7 +408,7 @@ export const SendTransaction = () => {
               {
                 target: candidateTo,
                 value: passkeyTxValue,
-                data: validateTransactionDataValue(txToSend.data),
+                data: validateTransactionDataValue(txToSend.data) || '0x',
               },
             ],
             300000

--- a/source/pages/Send/SendTransaction.tsx
+++ b/source/pages/Send/SendTransaction.tsx
@@ -408,7 +408,7 @@ export const SendTransaction = () => {
               {
                 target: candidateTo,
                 value: passkeyTxValue,
-                data: validateTransactionDataValue(txToSend.data) || '0x',
+                data: validateTransactionDataValue(txToSend.data),
               },
             ],
             300000

--- a/source/pages/Settings/CreateAccount.tsx
+++ b/source/pages/Settings/CreateAccount.tsx
@@ -52,6 +52,7 @@ const CreateAccount = () => {
       const deploymentSalt = bytesToHex(
         crypto.getRandomValues(new Uint8Array(32))
       );
+      await controllerEmitter(['wallet', 'assertPasskeySmartAccountSupported']);
       const credential = await createPasskeyCredential({
         accountName: label,
         challengeHex: bytesToHex(challenge),

--- a/source/pages/Settings/CreateAccount.tsx
+++ b/source/pages/Settings/CreateAccount.tsx
@@ -1,13 +1,16 @@
 import { Form, Input } from 'antd';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
 import { useNavigate, useLocation } from 'react-router-dom';
 
 import { NeutralButton } from 'components/index';
 import { CreatedAccountSuccessfully } from 'components/Modal/WarningBaseModal';
 import { useController } from 'hooks/useController';
+import { RootState } from 'state/store';
 import { navigateBack } from 'utils/navigationState';
 import { bytesToHex, createPasskeyCredential } from 'utils/passkey';
+import { PASSKEY_FACTORY_ADDRESSES } from 'utils/passkey/contracts';
 
 const CreateAccount = () => {
   const [address, setAddress] = useState<string | undefined>();
@@ -18,6 +21,12 @@ const CreateAccount = () => {
   const { controllerEmitter, handleWalletLockedError } = useController();
   const navigate = useNavigate();
   const location = useLocation();
+  const activeNetwork = useSelector(
+    ({ vault }: RootState) => vault.activeNetwork
+  );
+  const isPasskeySupported = Boolean(
+    PASSKEY_FACTORY_ADDRESSES[activeNetwork.chainId]
+  );
 
   const onSubmit = async ({ label }: { label?: string }) => {
     setLoading(true);
@@ -157,23 +166,25 @@ const CreateAccount = () => {
               {t('buttons.create')}
             </NeutralButton>
 
-            <div className="mt-4 rounded-lg border border-dashed border-brand-blue500/50 p-4 text-left">
-              <p className="mb-2 text-sm font-medium text-white">
-                {t('settings.createPasskeyAccount')}
-              </p>
-              <p className="mb-4 text-xs text-brand-graylight">
-                {t('settings.createPasskeyAccountDescription')}
-              </p>
-              <NeutralButton
-                type="button"
-                disabled={passkeyLoading || loading}
-                loading={passkeyLoading}
-                onClick={createPasskeyAccount}
-                fullWidth
-              >
-                {t('settings.createPasskeyAccount')}
-              </NeutralButton>
-            </div>
+            {isPasskeySupported && (
+              <div className="mt-4 rounded-lg border border-dashed border-brand-blue500/50 p-4 text-left">
+                <p className="mb-2 text-sm font-medium text-white">
+                  {t('settings.createPasskeyAccount')}
+                </p>
+                <p className="mb-4 text-xs text-brand-graylight">
+                  {t('settings.createPasskeyAccountDescription')}
+                </p>
+                <NeutralButton
+                  type="button"
+                  disabled={passkeyLoading || loading}
+                  loading={passkeyLoading}
+                  onClick={createPasskeyAccount}
+                  fullWidth
+                >
+                  {t('settings.createPasskeyAccount')}
+                </NeutralButton>
+              </div>
+            )}
           </div>
         </Form>
       )}

--- a/source/pages/Settings/CreateAccount.tsx
+++ b/source/pages/Settings/CreateAccount.tsx
@@ -7,10 +7,12 @@ import { NeutralButton } from 'components/index';
 import { CreatedAccountSuccessfully } from 'components/Modal/WarningBaseModal';
 import { useController } from 'hooks/useController';
 import { navigateBack } from 'utils/navigationState';
+import { bytesToHex, createPasskeyCredential } from 'utils/passkey';
 
 const CreateAccount = () => {
   const [address, setAddress] = useState<string | undefined>();
   const [loading, setLoading] = useState<boolean>(false);
+  const [passkeyLoading, setPasskeyLoading] = useState<boolean>(false);
   const [accountName, setAccountName] = useState<string>('');
   const { t } = useTranslation();
   const { controllerEmitter, handleWalletLockedError } = useController();
@@ -38,6 +40,63 @@ const CreateAccount = () => {
         // didn't have explicit error handling UI for create account failures
         console.error('Error creating account:', error);
       }
+    }
+  };
+
+  const createPasskeyAccount = async () => {
+    setPasskeyLoading(true);
+
+    try {
+      const label = accountName || t('settings.passkeyAccount');
+      const challenge = crypto.getRandomValues(new Uint8Array(32));
+      const deploymentSalt = bytesToHex(
+        crypto.getRandomValues(new Uint8Array(32))
+      );
+      const credential = await createPasskeyCredential({
+        accountName: label,
+        challengeHex: bytesToHex(challenge),
+        userDisplayName: label,
+      });
+      const prepared = (await controllerEmitter(
+        ['wallet', 'preparePasskeySmartAccount'],
+        [
+          {
+            credentialId: credential.credentialId,
+            credentialIdHash: credential.credentialIdHash,
+            deploymentSalt,
+            label,
+            passkeyName: label,
+            publicKey: {
+              originHash: credential.originHash,
+              originLength: credential.originLength,
+              rpIdHash: credential.rpIdHash,
+              x: credential.x,
+              y: credential.y,
+            },
+          },
+        ]
+      )) as any;
+
+      const { address: newAddress } = (await controllerEmitter(
+        ['wallet', 'createPasskeySmartAccount'],
+        [
+          {
+            address: prepared.address,
+            label,
+            metadata: prepared.metadata,
+          },
+        ]
+      )) as any;
+
+      setAccountName(label);
+      setAddress(newAddress);
+    } catch (error) {
+      const wasHandled = handleWalletLockedError(error);
+      if (!wasHandled) {
+        console.error('Error creating passkey account:', error);
+      }
+    } finally {
+      setPasskeyLoading(false);
     }
   };
 
@@ -96,6 +155,24 @@ const CreateAccount = () => {
             >
               {t('buttons.create')}
             </NeutralButton>
+
+            <div className="mt-4 rounded-lg border border-dashed border-brand-blue500/50 p-4 text-left">
+              <p className="mb-2 text-sm font-medium text-white">
+                {t('settings.createPasskeyAccount')}
+              </p>
+              <p className="mb-4 text-xs text-brand-graylight">
+                {t('settings.createPasskeyAccountDescription')}
+              </p>
+              <NeutralButton
+                type="button"
+                disabled={passkeyLoading || loading}
+                loading={passkeyLoading}
+                onClick={createPasskeyAccount}
+                fullWidth
+              >
+                {t('settings.createPasskeyAccount')}
+              </NeutralButton>
+            </div>
           </div>
         </Form>
       )}

--- a/source/pages/Settings/EditAccount.tsx
+++ b/source/pages/Settings/EditAccount.tsx
@@ -27,7 +27,9 @@ const EditAccountView = () => {
   const [form] = useForm();
 
   const getWalletType = useMemo(() => {
-    if (state.isTrezorWallet) {
+    if (state.accountType === KeyringAccountType.PasskeySmartAccount) {
+      return 'Passkey';
+    } else if (state.isTrezorWallet) {
       return HardWallets.TREZOR;
     } else if (state.isLedgerWallet) {
       return HardWallets.LEDGER;
@@ -45,13 +47,17 @@ const EditAccountView = () => {
     setLoading(true);
 
     try {
-      const accountType = state.isImported
-        ? KeyringAccountType.Imported
-        : state.isTrezorWallet
-        ? KeyringAccountType.Trezor
-        : state.isLedgerWallet
-        ? KeyringAccountType.Ledger
-        : KeyringAccountType.HDAccount;
+      const accountType =
+        state.accountType ||
+        (state.isImported
+          ? KeyringAccountType.Imported
+          : state.isTrezorWallet
+          ? KeyringAccountType.Trezor
+          : state.isLedgerWallet
+          ? KeyringAccountType.Ledger
+          : state.isPasskeySmartAccount
+          ? KeyringAccountType.PasskeySmartAccount
+          : KeyringAccountType.HDAccount);
 
       const accountId = state.id;
 

--- a/source/pages/Settings/ManageAccounts.tsx
+++ b/source/pages/Settings/ManageAccounts.tsx
@@ -132,7 +132,7 @@ const ManageAccountsView = React.memo(() => {
   const [isRemoving, setIsRemoving] = useState(false);
 
   const editAccount = useCallback(
-    (account: IKeyringAccountState) => {
+    (account: IKeyringAccountState, accountType: KeyringAccountType) => {
       // Create navigation context with scroll position from the ul element
       const scrollPosition = scrollContainerRef.current?.scrollTop || 0;
 
@@ -144,7 +144,7 @@ const ManageAccountsView = React.memo(() => {
       navigateWithContext(
         navigate,
         '/settings/edit-account',
-        account,
+        { ...account, accountType },
         returnContext
       );
     },
@@ -253,7 +253,7 @@ const ManageAccountsView = React.memo(() => {
 
           <div className="flex gap-x-2 items-center flex-shrink-0">
             <IconButton
-              onClick={() => editAccount(account)}
+              onClick={() => editAccount(account, accountType)}
               type="primary"
               shape="circle"
             >

--- a/source/pages/Settings/ManageAccounts.tsx
+++ b/source/pages/Settings/ManageAccounts.tsx
@@ -12,7 +12,7 @@ import { useLocation } from 'react-router-dom';
 
 import ledgerLogo from 'assets/all_assets/ledgerLogo.png';
 import trezorLogo from 'assets/all_assets/trezorLogo.png';
-import { PaliWhiteSmallIconSvg } from 'components/Icon/Icon';
+import { LockIconSvg, PaliWhiteSmallIconSvg } from 'components/Icon/Icon';
 import {
   IconButton,
   Icon,
@@ -77,6 +77,16 @@ const ACCOUNT_TYPE_CONFIG = {
           filter:
             'invert(100%) sepia(0%) saturate(0%) hue-rotate(44deg) brightness(108%) contrast(102%)',
         }}
+        {...props}
+      />
+    ),
+  },
+  [KeyringAccountType.PasskeySmartAccount]: {
+    label: 'Passkey',
+    bgColor: 'bg-purple-500',
+    icon: (props: any) => (
+      <LockIconSvg
+        className="mr-1 w-6 h-6 text-white opacity-90 group-hover:opacity-100 group-hover:text-brand-white transition-all duration-300"
         {...props}
       />
     ),

--- a/source/pages/Settings/PrivateKey.tsx
+++ b/source/pages/Settings/PrivateKey.tsx
@@ -26,7 +26,8 @@ const PrivateKeyView = () => {
   );
   const isHardwareAccount =
     activeAccountMeta.type === KeyringAccountType.Ledger ||
-    activeAccountMeta.type === KeyringAccountType.Trezor;
+    activeAccountMeta.type === KeyringAccountType.Trezor ||
+    activeAccountMeta.type === KeyringAccountType.PasskeySmartAccount;
 
   const { useCopyClipboard, alert } = useUtils();
 

--- a/source/pages/Transactions/SignEth.tsx
+++ b/source/pages/Transactions/SignEth.tsx
@@ -99,6 +99,21 @@ const EthSign: React.FC<ISign> = () => {
     }
   };
 
+  const isActiveAccountAddress = (value: unknown) =>
+    typeof value === 'string' && value.toLowerCase() === address.toLowerCase();
+
+  const getPersonalSignMessage = () => {
+    if (isActiveAccountAddress(data[0])) {
+      return data[1] || '';
+    }
+
+    if (isActiveAccountAddress(data[1])) {
+      return data[0] || '';
+    }
+
+    throw { message: t('send.signingForWrongAddress') };
+  };
+
   const encodePasskey1271Signature = async (hash: string) => {
     if (!activeAccount.passkey) {
       throw { message: t('send.passkeyActiveAccountRequired') };
@@ -129,12 +144,7 @@ const EthSign: React.FC<ISign> = () => {
 
   const getPasskeySignHash = (typedData?: any) => {
     if (data.eventName === 'personal_sign') {
-      const isFirstParamAddress =
-        data[0] &&
-        typeof data[0] === 'string' &&
-        data[0].startsWith('0x') &&
-        data[0].length === 42;
-      const msg = isFirstParamAddress ? data[1] || '' : data[0] || '';
+      const msg = getPersonalSignMessage();
       return hashMessage(isHexString(msg) ? arrayify(msg) : String(msg));
     }
 
@@ -342,32 +352,9 @@ const EthSign: React.FC<ISign> = () => {
     }
     if (data.eventName === 'personal_sign') {
       let msg = '';
-      let requestedAddress = '';
-
-      // Standard parameter order for personal_sign is [message, address]
-      // Some dapps may send [address, message] for compatibility
-      // Check if first param looks like an Ethereum address
-      const isFirstParamAddress =
-        data[0] &&
-        typeof data[0] === 'string' &&
-        data[0].startsWith('0x') &&
-        data[0].length === 42;
-
-      if (isFirstParamAddress) {
-        // Non-standard order: [address, message]
-        requestedAddress = data[0];
-        msg = data[1] || '';
-      } else {
-        // Standard order: [message, address]
-        msg = data[0] || '';
-        requestedAddress = data[1] || '';
-      }
-
-      // Validate that the requested address matches the active account
-      if (
-        requestedAddress &&
-        requestedAddress.toLowerCase() !== activeAccount.address.toLowerCase()
-      ) {
+      try {
+        msg = getPersonalSignMessage();
+      } catch {
         setErrorMsg(t('send.signingForWrongAddress'));
         return;
       }

--- a/source/pages/Transactions/SignEth.tsx
+++ b/source/pages/Transactions/SignEth.tsx
@@ -114,6 +114,18 @@ const EthSign: React.FC<ISign> = () => {
     throw { message: t('send.signingForWrongAddress') };
   };
 
+  const getEthSignPayload = () => {
+    if (isActiveAccountAddress(data[0])) {
+      return String(data[1] || '');
+    }
+
+    if (isActiveAccountAddress(data[1])) {
+      return String(data[0] || '');
+    }
+
+    throw { message: t('send.signingForWrongAddress') };
+  };
+
   const encodePasskey1271Signature = async (hash: string) => {
     if (!activeAccount.passkey) {
       throw { message: t('send.passkeyActiveAccountRequired') };
@@ -149,7 +161,7 @@ const EthSign: React.FC<ISign> = () => {
     }
 
     if (data.eventName === 'eth_sign') {
-      const payload = String(data[1] || data[0] || '');
+      const payload = getEthSignPayload();
       if (!isHexString(payload, 32)) {
         throw {
           message: t('send.passkeyEthSignHashRequired'),

--- a/source/pages/Transactions/SignEth.tsx
+++ b/source/pages/Transactions/SignEth.tsx
@@ -1,3 +1,6 @@
+import { defaultAbiCoder } from '@ethersproject/abi';
+import { arrayify, isHexString } from '@ethersproject/bytes';
+import { hashMessage, _TypedDataEncoder } from '@ethersproject/hash';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
@@ -19,6 +22,7 @@ import { createTemporaryAlarm } from 'utils/alarmUtils';
 import { dispatchBackgroundEvent } from 'utils/browser';
 import { handleTransactionError } from 'utils/errorHandling';
 import { getNetworkChain } from 'utils/network';
+import { getPasskeyAssertion } from 'utils/passkey';
 
 interface ISign {
   send?: boolean;
@@ -95,6 +99,75 @@ const EthSign: React.FC<ISign> = () => {
     }
   };
 
+  const encodePasskey1271Signature = async (hash: string) => {
+    if (!activeAccount.passkey) {
+      throw { message: t('send.passkeyActiveAccountRequired') };
+    }
+
+    const assertion = await getPasskeyAssertion(
+      activeAccount.passkey.credentialId,
+      hash
+    );
+
+    return defaultAbiCoder.encode(
+      [
+        'tuple(bytes authenticatorData,bytes clientDataJSON,uint256 typeOffset,uint256 challengeOffset,uint256 originOffset,bytes32 r,bytes32 s)',
+      ],
+      [
+        {
+          authenticatorData: assertion.authenticatorData,
+          clientDataJSON: assertion.clientDataJSON,
+          typeOffset: assertion.typeOffset,
+          challengeOffset: assertion.challengeOffset,
+          originOffset: assertion.originOffset,
+          r: assertion.r,
+          s: assertion.s,
+        },
+      ]
+    );
+  };
+
+  const getPasskeySignHash = (typedData?: any) => {
+    if (data.eventName === 'personal_sign') {
+      const isFirstParamAddress =
+        data[0] &&
+        typeof data[0] === 'string' &&
+        data[0].startsWith('0x') &&
+        data[0].length === 42;
+      const msg = isFirstParamAddress ? data[1] || '' : data[0] || '';
+      return hashMessage(isHexString(msg) ? arrayify(msg) : String(msg));
+    }
+
+    if (data.eventName === 'eth_sign') {
+      const payload = String(data[1] || data[0] || '');
+      if (!isHexString(payload, 32)) {
+        throw {
+          message: t('send.passkeyEthSignHashRequired'),
+        };
+      }
+      return payload;
+    }
+
+    if (typedData) {
+      if (data.eventName === 'eth_signTypedData') {
+        throw {
+          message: t('send.passkeyLegacyTypedDataUnsupported'),
+        };
+      }
+
+      const { domain, types, message: typedMessage } = typedData;
+      const sanitizedTypes = { ...types };
+      delete sanitizedTypes.EIP712Domain;
+      return _TypedDataEncoder.hash(
+        domain || {},
+        sanitizedTypes,
+        typedMessage || {}
+      );
+    }
+
+    throw { message: t('send.passkeyUnsupportedSigningRequest') };
+  };
+
   const onSubmit = async () => {
     setLoading(true);
 
@@ -111,7 +184,33 @@ const EthSign: React.FC<ISign> = () => {
     try {
       let response = '';
       const type = data.eventName;
-      if (data.eventName === 'eth_sign')
+      if (activeAccount.isPasskeySmartAccount && activeAccount.passkey) {
+        let typedData;
+        if (
+          data.eventName === 'eth_signTypedData' ||
+          data.eventName === 'eth_signTypedData_v3' ||
+          data.eventName === 'eth_signTypedData_v4'
+        ) {
+          if (
+            typeof data[0] === 'string' &&
+            data[0].toLowerCase() === address.toLowerCase()
+          ) {
+            typedData = data[1];
+          } else if (
+            typeof data[1] === 'string' &&
+            data[1].toLowerCase() === address.toLowerCase()
+          ) {
+            typedData = data[0];
+          } else {
+            throw { message: t('send.signingForWrongAddress') };
+          }
+          if (typeof typedData === 'string') typedData = JSON.parse(typedData);
+        }
+
+        response = await encodePasskey1271Signature(
+          getPasskeySignHash(typedData)
+        );
+      } else if (data.eventName === 'eth_sign')
         response = (await controllerEmitter(
           ['wallet', 'ethereumTransaction', 'ethSign'],
           [data],

--- a/source/pages/Transactions/SignEth.tsx
+++ b/source/pages/Transactions/SignEth.tsx
@@ -185,6 +185,12 @@ const EthSign: React.FC<ISign> = () => {
       let response = '';
       const type = data.eventName;
       if (activeAccount.isPasskeySmartAccount && activeAccount.passkey) {
+        await controllerEmitter(
+          ['wallet', 'ensurePasskeySmartAccountDeployed'],
+          [],
+          300000
+        );
+
         let typedData;
         if (
           data.eventName === 'eth_signTypedData' ||

--- a/source/pages/Transactions/SignEth.tsx
+++ b/source/pages/Transactions/SignEth.tsx
@@ -126,6 +126,19 @@ const EthSign: React.FC<ISign> = () => {
     throw { message: t('send.signingForWrongAddress') };
   };
 
+  const getTypedDataPayload = () => {
+    let typedData;
+    if (isActiveAccountAddress(data[0])) {
+      typedData = data[1];
+    } else if (isActiveAccountAddress(data[1])) {
+      typedData = data[0];
+    } else {
+      throw { message: t('send.signingForWrongAddress') };
+    }
+
+    return typeof typedData === 'string' ? JSON.parse(typedData) : typedData;
+  };
+
   const encodePasskey1271Signature = async (hash: string) => {
     if (!activeAccount.passkey) {
       throw { message: t('send.passkeyActiveAccountRequired') };
@@ -207,37 +220,21 @@ const EthSign: React.FC<ISign> = () => {
       let response = '';
       const type = data.eventName;
       if (activeAccount.isPasskeySmartAccount && activeAccount.passkey) {
+        const typedData =
+          data.eventName === 'eth_signTypedData' ||
+          data.eventName === 'eth_signTypedData_v3' ||
+          data.eventName === 'eth_signTypedData_v4'
+            ? getTypedDataPayload()
+            : undefined;
+        const signHash = getPasskeySignHash(typedData);
+
         await controllerEmitter(
           ['wallet', 'ensurePasskeySmartAccountDeployed'],
           [],
           300000
         );
 
-        let typedData;
-        if (
-          data.eventName === 'eth_signTypedData' ||
-          data.eventName === 'eth_signTypedData_v3' ||
-          data.eventName === 'eth_signTypedData_v4'
-        ) {
-          if (
-            typeof data[0] === 'string' &&
-            data[0].toLowerCase() === address.toLowerCase()
-          ) {
-            typedData = data[1];
-          } else if (
-            typeof data[1] === 'string' &&
-            data[1].toLowerCase() === address.toLowerCase()
-          ) {
-            typedData = data[0];
-          } else {
-            throw { message: t('send.signingForWrongAddress') };
-          }
-          if (typeof typedData === 'string') typedData = JSON.parse(typedData);
-        }
-
-        response = await encodePasskey1271Signature(
-          getPasskeySignHash(typedData)
-        );
+        response = await encodePasskey1271Signature(signHash);
       } else if (data.eventName === 'eth_sign')
         response = (await controllerEmitter(
           ['wallet', 'ethereumTransaction', 'ethSign'],

--- a/source/routers/index.tsx
+++ b/source/routers/index.tsx
@@ -201,6 +201,9 @@ const ConnectWallet = lazy(() =>
 const ChangeAccount = lazy(() =>
   import('pages').then((m) => ({ default: m.ChangeAccount }))
 );
+const CreatePasskeyAccount = lazy(() =>
+  import('pages').then((m) => ({ default: m.CreatePasskeyAccount }))
+);
 const ChangeConnectedAccount = lazy(() =>
   import('pages').then((m) => ({ default: m.ChangeConnectedAccount }))
 );
@@ -357,6 +360,10 @@ export const Router = () => {
               <Route path="phrase" element={<SeedConfirm />} />
               <Route path="login" element={<Start isExternal={true} />} />
               <Route path="connect-wallet" element={<ConnectWallet />} />
+              <Route
+                path="create-passkey-account"
+                element={<CreatePasskeyAccount />}
+              />
               <Route path="change-account" element={<ChangeAccount />} />
               <Route
                 path="change-active-connected-account"

--- a/source/scripts/Background/controllers/DAppController.ts
+++ b/source/scripts/Background/controllers/DAppController.ts
@@ -297,7 +297,7 @@ const DAppController = (): IDAppController => {
 
       switch (isInActiveSession) {
         case true:
-          _dapps[host].activeAddress = null;
+          delete _dapps[host];
           store.dispatch(removeDApp(host));
           await persistDappState('dapp disconnect');
 

--- a/source/scripts/Background/controllers/DAppController.ts
+++ b/source/scripts/Background/controllers/DAppController.ts
@@ -227,12 +227,8 @@ const DAppController = (): IDAppController => {
     accountId: number,
     accountType: KeyringAccountType
   ) => {
-    // Safety check: ensure the dapp session exists
     if (!_dapps[host]) {
-      console.warn(
-        `[DAppController] Cannot change account for ${host} - session not initialized`
-      );
-      return;
+      _dapps[host] = { activeAddress: '', hasWindow: false };
     }
 
     const date = Date.now();

--- a/source/scripts/Background/controllers/DAppController.ts
+++ b/source/scripts/Background/controllers/DAppController.ts
@@ -55,8 +55,13 @@ const DAppController = (): IDAppController => {
     }
 
     try {
-      const { isBitcoinBased } = store.getState().vault;
       const { host } = new URL(sender.url);
+      if (!isConnected(host)) {
+        delete _dapps[host];
+        return;
+      }
+
+      const { isBitcoinBased } = store.getState().vault;
       const activeAccount = isBitcoinBased
         ? getAccount(host)?.xpub
         : getAccount(host)?.address;

--- a/source/scripts/Background/controllers/DAppController.ts
+++ b/source/scripts/Background/controllers/DAppController.ts
@@ -269,6 +269,27 @@ const DAppController = (): IDAppController => {
     );
   };
 
+  const syncAccountSession = (
+    host: string,
+    accountId: number,
+    accountType: KeyringAccountType
+  ) => {
+    const date = Date.now();
+    const { accounts, isBitcoinBased } = store.getState().vault;
+    const account = accounts[accountType]?.[accountId];
+    if (!account) return;
+
+    store.dispatch(updateDAppAccount({ host, accountId, date, accountType }));
+
+    if (!_dapps[host]) {
+      _dapps[host] = { activeAddress: '', hasWindow: false };
+    }
+
+    _dapps[host].activeAddress = isBitcoinBased
+      ? account.xpub
+      : account.address;
+  };
+
   const disconnect = async (host: string) => {
     try {
       const previousConnectedDapps = getAll();
@@ -608,6 +629,7 @@ const DAppController = (): IDAppController => {
     setup,
     connect,
     changeAccount,
+    syncAccountSession,
     disconnect,
     requestPermissions,
     hasWindow,

--- a/source/scripts/Background/controllers/DAppController.ts
+++ b/source/scripts/Background/controllers/DAppController.ts
@@ -227,7 +227,7 @@ const DAppController = (): IDAppController => {
     return response;
   };
 
-  const changeAccount = (
+  const changeAccount = async (
     host: string,
     accountId: number,
     accountType: KeyringAccountType
@@ -250,6 +250,7 @@ const DAppController = (): IDAppController => {
     }
 
     store.dispatch(updateDAppAccount({ host, accountId, date, accountType }));
+    await persistDappState('dapp account change');
     _dapps[host].activeAddress = isBitcoinBased
       ? account.xpub
       : account.address;

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -1,7 +1,10 @@
 // Removed unused import: ethErrors
 
+import { getAddress } from '@ethersproject/address';
+import { BigNumber } from '@ethersproject/bignumber';
+import { AddressZero, HashZero } from '@ethersproject/constants';
 import { Contract } from '@ethersproject/contracts';
-import { namehash } from '@ethersproject/hash';
+import { id as hashText, namehash } from '@ethersproject/hash';
 import { formatUnits } from '@ethersproject/units';
 import {
   KeyringManager,
@@ -83,7 +86,12 @@ import {
   setPostNetworkSwitchLoading,
   setEnsName,
 } from 'state/vaultGlobal';
-import { INetworkType } from 'types/network';
+import {
+  INetworkType,
+  IPasskeySmartAccountMetadata,
+  KeyringAccountType as PaliKeyringAccountType,
+  PasskeySponsorMode,
+} from 'types/network';
 import { IBlacklistCheckResult } from 'types/security';
 import {
   ITokenEthProps,
@@ -105,6 +113,22 @@ import {
 import { decodeTransactionData } from 'utils/ethUtil';
 import { logError } from 'utils/logger';
 import { getNetworkChain } from 'utils/network';
+import {
+  getPasskeyFactory,
+  getPasskeyFactoryAddress,
+  PasskeyContractSponsorMode,
+  assertPasskeyRelayPayloadMatches,
+  normalizePasskeySponsorProof,
+  passkeyFactoryInterface,
+  passkeySmartAccountInterface,
+  PASSKEY_SMART_ACCOUNT_VERSION,
+  selectPasskeyDeploymentGasPayer,
+  selectPasskeyGasPayerCandidate,
+  selectFundedPasskeyGasPayerCandidate,
+  PasskeyRelayedTransactionNotFoundError,
+  verifyPasskeyRelayedSponsorProof,
+  verifyPasskeySponsorProof,
+} from 'utils/passkey';
 import { blacklistService } from 'utils/security/blacklistService';
 import { chromeStorage } from 'utils/storageAPI';
 import {
@@ -2538,6 +2562,868 @@ class MainController {
     return newAccount;
   }
 
+  public async createPasskeySmartAccount(params: {
+    address: string;
+    label?: string;
+    metadata: IPasskeySmartAccountMetadata;
+  }): Promise<any> {
+    const { accounts } = store.getState().vault;
+    const passkeyAccounts =
+      accounts[PaliKeyringAccountType.PasskeySmartAccount] || {};
+    const existingIds = Object.values(passkeyAccounts)
+      .map((account: any) => account.id)
+      .filter((id) => Number.isFinite(id))
+      .sort((a, b) => a - b);
+
+    let nextId = 0;
+    for (const id of existingIds) {
+      if (id === nextId) {
+        nextId += 1;
+      } else if (id > nextId) {
+        break;
+      }
+    }
+
+    const newAccount = {
+      address: params.address,
+      balances: {
+        [INetworkType.Syscoin]: -1,
+        [INetworkType.Ethereum]: -1,
+      },
+      id: nextId,
+      isImported: false,
+      isLedgerWallet: false,
+      isPasskeySmartAccount: true,
+      isTrezorWallet: false,
+      label: params.label || `Passkey Account ${nextId + 1}`,
+      passkey: params.metadata,
+      xprv: '',
+      xpub: params.address,
+    };
+
+    store.dispatch(
+      createAccount({
+        account: newAccount,
+        accountType: PaliKeyringAccountType.PasskeySmartAccount,
+      })
+    );
+    store.dispatch(
+      setActiveAccount({
+        id: newAccount.id,
+        type: PaliKeyringAccountType.PasskeySmartAccount,
+      })
+    );
+
+    await this.saveWalletState('create-passkey-smart-account', true, true);
+    return newAccount;
+  }
+
+  public async preparePasskeySmartAccount(params: {
+    credentialId: string;
+    credentialIdHash: string;
+    deploymentSalt: string;
+    label?: string;
+    passkeyName: string;
+    publicKey: {
+      originHash: string;
+      originLength: number;
+      rpIdHash: string;
+      x: string;
+      y: string;
+    };
+    sponsor?: {
+      mode?: string;
+      policyText?: string;
+      signer?: string;
+      url?: string;
+      urlHash?: string;
+    };
+  }): Promise<{
+    address: string;
+    factoryAddress: string;
+    metadata: IPasskeySmartAccountMetadata;
+  }> {
+    const { activeNetwork } = store.getState().vault;
+    if (activeNetwork.kind !== INetworkType.Ethereum) {
+      throw new Error('Passkey accounts are only supported on EVM networks');
+    }
+
+    const gasPayer = this.getPasskeyGasPayerCandidate();
+
+    const provider = this.ethereumTransaction?.web3Provider;
+    if (!provider) {
+      throw new Error('Web3 provider not available');
+    }
+
+    const factoryAddress = getPasskeyFactoryAddress(activeNetwork.chainId);
+    const factory = getPasskeyFactory(activeNetwork.chainId, provider);
+    const sponsor = this.normalizePasskeySponsor(params.sponsor);
+    const sponsorContractMode = this.getPasskeySponsorContractMode({
+      sponsor,
+    } as IPasskeySmartAccountMetadata);
+    const address = await factory.getAccountAddress(
+      gasPayer.account.address,
+      params.publicKey.x,
+      params.publicKey.y,
+      params.credentialIdHash,
+      params.publicKey.rpIdHash,
+      params.publicKey.originHash,
+      params.publicKey.originLength,
+      sponsorContractMode,
+      sponsor.signer || AddressZero,
+      sponsor.urlHash || HashZero,
+      params.deploymentSalt
+    );
+
+    return {
+      address,
+      factoryAddress,
+      metadata: {
+        chainId: activeNetwork.chainId,
+        contractVersion: PASSKEY_SMART_ACCOUNT_VERSION,
+        credentialId: params.credentialId,
+        credentialIdHash: params.credentialIdHash,
+        deploymentGasPayer: {
+          address: gasPayer.account.address,
+          id: gasPayer.account.id,
+          type: gasPayer.accountType,
+        },
+        deploymentSalt: params.deploymentSalt,
+        factoryAddress,
+        isDeployed: false,
+        passkeyName: params.passkeyName,
+        publicKey: params.publicKey,
+        sponsor,
+      },
+    };
+  }
+
+  private normalizePasskeySponsor(
+    sponsor?: {
+      mode?: string;
+      policyText?: string;
+      signer?: string;
+      url?: string;
+      urlHash?: string;
+    } | null
+  ): IPasskeySmartAccountMetadata['sponsor'] {
+    const requestedMode = sponsor?.mode || PasskeySponsorMode.Disabled;
+    if (
+      requestedMode !== PasskeySponsorMode.Disabled &&
+      requestedMode !== PasskeySponsorMode.GasOnly &&
+      requestedMode !== PasskeySponsorMode.Required
+    ) {
+      throw new Error(`Unsupported passkey sponsor mode: ${requestedMode}`);
+    }
+    const mode = requestedMode as PasskeySponsorMode;
+
+    let signer: string | undefined;
+    if (sponsor?.signer) {
+      signer = getAddress(sponsor.signer);
+    }
+
+    if (mode === PasskeySponsorMode.Required && !signer) {
+      throw new Error(
+        'Passkey sponsor mode "required" needs a valid sponsor signer'
+      );
+    }
+
+    const url = typeof sponsor?.url === 'string' ? sponsor.url.trim() : '';
+    const providedUrlHash =
+      typeof sponsor?.urlHash === 'string' ? sponsor.urlHash : '';
+    if (providedUrlHash && !/^0x[0-9a-fA-F]{64}$/.test(providedUrlHash)) {
+      throw new Error('Invalid passkey sponsor URL hash');
+    }
+
+    return {
+      mode,
+      ...(typeof sponsor?.policyText === 'string' && sponsor.policyText.trim()
+        ? { policyText: sponsor.policyText.trim() }
+        : {}),
+      ...(signer ? { signer } : {}),
+      ...(url ? { url, urlHash: hashText(url) } : {}),
+      ...(!url && providedUrlHash ? { urlHash: providedUrlHash } : {}),
+    };
+  }
+
+  private async passkeyGasPayerHasBalance(
+    address: string,
+    minimumBalanceWei: BigNumber
+  ) {
+    const provider = this.ethereumTransaction?.web3Provider;
+    if (!provider) {
+      throw new Error('Web3 provider not available');
+    }
+    const balance = await provider.getBalance(address);
+    return BigNumber.from(balance).gte(minimumBalanceWei);
+  }
+
+  private async getDefaultPasskeyGasPayer(minimumBalanceWei: BigNumber) {
+    const { accounts, activeAccount } = store.getState().vault;
+    return selectFundedPasskeyGasPayerCandidate(
+      accounts,
+      activeAccount,
+      (address) => this.passkeyGasPayerHasBalance(address, minimumBalanceWei)
+    );
+  }
+
+  private getPasskeyGasPayerCandidate() {
+    const { accounts, activeAccount } = store.getState().vault;
+    return selectPasskeyGasPayerCandidate(accounts, activeAccount);
+  }
+
+  private async getPasskeyDeploymentGasPayer(
+    metadata: IPasskeySmartAccountMetadata,
+    minimumBalanceWei: BigNumber
+  ) {
+    const { accounts } = store.getState().vault;
+    if (!metadata.deploymentGasPayer) {
+      return this.getDefaultPasskeyGasPayer(minimumBalanceWei);
+    }
+    const gasPayer = selectPasskeyDeploymentGasPayer(accounts, metadata, () => {
+      throw new Error(
+        'Passkey deployment gas payer is no longer available in this wallet'
+      );
+    });
+    if (
+      !(await this.passkeyGasPayerHasBalance(
+        gasPayer.account.address,
+        minimumBalanceWei
+      ))
+    ) {
+      throw new Error(
+        'Passkey deployment gas payer does not have native gas on this network'
+      );
+    }
+    return gasPayer;
+  }
+
+  private async runWithGasPayer<T>(
+    gasPayer: { account: any; accountType: PaliKeyringAccountType },
+    callback: () => Promise<T>
+  ): Promise<T> {
+    const original = store.getState().vault.activeAccount;
+    store.dispatch(
+      setActiveAccount({
+        id: gasPayer.account.id,
+        type: gasPayer.accountType,
+      })
+    );
+
+    try {
+      return await callback();
+    } finally {
+      store.dispatch(setActiveAccount(original));
+    }
+  }
+
+  private getPasskeySponsorContractMode(
+    metadata: IPasskeySmartAccountMetadata
+  ) {
+    switch (metadata.sponsor?.mode) {
+      case PasskeySponsorMode.GasOnly:
+        return PasskeyContractSponsorMode.GasOnly;
+      case PasskeySponsorMode.Required:
+        return PasskeyContractSponsorMode.Required;
+      case PasskeySponsorMode.Disabled:
+      default:
+        return PasskeyContractSponsorMode.None;
+    }
+  }
+
+  public async ensurePasskeySmartAccountDeployed(): Promise<boolean> {
+    const { activeAccount, activeNetwork, accounts } = store.getState().vault;
+    const account = accounts[activeAccount.type]?.[activeAccount.id] as any;
+
+    if (!account?.isPasskeySmartAccount || !account.passkey) {
+      throw new Error('Active account is not a passkey account');
+    }
+
+    const provider = this.ethereumTransaction?.web3Provider;
+    if (!provider) {
+      throw new Error('Web3 provider not available');
+    }
+
+    const code = await provider.getCode(account.address);
+    if (code && code !== '0x') {
+      return false;
+    }
+
+    const metadata = account.passkey as IPasskeySmartAccountMetadata;
+    const gasPrice = (await this.ethereumTransaction.getRecommendedGasPrice(
+      false
+    )) as string;
+    const gasLimit = BigNumber.from(3_000_000);
+    const gasPayer = await this.getPasskeyDeploymentGasPayer(
+      metadata,
+      BigNumber.from(gasPrice).mul(gasLimit)
+    );
+    const data = passkeyFactoryInterface.encodeFunctionData('createAccount', [
+      metadata.publicKey.x,
+      metadata.publicKey.y,
+      metadata.credentialIdHash,
+      metadata.publicKey.rpIdHash,
+      metadata.publicKey.originHash,
+      metadata.publicKey.originLength,
+      this.getPasskeySponsorContractMode(metadata),
+      metadata.sponsor?.signer || AddressZero,
+      metadata.sponsor?.urlHash || HashZero,
+      metadata.deploymentSalt,
+    ]);
+
+    await this.runWithGasPayer(gasPayer, async () => {
+      const tx = await this.ethereumTransaction.sendFormattedTransaction(
+        {
+          chainId: activeNetwork.chainId,
+          data,
+          from: gasPayer.account.address,
+          gasPrice,
+          gasLimit: gasLimit.toNumber(),
+          maxFeePerGas: 0,
+          maxPriorityFeePerGas: 0,
+          to:
+            metadata.factoryAddress ||
+            getPasskeyFactoryAddress(activeNetwork.chainId),
+          value: 0,
+        },
+        true
+      );
+      await tx.wait?.();
+    });
+
+    const deployedCode = await provider.getCode(account.address);
+    if (!deployedCode || deployedCode === '0x') {
+      throw new Error('Passkey smart account deployment address mismatch');
+    }
+
+    const updatedMetadata = {
+      ...metadata,
+      isDeployed: true,
+    };
+    store.dispatch(
+      setAccountPropertyByIdAndType({
+        id: account.id,
+        type: PaliKeyringAccountType.PasskeySmartAccount,
+        property: 'passkey',
+        value: updatedMetadata,
+      })
+    );
+    await this.saveWalletState('deploy-passkey-smart-account', true, true);
+    return true;
+  }
+
+  public async preparePasskeyExecution(params: {
+    data?: string;
+    target: string;
+    value: string;
+  }): Promise<{
+    actionHash: string;
+    execution: {
+      data: string;
+      deadline: number;
+      nonce: string;
+      target: string;
+      value: string;
+    };
+  }> {
+    await this.ensurePasskeySmartAccountDeployed();
+
+    const { activeAccount, accounts } = store.getState().vault;
+    const account = accounts[activeAccount.type]?.[activeAccount.id] as any;
+    const contract = new Contract(
+      account.address,
+      passkeySmartAccountInterface,
+      this.ethereumTransaction.web3Provider
+    );
+    const nonce = await contract.nonce();
+    const execution = {
+      target: params.target,
+      value: params.value,
+      data: params.data || '0x',
+      nonce: nonce.toString(),
+      deadline: Math.floor(Date.now() / 1000) + 15 * 60,
+    };
+    const actionHash = await contract.getActionHash(execution);
+
+    return { actionHash, execution };
+  }
+
+  public async submitPasskeyExecution(params: {
+    execution: {
+      data: string;
+      deadline: number;
+      nonce: string;
+      target: string;
+      value: string;
+    };
+    proof: {
+      authenticatorData: string;
+      challengeOffset: number;
+      clientDataJSON: string;
+      originOffset: number;
+      r: string;
+      s: string;
+      typeOffset: number;
+    };
+    sponsorProof?:
+      | string
+      | {
+          r?: string;
+          s?: string;
+          signature?: string;
+          v?: number | string;
+        };
+    sponsorSignature?: string;
+  }) {
+    const { activeAccount, activeNetwork, accounts } = store.getState().vault;
+    const account = accounts[activeAccount.type]?.[activeAccount.id] as any;
+
+    if (!account?.isPasskeySmartAccount) {
+      throw new Error('Active account is not a passkey account');
+    }
+
+    const emptySponsorProof = { v: 0, r: HashZero, s: HashZero };
+    let sponsorProof = emptySponsorProof;
+    const sponsorResult = await this.resolvePasskeySponsorResult(
+      account,
+      activeNetwork.chainId,
+      params
+    );
+    if (sponsorResult.type === 'relayed') {
+      try {
+        await this.verifyPasskeyRelayedTransaction(
+          sponsorResult.txHash,
+          account.address,
+          params.execution,
+          params.proof,
+          account.passkey as IPasskeySmartAccountMetadata
+        );
+        return { hash: sponsorResult.txHash };
+      } catch (error) {
+        const metadata = account.passkey as IPasskeySmartAccountMetadata;
+        if (
+          metadata.sponsor?.mode !== PasskeySponsorMode.GasOnly ||
+          error instanceof PasskeyRelayedTransactionNotFoundError
+        ) {
+          throw error;
+        }
+      }
+    } else {
+      sponsorProof = sponsorResult.sponsorProof;
+    }
+
+    const gasPrice = (await this.ethereumTransaction.getRecommendedGasPrice(
+      false
+    )) as string;
+    const gasLimit = BigNumber.from(1_000_000);
+    const gasPayer = await this.getDefaultPasskeyGasPayer(
+      BigNumber.from(gasPrice).mul(gasLimit)
+    );
+    const data = passkeySmartAccountInterface.encodeFunctionData('execute', [
+      params.execution,
+      params.proof,
+      sponsorProof,
+    ]);
+
+    return await this.runWithGasPayer(gasPayer, async () =>
+      this.sendAndSaveEthTransaction(
+        {
+          chainId: activeNetwork.chainId,
+          data,
+          from: gasPayer.account.address,
+          gasPrice,
+          gasLimit: gasLimit.toNumber(),
+          maxFeePerGas: 0,
+          maxPriorityFeePerGas: 0,
+          to: account.address,
+          value: 0,
+        },
+        true
+      )
+    );
+  }
+
+  private async resolvePasskeySponsorResult(
+    account: any,
+    chainId: number,
+    params: {
+      execution: {
+        data: string;
+        deadline: number;
+        nonce: string;
+        target: string;
+        value: string;
+      };
+      proof: {
+        authenticatorData: string;
+        challengeOffset: number;
+        clientDataJSON: string;
+        originOffset: number;
+        r: string;
+        s: string;
+        typeOffset: number;
+      };
+      sponsorProof?:
+        | string
+        | {
+            r?: string;
+            s?: string;
+            signature?: string;
+            v?: number | string;
+          };
+      sponsorSignature?: string;
+    }
+  ): Promise<
+    | { sponsorProof: { r: string; s: string; v: number }; type: 'local' }
+    | { txHash: string; type: 'relayed' }
+  > {
+    const metadata = account.passkey as IPasskeySmartAccountMetadata;
+    const emptyProof = { v: 0, r: HashZero, s: HashZero };
+
+    const contract = new Contract(
+      account.address,
+      passkeySmartAccountInterface,
+      this.ethereumTransaction.web3Provider
+    );
+    const actionHash = await contract.getActionHash(params.execution);
+    const providedProof = this.normalizePasskeySponsorProof(
+      params.sponsorProof || params.sponsorSignature
+    );
+    if (providedProof) {
+      verifyPasskeySponsorProof(actionHash, providedProof, metadata);
+      return { sponsorProof: providedProof, type: 'local' };
+    }
+
+    if (
+      metadata.sponsor?.mode !== PasskeySponsorMode.Required &&
+      metadata.sponsor?.mode !== PasskeySponsorMode.GasOnly
+    ) {
+      return { sponsorProof: emptyProof, type: 'local' };
+    }
+
+    if (
+      !metadata.sponsor?.url &&
+      metadata.sponsor?.mode === PasskeySponsorMode.Required
+    ) {
+      throw new Error(
+        'This passkey account requires sponsor authorization, but no sponsor URL is configured'
+      );
+    }
+    if (!metadata.sponsor?.url) {
+      return { sponsorProof: emptyProof, type: 'local' };
+    }
+
+    let sponsorResult:
+      | {
+          sponsorProof: { r: string; s: string; v: number };
+          type: 'authorization';
+        }
+      | { txHash: string; type: 'relayed' };
+    try {
+      sponsorResult = await this.fetchPasskeySponsorResult(
+        metadata.sponsor.url,
+        {
+          account: account.address,
+          actionHash,
+          chainId,
+          execution: params.execution,
+          proof: params.proof,
+          sponsorSigner: metadata.sponsor.signer,
+          version: PASSKEY_SMART_ACCOUNT_VERSION,
+        }
+      );
+    } catch (error) {
+      if (metadata.sponsor.mode === PasskeySponsorMode.GasOnly) {
+        return { sponsorProof: emptyProof, type: 'local' };
+      }
+      throw error;
+    }
+
+    if (sponsorResult.type === 'relayed') {
+      return sponsorResult;
+    }
+    if (metadata.sponsor.mode === PasskeySponsorMode.GasOnly) {
+      return { sponsorProof: emptyProof, type: 'local' };
+    }
+    verifyPasskeySponsorProof(actionHash, sponsorResult.sponsorProof, metadata);
+    return { sponsorProof: sponsorResult.sponsorProof, type: 'local' };
+  }
+
+  private normalizePasskeySponsorProof(
+    proofOrSignature?:
+      | string
+      | {
+          r?: string;
+          s?: string;
+          signature?: string;
+          v?: number | string;
+        }
+      | null
+  ): { r: string; s: string; v: number } | null {
+    return normalizePasskeySponsorProof(proofOrSignature);
+  }
+
+  private async fetchPasskeySponsorResult(
+    sponsorUrl: string,
+    payload: {
+      account: string;
+      actionHash: string;
+      chainId: number;
+      execution: {
+        data: string;
+        deadline: number;
+        nonce: string;
+        target: string;
+        value: string;
+      };
+      proof: {
+        authenticatorData: string;
+        challengeOffset: number;
+        clientDataJSON: string;
+        originOffset: number;
+        r: string;
+        s: string;
+        typeOffset: number;
+      };
+      sponsorSigner?: string;
+      version: string;
+    }
+  ): Promise<
+    | {
+        sponsorProof: { r: string; s: string; v: number };
+        type: 'authorization';
+      }
+    | { txHash: string; type: 'relayed' }
+  > {
+    const responseBody = await this.postPasskeySponsorRequest(sponsorUrl, {
+      ...payload,
+      idempotencyKey: payload.actionHash,
+      requestType: 'execute',
+    });
+    return this.resolvePasskeySponsorResponse(
+      sponsorUrl,
+      payload,
+      responseBody
+    );
+  }
+
+  private async postPasskeySponsorRequest(
+    sponsorUrl: string,
+    payload: Record<string, unknown>
+  ) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 8_000);
+
+    try {
+      const response = await fetch(sponsorUrl, {
+        body: JSON.stringify(payload),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        throw new Error(`Sponsor authorization failed: ${response.status}`);
+      }
+
+      return response.json();
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private async resolvePasskeySponsorResponse(
+    sponsorUrl: string,
+    payload: {
+      account: string;
+      actionHash: string;
+      chainId: number;
+      execution: {
+        data: string;
+        deadline: number;
+        nonce: string;
+        target: string;
+        value: string;
+      };
+      proof: {
+        authenticatorData: string;
+        challengeOffset: number;
+        clientDataJSON: string;
+        originOffset: number;
+        r: string;
+        s: string;
+        typeOffset: number;
+      };
+      sponsorSigner?: string;
+      version: string;
+    },
+    body: any
+  ): Promise<
+    | {
+        sponsorProof: { r: string; s: string; v: number };
+        type: 'authorization';
+      }
+    | { txHash: string; type: 'relayed' }
+  > {
+    const immediate = this.parsePasskeySponsorResponse(body);
+    if (immediate.type !== 'pending') {
+      return immediate;
+    }
+
+    return this.pollPasskeySponsorRequest(
+      immediate.statusUrl || sponsorUrl,
+      payload,
+      immediate.requestId
+    );
+  }
+
+  private parsePasskeySponsorResponse(body: any):
+    | { requestId: string; statusUrl?: string; type: 'pending' }
+    | {
+        sponsorProof: { r: string; s: string; v: number };
+        type: 'authorization';
+      }
+    | { txHash: string; type: 'relayed' } {
+    const txHash = body?.txHash || body?.transactionHash || body?.hash;
+    if (typeof txHash === 'string' && /^0x[0-9a-fA-F]{64}$/.test(txHash)) {
+      return { txHash, type: 'relayed' };
+    }
+
+    const sponsorProof = this.normalizePasskeySponsorProof(
+      body?.sponsorProof || body?.signature || body?.sponsorSignature
+    );
+    if (sponsorProof) {
+      return { sponsorProof, type: 'authorization' };
+    }
+
+    const requestId = body?.requestId || body?.id;
+    const status = String(body?.status || body?.type || '').toLowerCase();
+    if (requestId && (status === 'pending' || status === 'queued' || !status)) {
+      return {
+        requestId: String(requestId),
+        statusUrl:
+          typeof body?.statusUrl === 'string' ? body.statusUrl : undefined,
+        type: 'pending',
+      };
+    }
+
+    throw new Error(
+      'Sponsor response did not include txHash, signature, or pending request id'
+    );
+  }
+
+  private async pollPasskeySponsorRequest(
+    statusUrl: string,
+    payload: {
+      account: string;
+      actionHash: string;
+      chainId: number;
+      execution: {
+        data: string;
+        deadline: number;
+        nonce: string;
+        target: string;
+        value: string;
+      };
+      proof: {
+        authenticatorData: string;
+        challengeOffset: number;
+        clientDataJSON: string;
+        originOffset: number;
+        r: string;
+        s: string;
+        typeOffset: number;
+      };
+      sponsorSigner?: string;
+      version: string;
+    },
+    requestId: string
+  ): Promise<
+    | {
+        sponsorProof: { r: string; s: string; v: number };
+        type: 'authorization';
+      }
+    | { txHash: string; type: 'relayed' }
+  > {
+    for (let attempt = 0; attempt < 12; attempt++) {
+      await new Promise((resolve) => setTimeout(resolve, 5_000));
+      const body = await this.postPasskeySponsorRequest(statusUrl, {
+        account: payload.account,
+        actionHash: payload.actionHash,
+        chainId: payload.chainId,
+        idempotencyKey: payload.actionHash,
+        requestId,
+        requestType: 'status',
+        version: payload.version,
+      });
+      const result = this.parsePasskeySponsorResponse(body);
+      if (result.type !== 'pending') {
+        return result;
+      }
+    }
+
+    throw new Error('Sponsor relay request is still pending');
+  }
+
+  private async verifyPasskeyRelayedTransaction(
+    txHash: string,
+    expectedAccount: string,
+    expectedExecution: {
+      data: string;
+      deadline: number;
+      nonce: string;
+      target: string;
+      value: string;
+    },
+    expectedProof: {
+      authenticatorData: string;
+      challengeOffset: number;
+      clientDataJSON: string;
+      originOffset: number;
+      r: string;
+      s: string;
+      typeOffset: number;
+    },
+    metadata: IPasskeySmartAccountMetadata
+  ) {
+    const provider = this.ethereumTransaction?.web3Provider;
+    if (!provider) {
+      throw new Error('Web3 provider not available');
+    }
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const tx = await provider.getTransaction(txHash);
+      if (tx) {
+        if (tx.to?.toLowerCase() !== expectedAccount.toLowerCase()) {
+          throw new Error('Sponsor relayed an unexpected passkey transaction');
+        }
+        const decoded = passkeySmartAccountInterface.decodeFunctionData(
+          'execute',
+          tx.data
+        );
+        assertPasskeyRelayPayloadMatches(
+          decoded[0],
+          decoded[1],
+          expectedExecution,
+          expectedProof
+        );
+        if (metadata.sponsor?.mode === PasskeySponsorMode.Required) {
+          const actionHash = await new Contract(
+            expectedAccount,
+            passkeySmartAccountInterface,
+            provider
+          ).getActionHash(expectedExecution);
+          verifyPasskeyRelayedSponsorProof(actionHash, decoded[2], metadata);
+        }
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 2_000));
+    }
+    throw new PasskeyRelayedTransactionNotFoundError();
+  }
+
   public async setAccount(
     id: number,
     type: KeyringAccountType,
@@ -3919,7 +4805,7 @@ class MainController {
   }: {
     activeAccount: {
       id: number;
-      type: KeyringAccountType;
+      type: PaliKeyringAccountType;
     };
     activeNetwork: INetwork;
     isBitcoinBased: boolean;
@@ -4031,7 +4917,7 @@ class MainController {
   }: {
     activeAccount: {
       id: number;
-      type: KeyringAccountType;
+      type: PaliKeyringAccountType;
     };
     activeNetwork: INetwork;
     isBitcoinBased: boolean;

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -39,7 +39,6 @@ import { clearNavigationState } from '../../../utils/navigationState';
 import { checkForUpdates } from '../handlers/handlePaliUpdates';
 import PaliLogo from 'assets/all_assets/favicon-32.png';
 import { ASSET_PRICE_API } from 'constants/index';
-import { updateDAppAccount } from 'state/dapp';
 import { setPrices } from 'state/price';
 import store from 'state/store';
 import { loadAndActivateSlip44Vault, saveMainState } from 'state/store';
@@ -3695,7 +3694,7 @@ class MainController {
     }
 
     const { dapps } = store.getState().dapp;
-    const date = Date.now();
+    const controller = getController();
     for (const [host, dapp] of Object.entries(dapps)) {
       const dappAccount = accounts[dapp.accountType]?.[dapp.accountId];
       if (
@@ -3708,13 +3707,10 @@ class MainController {
         continue;
       }
 
-      store.dispatch(
-        updateDAppAccount({
-          host,
-          accountId: fallbackAccount.id,
-          accountType: fallbackAccount.type,
-          date,
-        })
+      controller.dapp.changeAccount(
+        host,
+        fallbackAccount.id,
+        fallbackAccount.type
       );
     }
   }

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -3512,14 +3512,22 @@ class MainController {
     // This prevents concurrent account switches across all contexts
     return accountSwitchMutex.runExclusive(async () => {
       try {
-        const { isBitcoinBased } = store.getState().vault;
-        if (
-          isBitcoinBased &&
-          String(type) === PaliKeyringAccountType.PasskeySmartAccount
-        ) {
-          throw new Error(
-            'Passkey accounts are only available on EVM networks'
-          );
+        const { accounts, activeNetwork, isBitcoinBased } =
+          store.getState().vault;
+        if (String(type) === PaliKeyringAccountType.PasskeySmartAccount) {
+          const account = accounts[type]?.[id] as any;
+          if (isBitcoinBased) {
+            throw new Error(
+              'Passkey accounts are only available on EVM networks'
+            );
+          }
+          if (
+            Number(account?.passkey?.chainId) !== Number(activeNetwork.chainId)
+          ) {
+            throw new Error(
+              'Passkey account is not available on the active network'
+            );
+          }
         }
 
         // Cancel any pending async operations before switching accounts

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -2816,6 +2816,7 @@ class MainController {
     callback: () => Promise<T>
   ): Promise<T> {
     const original = store.getState().vault.activeAccount;
+    let callbackSucceeded = false;
     store.dispatch(
       setActiveAccount({
         id: gasPayer.account.id,
@@ -2824,9 +2825,26 @@ class MainController {
     );
 
     try {
-      return await callback();
+      const result = await callback();
+      callbackSucceeded = true;
+      return result;
     } finally {
       store.dispatch(setActiveAccount(original));
+      try {
+        await this.saveWalletState(
+          'restore-passkey-active-account',
+          false,
+          true
+        );
+      } catch (error) {
+        if (callbackSucceeded) {
+          throw error;
+        }
+        console.error(
+          '[MainController] Failed to persist restored active account after passkey gas payer operation:',
+          error
+        );
+      }
     }
   }
 

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -2868,6 +2868,16 @@ class MainController {
     return getPasskeyFactoryAddress(activeNetwork.chainId);
   }
 
+  public assertPasskeySmartAccountSupported(): boolean {
+    const { activeNetwork } = store.getState().vault;
+    if (activeNetwork.kind !== INetworkType.Ethereum) {
+      throw new Error('Passkey accounts are only supported on EVM networks');
+    }
+
+    getPasskeyFactoryAddress(activeNetwork.chainId);
+    return true;
+  }
+
   private async assertPasskeyExecutionTargetAllowed(target: string) {
     const blacklistResult = await blacklistService.checkAddress(
       getAddress(target)

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -2868,6 +2868,23 @@ class MainController {
     return getPasskeyFactoryAddress(activeNetwork.chainId);
   }
 
+  private async assertPasskeyExecutionTargetAllowed(target: string) {
+    const blacklistResult = await blacklistService.checkAddress(
+      getAddress(target)
+    );
+    if (
+      blacklistResult.isBlacklisted &&
+      (blacklistResult.severity === 'critical' ||
+        blacklistResult.severity === 'high')
+    ) {
+      throw new Error(
+        `Passkey transaction blocked: ${
+          blacklistResult.reason || 'Execution target address is blacklisted'
+        }. Severity: ${blacklistResult.severity}`
+      );
+    }
+  }
+
   public async ensurePasskeySmartAccountDeployed(): Promise<boolean> {
     const { activeAccount, activeNetwork, accounts } = store.getState().vault;
     const account = accounts[activeAccount.type]?.[activeAccount.id] as any;
@@ -2963,6 +2980,7 @@ class MainController {
       value: string;
     };
   }> {
+    await this.assertPasskeyExecutionTargetAllowed(params.target);
     await this.ensurePasskeySmartAccountDeployed();
 
     const { activeAccount, accounts } = store.getState().vault;
@@ -3021,6 +3039,7 @@ class MainController {
 
     const metadata = account.passkey as IPasskeySmartAccountMetadata;
     this.assertPasskeyAccountNetwork(metadata);
+    await this.assertPasskeyExecutionTargetAllowed(params.execution.target);
 
     const emptySponsorProof = { v: 0, r: HashZero, s: HashZero };
     let sponsorProof = emptySponsorProof;

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -3512,6 +3512,16 @@ class MainController {
     // This prevents concurrent account switches across all contexts
     return accountSwitchMutex.runExclusive(async () => {
       try {
+        const { isBitcoinBased } = store.getState().vault;
+        if (
+          isBitcoinBased &&
+          String(type) === PaliKeyringAccountType.PasskeySmartAccount
+        ) {
+          throw new Error(
+            'Passkey accounts are only available on EVM networks'
+          );
+        }
+
         // Cancel any pending async operations before switching accounts
         if (this.cancellablePromises.transactionPromise) {
           this.cancellablePromises.transactionPromise.cancel();

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -2953,13 +2953,15 @@ class MainController {
       return false;
     }
 
-    const gasPrice = (await this.ethereumTransaction.getRecommendedGasPrice(
-      false
-    )) as string;
+    const { maxFeePerGas, maxPriorityFeePerGas } =
+      (await this.ethereumTransaction.getFeeDataWithDynamicMaxPriorityFeePerGas()) as {
+        maxFeePerGas: BigNumber;
+        maxPriorityFeePerGas: BigNumber;
+      };
     const gasLimit = BigNumber.from(3_000_000);
     const gasPayer = await this.getPasskeyDeploymentGasPayer(
       metadata,
-      BigNumber.from(gasPrice).mul(gasLimit)
+      BigNumber.from(maxFeePerGas).mul(gasLimit)
     );
     const data = passkeyFactoryInterface.encodeFunctionData('createAccount', [
       metadata.publicKey.x,
@@ -2980,14 +2982,13 @@ class MainController {
           chainId: activeNetwork.chainId,
           data,
           from: gasPayer.account.address,
-          gasPrice,
           gasLimit: gasLimit.toNumber(),
-          maxFeePerGas: 0,
-          maxPriorityFeePerGas: 0,
+          maxFeePerGas,
+          maxPriorityFeePerGas,
           to: metadata.factoryAddress || factoryAddress,
           value: 0,
         },
-        true
+        false
       );
       await tx.wait?.();
     });
@@ -3125,12 +3126,14 @@ class MainController {
       sponsorProof = sponsorResult.sponsorProof;
     }
 
-    const gasPrice = (await this.ethereumTransaction.getRecommendedGasPrice(
-      false
-    )) as string;
+    const { maxFeePerGas, maxPriorityFeePerGas } =
+      (await this.ethereumTransaction.getFeeDataWithDynamicMaxPriorityFeePerGas()) as {
+        maxFeePerGas: BigNumber;
+        maxPriorityFeePerGas: BigNumber;
+      };
     const gasLimit = BigNumber.from(1_000_000);
     const gasPayer = await this.getDefaultPasskeyGasPayer(
-      BigNumber.from(gasPrice).mul(gasLimit)
+      BigNumber.from(maxFeePerGas).mul(gasLimit)
     );
     const data = passkeySmartAccountInterface.encodeFunctionData('execute', [
       params.execution,
@@ -3144,14 +3147,13 @@ class MainController {
           chainId: activeNetwork.chainId,
           data,
           from: gasPayer.account.address,
-          gasPrice,
           gasLimit: gasLimit.toNumber(),
-          maxFeePerGas: 0,
-          maxPriorityFeePerGas: 0,
+          maxFeePerGas,
+          maxPriorityFeePerGas,
           to: account.address,
           value: 0,
         },
-        true,
+        false,
         {
           id: account.id,
           type: PaliKeyringAccountType.PasskeySmartAccount,

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -3694,7 +3694,7 @@ class MainController {
     return null;
   }
 
-  private ensureActiveAccountCompatibleWithNetwork(network: INetwork) {
+  private async ensureActiveAccountCompatibleWithNetwork(network: INetwork) {
     const { accounts, activeAccount } = store.getState().vault;
     const currentAccount = accounts[activeAccount.type]?.[activeAccount.id];
     let fallbackAccount = this.isAccountCompatibleWithNetwork(
@@ -3729,7 +3729,6 @@ class MainController {
           activeAccount,
         }
       );
-      return;
     }
 
     const { dapps } = store.getState().dapp;
@@ -3746,11 +3745,7 @@ class MainController {
         continue;
       }
 
-      controller.dapp.syncAccountSession(
-        host,
-        fallbackAccount.id,
-        fallbackAccount.type
-      );
+      await controller.dapp.disconnect(host);
     }
   }
 
@@ -5970,7 +5965,7 @@ class MainController {
     // - network configuration
     // - isBitcoinBased (derived from activeChain)
     store.dispatch(setNetworkChange({ activeNetwork: network }));
-    this.ensureActiveAccountCompatibleWithNetwork(network);
+    await this.ensureActiveAccountCompatibleWithNetwork(network);
 
     // Dispatch success immediately to prevent getting stuck in "switching" state
     store.dispatch(switchNetworkSuccess());

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -2,6 +2,7 @@
 
 import { getAddress } from '@ethersproject/address';
 import { BigNumber } from '@ethersproject/bignumber';
+import { isHexString } from '@ethersproject/bytes';
 import { AddressZero, HashZero } from '@ethersproject/constants';
 import { Contract } from '@ethersproject/contracts';
 import { id as hashText, namehash } from '@ethersproject/hash';
@@ -3608,6 +3609,71 @@ class MainController {
     }
   }
 
+  private isAccountCompatibleWithNetwork(
+    account: any,
+    type: PaliKeyringAccountType,
+    network: INetwork
+  ): boolean {
+    if (!account) return false;
+
+    if (String(type) === PaliKeyringAccountType.PasskeySmartAccount) {
+      return (
+        network.kind === INetworkType.Ethereum &&
+        Number(account?.passkey?.chainId) === Number(network.chainId)
+      );
+    }
+
+    const address = account.address;
+    if (typeof address !== 'string') return false;
+
+    return network.kind === INetworkType.Syscoin
+      ? !isHexString(address)
+      : isHexString(address);
+  }
+
+  private ensureActiveAccountCompatibleWithNetwork(network: INetwork) {
+    const { accounts, activeAccount } = store.getState().vault;
+    const currentAccount = accounts[activeAccount.type]?.[activeAccount.id];
+
+    if (
+      this.isAccountCompatibleWithNetwork(
+        currentAccount,
+        activeAccount.type,
+        network
+      )
+    ) {
+      return;
+    }
+
+    for (const [accountType, accountsOfType] of Object.entries(accounts)) {
+      for (const account of Object.values(accountsOfType || {}) as any[]) {
+        if (
+          this.isAccountCompatibleWithNetwork(
+            account,
+            accountType as PaliKeyringAccountType,
+            network
+          )
+        ) {
+          store.dispatch(
+            setActiveAccount({
+              id: account.id,
+              type: accountType as PaliKeyringAccountType,
+            })
+          );
+          return;
+        }
+      }
+    }
+
+    console.warn(
+      '[MainController] No compatible account found after network switch',
+      {
+        network: network.chainId,
+        activeAccount,
+      }
+    );
+  }
+
   public async setActiveNetwork(
     network: INetwork,
     syncUpdates = false
@@ -5824,6 +5890,7 @@ class MainController {
     // - network configuration
     // - isBitcoinBased (derived from activeChain)
     store.dispatch(setNetworkChange({ activeNetwork: network }));
+    this.ensureActiveAccountCompatibleWithNetwork(network);
 
     // Dispatch success immediately to prevent getting stuck in "switching" state
     store.dispatch(switchNetworkSuccess());

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -2629,6 +2629,19 @@ class MainController {
     );
 
     await this.saveWalletState('create-passkey-smart-account', true, true);
+    setTimeout(() => {
+      this.getLatestUpdateForCurrentAccount(true, true, false, true)
+        .catch((error) => {
+          console.error(
+            '[MainController] Failed to update passkey account after creation:',
+            error
+          );
+        })
+        .finally(() => {
+          store.dispatch(setIsPollingUpdate(false));
+          store.dispatch(setPostNetworkSwitchLoading(false));
+        });
+    }, 10);
     return newAccount;
   }
 

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -2568,6 +2568,19 @@ class MainController {
     metadata: IPasskeySmartAccountMetadata;
   }): Promise<any> {
     const { accounts } = store.getState().vault;
+    const normalizedAddress = params.address.toLowerCase();
+    const accountAlreadyExists = Object.values(accounts).some(
+      (accountsByType: Record<number, any>) =>
+        Object.values(accountsByType || {}).some(
+          (account: any) =>
+            account?.address?.toLowerCase?.() === normalizedAddress
+        )
+    );
+
+    if (accountAlreadyExists) {
+      throw new Error('Account already exists on your Wallet.');
+    }
+
     const passkeyAccounts =
       accounts[PaliKeyringAccountType.PasskeySmartAccount] || {};
     const existingIds = Object.values(passkeyAccounts)

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -3707,7 +3707,7 @@ class MainController {
         continue;
       }
 
-      controller.dapp.changeAccount(
+      controller.dapp.syncAccountSession(
         host,
         fallbackAccount.id,
         fallbackAccount.type

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -2816,7 +2816,6 @@ class MainController {
     callback: () => Promise<T>
   ): Promise<T> {
     const original = store.getState().vault.activeAccount;
-    let callbackSucceeded = false;
     store.dispatch(
       setActiveAccount({
         id: gasPayer.account.id,
@@ -2825,9 +2824,7 @@ class MainController {
     );
 
     try {
-      const result = await callback();
-      callbackSucceeded = true;
-      return result;
+      return await callback();
     } finally {
       store.dispatch(setActiveAccount(original));
       try {
@@ -2837,9 +2834,6 @@ class MainController {
           true
         );
       } catch (error) {
-        if (callbackSucceeded) {
-          throw error;
-        }
         console.error(
           '[MainController] Failed to persist restored active account after passkey gas payer operation:',
           error
@@ -2862,6 +2856,18 @@ class MainController {
     }
   }
 
+  private assertPasskeyAccountNetwork(metadata: IPasskeySmartAccountMetadata) {
+    const { activeNetwork } = store.getState().vault;
+    if (
+      activeNetwork.kind !== INetworkType.Ethereum ||
+      metadata.chainId !== activeNetwork.chainId
+    ) {
+      throw new Error('Passkey account is not available on the active network');
+    }
+
+    return getPasskeyFactoryAddress(activeNetwork.chainId);
+  }
+
   public async ensurePasskeySmartAccountDeployed(): Promise<boolean> {
     const { activeAccount, activeNetwork, accounts } = store.getState().vault;
     const account = accounts[activeAccount.type]?.[activeAccount.id] as any;
@@ -2869,6 +2875,9 @@ class MainController {
     if (!account?.isPasskeySmartAccount || !account.passkey) {
       throw new Error('Active account is not a passkey account');
     }
+
+    const metadata = account.passkey as IPasskeySmartAccountMetadata;
+    const factoryAddress = this.assertPasskeyAccountNetwork(metadata);
 
     const provider = this.ethereumTransaction?.web3Provider;
     if (!provider) {
@@ -2880,7 +2889,6 @@ class MainController {
       return false;
     }
 
-    const metadata = account.passkey as IPasskeySmartAccountMetadata;
     const gasPrice = (await this.ethereumTransaction.getRecommendedGasPrice(
       false
     )) as string;
@@ -2912,9 +2920,7 @@ class MainController {
           gasLimit: gasLimit.toNumber(),
           maxFeePerGas: 0,
           maxPriorityFeePerGas: 0,
-          to:
-            metadata.factoryAddress ||
-            getPasskeyFactoryAddress(activeNetwork.chainId),
+          to: metadata.factoryAddress || factoryAddress,
           value: 0,
         },
         true
@@ -3013,6 +3019,9 @@ class MainController {
       throw new Error('Active account is not a passkey account');
     }
 
+    const metadata = account.passkey as IPasskeySmartAccountMetadata;
+    this.assertPasskeyAccountNetwork(metadata);
+
     const emptySponsorProof = { v: 0, r: HashZero, s: HashZero };
     let sponsorProof = emptySponsorProof;
     const sponsorResult = await this.resolvePasskeySponsorResult(
@@ -3027,11 +3036,10 @@ class MainController {
           account.address,
           params.execution,
           params.proof,
-          account.passkey as IPasskeySmartAccountMetadata
+          metadata
         );
         return { hash: sponsorResult.txHash };
       } catch (error) {
-        const metadata = account.passkey as IPasskeySmartAccountMetadata;
         if (
           metadata.sponsor?.mode !== PasskeySponsorMode.GasOnly ||
           error instanceof PasskeyRelayedTransactionNotFoundError

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -2896,6 +2896,29 @@ class MainController {
     }
   }
 
+  private normalizePasskeyExecutionPayload(params: {
+    data?: string;
+    target: string;
+    value: string;
+  }) {
+    const target = getAddress(params.target);
+    const value = BigNumber.from(params.value);
+    if (value.lt(0)) {
+      throw new Error('Passkey execution value cannot be negative');
+    }
+
+    const data = params.data || '0x';
+    if (!isHexString(data)) {
+      throw new Error('Passkey execution data must be hex bytes');
+    }
+
+    return {
+      data,
+      target,
+      value: value.toString(),
+    };
+  }
+
   public async ensurePasskeySmartAccountDeployed(): Promise<boolean> {
     const { activeAccount, activeNetwork, accounts } = store.getState().vault;
     const account = accounts[activeAccount.type]?.[activeAccount.id] as any;
@@ -2991,7 +3014,8 @@ class MainController {
       value: string;
     };
   }> {
-    await this.assertPasskeyExecutionTargetAllowed(params.target);
+    const normalizedParams = this.normalizePasskeyExecutionPayload(params);
+    await this.assertPasskeyExecutionTargetAllowed(normalizedParams.target);
     await this.ensurePasskeySmartAccountDeployed();
 
     const { activeAccount, accounts } = store.getState().vault;
@@ -3003,9 +3027,9 @@ class MainController {
     );
     const nonce = await contract.nonce();
     const execution = {
-      target: params.target,
-      value: params.value,
-      data: params.data || '0x',
+      target: normalizedParams.target,
+      value: normalizedParams.value,
+      data: normalizedParams.data,
       nonce: nonce.toString(),
       deadline: Math.floor(Date.now() / 1000) + 15 * 60,
     };

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -39,6 +39,7 @@ import { clearNavigationState } from '../../../utils/navigationState';
 import { checkForUpdates } from '../handlers/handlePaliUpdates';
 import PaliLogo from 'assets/all_assets/favicon-32.png';
 import { ASSET_PRICE_API } from 'constants/index';
+import { updateDAppAccount } from 'state/dapp';
 import { setPrices } from 'state/price';
 import store from 'state/store';
 import { loadAndActivateSlip44Vault, saveMainState } from 'state/store';
@@ -3631,19 +3632,8 @@ class MainController {
       : isHexString(address);
   }
 
-  private ensureActiveAccountCompatibleWithNetwork(network: INetwork) {
-    const { accounts, activeAccount } = store.getState().vault;
-    const currentAccount = accounts[activeAccount.type]?.[activeAccount.id];
-
-    if (
-      this.isAccountCompatibleWithNetwork(
-        currentAccount,
-        activeAccount.type,
-        network
-      )
-    ) {
-      return;
-    }
+  private getFirstCompatibleAccountForNetwork(network: INetwork) {
+    const { accounts } = store.getState().vault;
 
     for (const [accountType, accountsOfType] of Object.entries(accounts)) {
       for (const account of Object.values(accountsOfType || {}) as any[]) {
@@ -3654,24 +3644,79 @@ class MainController {
             network
           )
         ) {
-          store.dispatch(
-            setActiveAccount({
-              id: account.id,
-              type: accountType as PaliKeyringAccountType,
-            })
-          );
-          return;
+          return {
+            account,
+            id: account.id,
+            type: accountType as PaliKeyringAccountType,
+          };
         }
       }
     }
 
-    console.warn(
-      '[MainController] No compatible account found after network switch',
-      {
-        network: network.chainId,
-        activeAccount,
+    return null;
+  }
+
+  private ensureActiveAccountCompatibleWithNetwork(network: INetwork) {
+    const { accounts, activeAccount } = store.getState().vault;
+    const currentAccount = accounts[activeAccount.type]?.[activeAccount.id];
+    let fallbackAccount = this.isAccountCompatibleWithNetwork(
+      currentAccount,
+      activeAccount.type,
+      network
+    )
+      ? {
+          account: currentAccount,
+          id: activeAccount.id,
+          type: activeAccount.type,
+        }
+      : null;
+
+    if (!fallbackAccount) {
+      fallbackAccount = this.getFirstCompatibleAccountForNetwork(network);
+      if (fallbackAccount) {
+        store.dispatch(
+          setActiveAccount({
+            id: fallbackAccount.id,
+            type: fallbackAccount.type,
+          })
+        );
       }
-    );
+    }
+
+    if (!fallbackAccount) {
+      console.warn(
+        '[MainController] No compatible account found after network switch',
+        {
+          network: network.chainId,
+          activeAccount,
+        }
+      );
+      return;
+    }
+
+    const { dapps } = store.getState().dapp;
+    const date = Date.now();
+    for (const [host, dapp] of Object.entries(dapps)) {
+      const dappAccount = accounts[dapp.accountType]?.[dapp.accountId];
+      if (
+        this.isAccountCompatibleWithNetwork(
+          dappAccount,
+          dapp.accountType,
+          network
+        )
+      ) {
+        continue;
+      }
+
+      store.dispatch(
+        updateDAppAccount({
+          host,
+          accountId: fallbackAccount.id,
+          accountType: fallbackAccount.type,
+          date,
+        })
+      );
+    }
   }
 
   public async setActiveNetwork(

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -3060,12 +3060,19 @@ class MainController {
     );
     if (sponsorResult.type === 'relayed') {
       try {
-        await this.verifyPasskeyRelayedTransaction(
+        const txResponse = await this.verifyPasskeyRelayedTransaction(
           sponsorResult.txHash,
           account.address,
           params.execution,
           params.proof,
           metadata
+        );
+        await this.sendAndSaveTransaction(
+          txResponse as IEvmTransactionResponse,
+          {
+            id: account.id,
+            type: PaliKeyringAccountType.PasskeySmartAccount,
+          }
         );
         return { hash: sponsorResult.txHash };
       } catch (error) {
@@ -3489,7 +3496,7 @@ class MainController {
           ).getActionHash(expectedExecution);
           verifyPasskeyRelayedSponsorProof(actionHash, decoded[2], metadata);
         }
-        return;
+        return tx;
       }
       await new Promise((resolve) => setTimeout(resolve, 2_000));
     }

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -3106,7 +3106,11 @@ class MainController {
           to: account.address,
           value: 0,
         },
-        true
+        true,
+        {
+          id: account.id,
+          type: PaliKeyringAccountType.PasskeySmartAccount,
+        }
       )
     );
   }
@@ -4507,7 +4511,8 @@ class MainController {
   }
 
   private async sendAndSaveTransaction(
-    tx: IEvmTransactionResponse | ISysTransaction | ITxid
+    tx: IEvmTransactionResponse | ISysTransaction | ITxid,
+    targetAccount?: { id: number; type: PaliKeyringAccountType }
   ) {
     const { isBitcoinBased, activeNetwork } = store.getState().vault;
 
@@ -4531,6 +4536,8 @@ class MainController {
 
       store.dispatch(
         setSingleTransactionToState({
+          accountId: targetAccount?.id,
+          accountType: targetAccount?.type,
           chainId: activeNetwork.chainId,
           networkType: TransactionsType.Syscoin,
           transaction: minimalTx as ISysTransaction,
@@ -4539,7 +4546,8 @@ class MainController {
 
       // Notify about new pending transaction
       const { accounts, activeAccount } = store.getState().vault;
-      const account = accounts[activeAccount.type]?.[activeAccount.id];
+      const accountInfo = targetAccount ?? activeAccount;
+      const account = accounts[accountInfo.type]?.[accountInfo.id];
       if (account) {
         notificationManager.notifyTransaction({
           transaction: minimalTx,
@@ -4598,6 +4606,8 @@ class MainController {
 
     store.dispatch(
       setSingleTransactionToState({
+        accountId: targetAccount?.id,
+        accountType: targetAccount?.type,
         chainId: activeNetwork.chainId,
         networkType: isBitcoinBased
           ? TransactionsType.Syscoin
@@ -4608,7 +4618,8 @@ class MainController {
 
     // Notify about new pending transaction
     const { accounts, activeAccount } = store.getState().vault;
-    const account = accounts[activeAccount.type]?.[activeAccount.id];
+    const accountInfo = targetAccount ?? activeAccount;
+    const account = accounts[accountInfo.type]?.[accountInfo.id];
     if (account) {
       notificationManager.notifyTransaction({
         transaction: txWithTimestamp,
@@ -4722,7 +4733,8 @@ class MainController {
    */
   public async sendAndSaveEthTransaction(
     params: any,
-    isLegacy?: boolean
+    isLegacy?: boolean,
+    targetAccount?: { id: number; type: PaliKeyringAccountType }
   ): Promise<IEvmTransactionResponse> {
     try {
       const controller = getController();
@@ -4751,7 +4763,7 @@ class MainController {
         );
 
       // Save the transaction (this will also clear navigation state)
-      await this.sendAndSaveTransaction(txResponse);
+      await this.sendAndSaveTransaction(txResponse, targetAccount);
 
       return txResponse;
     } catch (error) {

--- a/source/scripts/Background/controllers/message-handler/method-handlers.ts
+++ b/source/scripts/Background/controllers/message-handler/method-handlers.ts
@@ -454,6 +454,11 @@ export class WalletMethodHandler implements IMethodHandler {
         return { asset: params?.[0] || null };
       case 'addEthereumChain':
         return { chainConfig: params?.[0] };
+      case 'createPasskeyAccount':
+        return {
+          label: params?.[0]?.label,
+          sponsor: params?.[0]?.sponsor,
+        };
       case 'sendCalls':
         // Parse the sendCalls parameters
         return params?.[0] || {};

--- a/source/scripts/Background/controllers/message-handler/method-registry.ts
+++ b/source/scripts/Background/controllers/message-handler/method-registry.ts
@@ -155,6 +155,22 @@ export const METHOD_REGISTRY: MethodRegistry = {
     requiresActiveAccount: true,
   },
 
+  wallet_createPasskeyAccount: {
+    name: 'wallet_createPasskeyAccount',
+    handlerType: MethodHandlerType.Wallet,
+    requiresTabId: true,
+    requiresAuth: true,
+    requiresConnection: true,
+    allowHardwareWallet: false,
+    networkPreference: NetworkPreference.EVM,
+    networkEnforcement: NetworkEnforcement.Always,
+    hasPopup: true,
+    popupRoute: MethodRoute.CreatePasskeyAccount,
+    popupEventName: 'createPasskeyAccount',
+    requiresActiveAccount: true,
+    isBlocking: true,
+  },
+
   wallet_getTokens: {
     name: 'wallet_getTokens',
     handlerType: MethodHandlerType.Wallet,

--- a/source/scripts/Background/controllers/message-handler/request-pipeline.ts
+++ b/source/scripts/Background/controllers/message-handler/request-pipeline.ts
@@ -943,11 +943,17 @@ export const accountSwitchingMiddleware: Middleware = async (context, next) => {
     '[Pipeline] Blocking method requires switching to connected account...'
   );
 
-  // Need to switch to the connected account
-  const dappAccountType = account.isImported ? 'Imported' : 'HDAccount';
+  const dappConnection = dapp.get(originalRequest.host);
+  if (!dappConnection) {
+    throw cleanErrorStack(
+      ethErrors.provider.unauthorized(
+        'Connected account metadata is unavailable for this operation'
+      )
+    );
+  }
 
   try {
-    await promptAccountSwitch(context, account, dappAccountType);
+    await promptAccountSwitch(context, account, dappConnection.accountType);
   } catch (error) {
     throw cleanErrorStack(
       ethErrors.provider.unauthorized(

--- a/source/scripts/Background/controllers/message-handler/types.ts
+++ b/source/scripts/Background/controllers/message-handler/types.ts
@@ -34,6 +34,7 @@ export enum MethodRoute {
   ChangeAccount = 'change-account',
   ChangeActiveConnectedAccount = 'change-active-connected-account',
   Connect = 'connect-wallet',
+  CreatePasskeyAccount = 'create-passkey-account',
   DecryptKey = 'tx/decrypt',
   EncryptKey = 'tx/encryptKey',
   EthSign = 'tx/ethSign',

--- a/source/state/vault/index.ts
+++ b/source/state/vault/index.ts
@@ -37,6 +37,7 @@ const initialState: IVaultState = {
     [KeyringAccountType.Imported]: {},
     [KeyringAccountType.Trezor]: {},
     [KeyringAccountType.Ledger]: {},
+    [KeyringAccountType.PasskeySmartAccount]: {},
   },
   accountAssets: {
     [KeyringAccountType.HDAccount]: {
@@ -48,6 +49,7 @@ const initialState: IVaultState = {
     [KeyringAccountType.Imported]: {},
     [KeyringAccountType.Trezor]: {},
     [KeyringAccountType.Ledger]: {},
+    [KeyringAccountType.PasskeySmartAccount]: {},
   },
   accountTransactions: {
     [KeyringAccountType.HDAccount]: {
@@ -59,6 +61,7 @@ const initialState: IVaultState = {
     [KeyringAccountType.Imported]: {},
     [KeyringAccountType.Trezor]: {},
     [KeyringAccountType.Ledger]: {},
+    [KeyringAccountType.PasskeySmartAccount]: {},
   },
   activeAccount: {
     id: 0,
@@ -75,6 +78,18 @@ const initialState: IVaultState = {
   },
 };
 
+const ensureAccountTypeBuckets = (state: IVaultState) => {
+  Object.values(KeyringAccountType).forEach((accountType) => {
+    if (!state.accounts[accountType]) state.accounts[accountType] = {};
+    if (!state.accountAssets[accountType])
+      state.accountAssets[accountType] = {};
+    if (!state.accountTransactions[accountType])
+      state.accountTransactions[accountType] = {};
+  });
+
+  return state;
+};
+
 const VaultState = createSlice({
   name: 'vault',
   initialState,
@@ -82,7 +97,7 @@ const VaultState = createSlice({
     rehydrate(_state: IVaultState, action: PayloadAction<IVaultState>) {
       // Complete replacement - ensures loaded vault state is exactly what was saved
       // This matches the behavior of initializeCleanVaultForSlip44 for consistency
-      return action.payload;
+      return ensureAccountTypeBuckets(action.payload);
     },
     setAccounts(
       state: IVaultState,
@@ -296,18 +311,21 @@ const VaultState = createSlice({
           [KeyringAccountType.Imported]: {},
           [KeyringAccountType.Trezor]: {},
           [KeyringAccountType.Ledger]: {},
+          [KeyringAccountType.PasskeySmartAccount]: {},
         },
         accountAssets: {
           [KeyringAccountType.HDAccount]: {}, // 🔥 EMPTY - no default assets!
           [KeyringAccountType.Imported]: {},
           [KeyringAccountType.Trezor]: {},
           [KeyringAccountType.Ledger]: {},
+          [KeyringAccountType.PasskeySmartAccount]: {},
         },
         accountTransactions: {
           [KeyringAccountType.HDAccount]: {}, // 🔥 EMPTY - no default transactions!
           [KeyringAccountType.Imported]: {},
           [KeyringAccountType.Trezor]: {},
           [KeyringAccountType.Ledger]: {},
+          [KeyringAccountType.PasskeySmartAccount]: {},
         },
         activeAccount: {
           id: 0, // Will be updated when first account is created
@@ -340,6 +358,7 @@ const VaultState = createSlice({
         [KeyringAccountType.Imported]: {},
         [KeyringAccountType.Trezor]: {},
         [KeyringAccountType.Ledger]: {},
+        [KeyringAccountType.PasskeySmartAccount]: {},
       };
       state.accountAssets = {
         [KeyringAccountType.HDAccount]: {
@@ -351,6 +370,7 @@ const VaultState = createSlice({
         [KeyringAccountType.Imported]: {},
         [KeyringAccountType.Trezor]: {},
         [KeyringAccountType.Ledger]: {},
+        [KeyringAccountType.PasskeySmartAccount]: {},
       };
       state.accountTransactions = {
         [KeyringAccountType.HDAccount]: {
@@ -362,6 +382,7 @@ const VaultState = createSlice({
         [KeyringAccountType.Imported]: {},
         [KeyringAccountType.Trezor]: {},
         [KeyringAccountType.Ledger]: {},
+        [KeyringAccountType.PasskeySmartAccount]: {},
       };
       state.activeAccount = { id: 0, type: KeyringAccountType.HDAccount };
     },

--- a/source/state/vault/index.ts
+++ b/source/state/vault/index.ts
@@ -443,27 +443,32 @@ const VaultState = createSlice({
     setSingleTransactionToState: (
       state: IVaultState,
       action: PayloadAction<{
+        accountId?: number;
+        accountType?: KeyringAccountType;
         chainId: number;
         networkType: TransactionsType;
         transaction: IEvmTransaction | ISysTransaction;
       }>
     ) => {
       const { activeAccount } = state;
-      const { networkType, chainId, transaction } = action.payload;
+      const { accountId, accountType, networkType, chainId, transaction } =
+        action.payload;
+      const targetAccountId = accountId ?? activeAccount.id;
+      const targetAccountType = accountType ?? activeAccount.type;
 
       // Ensure accountTransactions exists for this account
-      if (!state.accountTransactions[activeAccount.type]) {
-        state.accountTransactions[activeAccount.type] = {};
+      if (!state.accountTransactions[targetAccountType]) {
+        state.accountTransactions[targetAccountType] = {};
       }
-      if (!state.accountTransactions[activeAccount.type][activeAccount.id]) {
-        state.accountTransactions[activeAccount.type][activeAccount.id] = {
+      if (!state.accountTransactions[targetAccountType][targetAccountId]) {
+        state.accountTransactions[targetAccountType][targetAccountId] = {
           ethereum: {},
           syscoin: {},
         };
       }
 
       const currentAccountTransactions =
-        state.accountTransactions[activeAccount.type][activeAccount.id];
+        state.accountTransactions[targetAccountType][targetAccountId];
 
       // Check if the networkType exists in the current account's transactions
       if (!currentAccountTransactions[networkType]) {

--- a/source/state/vault/types.ts
+++ b/source/state/vault/types.ts
@@ -125,5 +125,5 @@ export enum TransactionsType {
 export type IOmmitedAccount = Omit<IKeyringAccountState, 'xprv'>;
 
 export type IOmittedVault = Omit<IVaultState, 'accounts'> & {
-  accounts: { [id: number]: IOmmitedAccount };
+  accounts: { [key in KeyringAccountType]: { [id: number]: IOmmitedAccount } };
 };

--- a/source/types/controllers.ts
+++ b/source/types/controllers.ts
@@ -75,11 +75,19 @@ export interface IDAppController {
    * Sets whether a DApp has an open popup
    */
   setHasWindow: (host: string, hasWindow: boolean) => void;
-
   /**
    * Setup communication
    */
   setup: (sender: chrome.runtime.MessageSender) => void;
+
+  /**
+   * Synchronizes persisted and in-memory dApp account state without emitting provider events.
+   */
+  syncAccountSession: (
+    host: string,
+    accountId: number,
+    accountType: KeyringAccountType
+  ) => void;
 }
 
 export interface IEventData {

--- a/source/types/controllers.ts
+++ b/source/types/controllers.ts
@@ -15,7 +15,7 @@ export interface IDAppController {
     host: string,
     accountId: number,
     accountType: KeyringAccountType
-  ) => void;
+  ) => Promise<void>;
   /**
    * Completes a connection with a DApp
    * @emits connect

--- a/source/types/network.ts
+++ b/source/types/network.ts
@@ -28,9 +28,48 @@ export enum KeyringAccountType {
   HDAccount = 'HDAccount',
   Imported = 'Imported',
   Ledger = 'Ledger',
+  PasskeySmartAccount = 'PasskeySmartAccount',
   Trezor = 'Trezor',
 }
 /* eslint-enable no-shadow */
+
+/* eslint-disable no-shadow */
+export enum PasskeySponsorMode {
+  Disabled = 'disabled',
+  GasOnly = 'gasOnly',
+  Required = 'required',
+}
+/* eslint-enable no-shadow */
+
+export interface IPasskeySmartAccountMetadata {
+  chainId: number;
+  contractVersion: string;
+  credentialId: string;
+  credentialIdHash: string;
+  deploymentGasPayer?: {
+    address: string;
+    id: number;
+    type: KeyringAccountType;
+  };
+  deploymentSalt: string;
+  factoryAddress?: string;
+  isDeployed: boolean;
+  passkeyName: string;
+  publicKey: {
+    originHash: string;
+    originLength: number;
+    rpIdHash: string;
+    x: string;
+    y: string;
+  };
+  sponsor?: {
+    mode: PasskeySponsorMode;
+    policyText?: string;
+    signer?: string;
+    url?: string;
+    urlHash?: string;
+  };
+}
 
 export type IKeyringBalances = {
   [INetworkType.Syscoin]: number;
@@ -46,8 +85,10 @@ export interface IKeyringAccountState {
   id: number;
   isImported: boolean;
   isLedgerWallet: boolean;
+  isPasskeySmartAccount?: boolean;
   isTrezorWallet: boolean;
   label: string;
+  passkey?: IPasskeySmartAccountMetadata;
   xprv: string;
   xpub: string;
 }
@@ -62,6 +103,7 @@ export const initialActiveHdAccountState: IKeyringAccountState = {
   isTrezorWallet: false,
   isLedgerWallet: false,
   label: 'Account 1',
+  isPasskeySmartAccount: false,
   evmTxCountByChainId: {},
   xprv: '',
   xpub: '',

--- a/source/utils/account.ts
+++ b/source/utils/account.ts
@@ -11,13 +11,18 @@ export const removeXprv = (account: IKeyringAccountState): IOmmitedAccount => {
 export const removeSensitiveDataFromVault = (
   vault: IVaultState
 ): IOmittedVault => {
-  const accounts = {};
+  const accounts = {
+    [KeyringAccountType.HDAccount]: {},
+    [KeyringAccountType.Imported]: {},
+    [KeyringAccountType.Trezor]: {},
+    [KeyringAccountType.Ledger]: {},
+    [KeyringAccountType.PasskeySmartAccount]: {},
+  };
 
-  for (const account of Object.values(vault.accounts.HDAccount)) {
-    accounts[KeyringAccountType.HDAccount][account.id] = removeXprv(account);
-  }
-  for (const account of Object.values(vault.accounts.Imported)) {
-    accounts[KeyringAccountType.Imported][account.id] = removeXprv(account);
+  for (const accountType of Object.values(KeyringAccountType)) {
+    for (const account of Object.values(vault.accounts[accountType] || {})) {
+      accounts[accountType][account.id] = removeXprv(account);
+    }
   }
 
   return {

--- a/source/utils/index.ts
+++ b/source/utils/index.ts
@@ -20,6 +20,7 @@ export * from './storageAPI';
 export * from './strings';
 export * from './tokens';
 export * from './navigationState';
+export * from './passkey';
 
 /**
  * Safely extracts an error message from various error types

--- a/source/utils/passkey/base64url.ts
+++ b/source/utils/passkey/base64url.ts
@@ -1,0 +1,45 @@
+export const bytesToBase64Url = (bytes: Uint8Array): string => {
+  let binary = '';
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+
+  return btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/u, '');
+};
+
+export const base64UrlToBytes = (value: string): Uint8Array => {
+  const padded = value
+    .replace(/-/g, '+')
+    .replace(/_/g, '/')
+    .padEnd(Math.ceil(value.length / 4) * 4, '=');
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+
+  return bytes;
+};
+
+export const bytesToHex = (bytes: Uint8Array): string =>
+  `0x${Array.from(bytes)
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('')}`;
+
+export const hexToBytes = (value: string): Uint8Array => {
+  const clean = value.startsWith('0x') ? value.slice(2) : value;
+  if (!/^[0-9a-fA-F]*$/u.test(clean) || clean.length % 2 !== 0) {
+    throw new Error('Invalid hex string');
+  }
+
+  const bytes = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < bytes.length; i += 1) {
+    bytes[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+  }
+
+  return bytes;
+};

--- a/source/utils/passkey/cbor.ts
+++ b/source/utils/passkey/cbor.ts
@@ -1,0 +1,111 @@
+type CborMap = Map<string | number, CborValue>;
+type CborValue = CborMap | Uint8Array | string | number | boolean | null;
+
+type DecodeResult = {
+  offset: number;
+  value: CborValue;
+};
+
+const readLength = (data: Uint8Array, offset: number, additional: number) => {
+  if (additional < 24) return { length: additional, offset };
+  if (additional === 24) return { length: data[offset], offset: offset + 1 };
+  if (additional === 25)
+    return {
+      length: (data[offset] << 8) | data[offset + 1],
+      offset: offset + 2,
+    };
+  if (additional === 26) {
+    return {
+      length:
+        (data[offset] * 0x1000000 +
+          ((data[offset + 1] << 16) |
+            (data[offset + 2] << 8) |
+            data[offset + 3])) >>>
+        0,
+      offset: offset + 4,
+    };
+  }
+
+  throw new Error('Unsupported CBOR length');
+};
+
+export const decodeCbor = (data: Uint8Array, offset = 0): DecodeResult => {
+  const first = data[offset];
+  const major = first >> 5;
+  const additional = first & 0x1f;
+  let cursor = offset + 1;
+
+  if (major === 0) {
+    const length = readLength(data, cursor, additional);
+    return { value: length.length, offset: length.offset };
+  }
+
+  if (major === 1) {
+    const length = readLength(data, cursor, additional);
+    return { value: -1 - length.length, offset: length.offset };
+  }
+
+  if (major === 2) {
+    const length = readLength(data, cursor, additional);
+    cursor = length.offset;
+    return {
+      value: data.slice(cursor, cursor + length.length),
+      offset: cursor + length.length,
+    };
+  }
+
+  if (major === 3) {
+    const length = readLength(data, cursor, additional);
+    cursor = length.offset;
+    const bytes = data.slice(cursor, cursor + length.length);
+    return {
+      value: new TextDecoder().decode(bytes),
+      offset: cursor + length.length,
+    };
+  }
+
+  if (major === 5) {
+    const length = readLength(data, cursor, additional);
+    cursor = length.offset;
+    const map = new Map<string | number, CborValue>();
+
+    for (let i = 0; i < length.length; i += 1) {
+      const key = decodeCbor(data, cursor);
+      cursor = key.offset;
+      const value = decodeCbor(data, cursor);
+      cursor = value.offset;
+
+      if (typeof key.value !== 'string' && typeof key.value !== 'number') {
+        throw new Error('Unsupported CBOR map key');
+      }
+
+      map.set(key.value, value.value);
+    }
+
+    return { value: map, offset: cursor };
+  }
+
+  if (major === 7) {
+    if (additional === 20) return { value: false, offset: cursor };
+    if (additional === 21) return { value: true, offset: cursor };
+    if (additional === 22) return { value: null, offset: cursor };
+  }
+
+  throw new Error('Unsupported CBOR value');
+};
+
+export const asCborMap = (value: CborValue): CborMap => {
+  if (!(value instanceof Map)) {
+    throw new Error('Expected CBOR map');
+  }
+
+  return value;
+};
+
+export const asCborBytes = (value: CborValue): Uint8Array => {
+  if (!(value instanceof Uint8Array)) {
+    throw new Error('Expected CBOR byte string');
+  }
+
+  return value;
+};

--- a/source/utils/passkey/contracts.ts
+++ b/source/utils/passkey/contracts.ts
@@ -1,0 +1,61 @@
+import { Interface } from '@ethersproject/abi';
+import { Contract } from '@ethersproject/contracts';
+
+import { CHAIN_IDS } from 'utils/constants';
+
+import type { Provider } from '@ethersproject/providers';
+
+/* eslint-disable no-shadow */
+export enum PasskeyContractSponsorMode {
+  None = 0,
+  GasOnly = 1,
+  Required = 2,
+}
+/* eslint-enable no-shadow */
+
+export const PASSKEY_SMART_ACCOUNT_VERSION = 'PALI_PASSKEY_SMART_ACCOUNT_V1';
+
+export const PASSKEY_FACTORY_ADDRESSES: Partial<Record<number, string>> = {
+  [CHAIN_IDS.ZKSYS_TANENBAUM_TESTNET]:
+    '0xBFF8d58E8fab137C7215f9Be20ab273cDBC6b87d',
+};
+
+export const PASSKEY_FACTORY_ABI = [
+  'function createAccount(bytes32 passkeyX, bytes32 passkeyY, bytes32 credentialIdHash, bytes32 rpIdHash, bytes32 originHash, uint256 originLength, uint8 sponsorMode, address sponsorSigner, bytes32 sponsorUrlHash, bytes32 salt) payable returns (address account)',
+  'function getAccountAddress(address creator, bytes32 passkeyX, bytes32 passkeyY, bytes32 credentialIdHash, bytes32 rpIdHash, bytes32 originHash, uint256 originLength, uint8 sponsorMode, address sponsorSigner, bytes32 sponsorUrlHash, bytes32 salt) view returns (address)',
+] as const;
+
+export const PASSKEY_SMART_ACCOUNT_ABI = [
+  'function execute((address target,uint256 value,bytes data,uint256 nonce,uint256 deadline) execution,(bytes authenticatorData,bytes clientDataJSON,uint256 typeOffset,uint256 challengeOffset,uint256 originOffset,bytes32 r,bytes32 s) proof,(uint8 v,bytes32 r,bytes32 s) sponsorProof) payable returns (bytes returndata)',
+  'function getActionHash((address target,uint256 value,bytes data,uint256 nonce,uint256 deadline) execution) view returns (bytes32)',
+  'function isValidSignature(bytes32 hash, bytes signature) view returns (bytes4)',
+  'function nonce() view returns (uint256)',
+  'function sponsorMode() view returns (uint8)',
+  'function sponsorSigner() view returns (address)',
+] as const;
+
+export const getPasskeyFactoryAddress = (chainId: number): string => {
+  const address = PASSKEY_FACTORY_ADDRESSES[chainId];
+  if (!address) {
+    throw new Error(
+      'Passkey account factory is not configured for this network'
+    );
+  }
+
+  return address;
+};
+
+export const getPasskeyFactory = (
+  chainId: number,
+  provider: Provider
+): Contract =>
+  new Contract(
+    getPasskeyFactoryAddress(chainId),
+    PASSKEY_FACTORY_ABI,
+    provider
+  );
+
+export const passkeyFactoryInterface = new Interface(PASSKEY_FACTORY_ABI);
+export const passkeySmartAccountInterface = new Interface(
+  PASSKEY_SMART_ACCOUNT_ABI
+);

--- a/source/utils/passkey/index.ts
+++ b/source/utils/passkey/index.ts
@@ -1,0 +1,4 @@
+export * from './base64url';
+export * from './contracts';
+export * from './validation';
+export * from './webauthn';

--- a/source/utils/passkey/validation.spec.ts
+++ b/source/utils/passkey/validation.spec.ts
@@ -1,0 +1,409 @@
+jest.unmock('@ethersproject/bytes');
+jest.unmock('@ethersproject/hash');
+jest.unmock('@ethersproject/strings');
+jest.unmock('@ethersproject/transactions');
+jest.unmock('@ethersproject/wallet');
+
+import { arrayify } from '@ethersproject/bytes';
+import { Wallet } from '@ethersproject/wallet';
+
+import {
+  IPasskeySmartAccountMetadata,
+  KeyringAccountType,
+  PasskeySponsorMode,
+} from 'types/network';
+
+import {
+  assertPasskeyRelayPayloadMatches,
+  getPasskeyGasPayerCandidates,
+  normalizePasskeySponsorProof,
+  PasskeyRelayedTransactionNotFoundError,
+  selectPasskeyDeploymentGasPayer,
+  selectFundedPasskeyGasPayerCandidate,
+  selectPasskeyGasPayerCandidate,
+  validatePasskeyClientDataJSON,
+  verifyPasskeyRelayedSponsorProof,
+  verifyPasskeySponsorProof,
+} from './validation';
+
+const baseMetadata = (
+  sponsor: IPasskeySmartAccountMetadata['sponsor']
+): IPasskeySmartAccountMetadata => ({
+  chainId: 57057,
+  contractVersion: '1',
+  credentialId: 'credential',
+  credentialIdHash:
+    '0x0000000000000000000000000000000000000000000000000000000000000001',
+  deploymentSalt:
+    '0x0000000000000000000000000000000000000000000000000000000000000002',
+  isDeployed: false,
+  passkeyName: 'Test passkey',
+  publicKey: {
+    originHash:
+      '0x0000000000000000000000000000000000000000000000000000000000000006',
+    originLength: 23,
+    rpIdHash:
+      '0x0000000000000000000000000000000000000000000000000000000000000003',
+    x: '0x0000000000000000000000000000000000000000000000000000000000000004',
+    y: '0x0000000000000000000000000000000000000000000000000000000000000005',
+  },
+  sponsor,
+});
+
+describe('passkey validation utilities', () => {
+  it('verifies required sponsor proofs against the configured signer', async () => {
+    const sponsor = Wallet.createRandom();
+    const actionHash =
+      '0x1111111111111111111111111111111111111111111111111111111111111111';
+    const signature = await sponsor.signMessage(arrayify(actionHash));
+    const proof = normalizePasskeySponsorProof(signature);
+
+    expect(proof).not.toBeNull();
+    expect(() =>
+      verifyPasskeySponsorProof(
+        actionHash,
+        proof!,
+        baseMetadata({
+          mode: PasskeySponsorMode.Required,
+          signer: sponsor.address,
+        })
+      )
+    ).not.toThrow();
+  });
+
+  it('rejects required sponsor proofs from a different signer', async () => {
+    const sponsor = Wallet.createRandom();
+    const attacker = Wallet.createRandom();
+    const actionHash =
+      '0x2222222222222222222222222222222222222222222222222222222222222222';
+    const signature = await attacker.signMessage(arrayify(actionHash));
+    const proof = normalizePasskeySponsorProof(signature);
+
+    expect(() =>
+      verifyPasskeySponsorProof(
+        actionHash,
+        proof!,
+        baseMetadata({
+          mode: PasskeySponsorMode.Required,
+          signer: sponsor.address,
+        })
+      )
+    ).toThrow('Passkey sponsor signature does not match configured signer');
+  });
+
+  it('verifies relayed required sponsor proofs before accepting sponsor tx hashes', async () => {
+    const sponsor = Wallet.createRandom();
+    const actionHash =
+      '0x7777777777777777777777777777777777777777777777777777777777777777';
+    const signature = await sponsor.signMessage(arrayify(actionHash));
+    const sponsorProof = normalizePasskeySponsorProof(signature);
+
+    expect(() =>
+      verifyPasskeyRelayedSponsorProof(
+        actionHash,
+        sponsorProof,
+        baseMetadata({
+          mode: PasskeySponsorMode.Required,
+          signer: sponsor.address,
+        })
+      )
+    ).not.toThrow();
+  });
+
+  it('rejects relayed required sponsor transactions without a sponsor proof', () => {
+    const sponsor = Wallet.createRandom();
+    const actionHash =
+      '0x8888888888888888888888888888888888888888888888888888888888888888';
+
+    expect(() =>
+      verifyPasskeyRelayedSponsorProof(
+        actionHash,
+        null,
+        baseMetadata({
+          mode: PasskeySponsorMode.Required,
+          signer: sponsor.address,
+        })
+      )
+    ).toThrow('without sponsor proof');
+  });
+
+  it('rejects relayed required sponsor transactions signed by the wrong sponsor', async () => {
+    const sponsor = Wallet.createRandom();
+    const attacker = Wallet.createRandom();
+    const actionHash =
+      '0x9999999999999999999999999999999999999999999999999999999999999999';
+    const sponsorProof = normalizePasskeySponsorProof(
+      await attacker.signMessage(arrayify(actionHash))
+    );
+
+    expect(() =>
+      verifyPasskeyRelayedSponsorProof(
+        actionHash,
+        sponsorProof,
+        baseMetadata({
+          mode: PasskeySponsorMode.Required,
+          signer: sponsor.address,
+        })
+      )
+    ).toThrow('does not match configured signer');
+  });
+
+  it('requires the stored deployment gas payer when metadata has one', () => {
+    const account = {
+      address: '0x1111111111111111111111111111111111111111',
+      id: 0,
+    };
+    const metadata = {
+      ...baseMetadata({ mode: PasskeySponsorMode.Disabled }),
+      deploymentGasPayer: {
+        address: account.address,
+        id: 0,
+        type: KeyringAccountType.HDAccount,
+      },
+    };
+    const fallback = jest.fn();
+
+    expect(
+      selectPasskeyDeploymentGasPayer(
+        { [KeyringAccountType.HDAccount]: { 0: account } },
+        metadata,
+        fallback
+      )
+    ).toEqual({ account, accountType: KeyringAccountType.HDAccount });
+    expect(fallback).not.toHaveBeenCalled();
+  });
+
+  it('does not silently fall back if the stored deployment gas payer is missing', () => {
+    const metadata = {
+      ...baseMetadata({ mode: PasskeySponsorMode.Disabled }),
+      deploymentGasPayer: {
+        address: '0x1111111111111111111111111111111111111111',
+        id: 0,
+        type: KeyringAccountType.HDAccount,
+      },
+    };
+
+    expect(() =>
+      selectPasskeyDeploymentGasPayer(
+        { [KeyringAccountType.HDAccount]: {} },
+        metadata,
+        jest.fn()
+      )
+    ).toThrow('Passkey deployment gas payer is no longer available');
+  });
+
+  it('orders gas payer candidates by active software account, then HD, then imported', () => {
+    const hd0 = {
+      address: '0x1111111111111111111111111111111111111111',
+      id: 0,
+    };
+    const hd1 = {
+      address: '0x2222222222222222222222222222222222222222',
+      id: 1,
+    };
+    const imported0 = {
+      address: '0x3333333333333333333333333333333333333333',
+      id: 0,
+    };
+
+    expect(
+      getPasskeyGasPayerCandidates(
+        {
+          [KeyringAccountType.HDAccount]: { 0: hd0, 1: hd1 },
+          [KeyringAccountType.Imported]: { 0: imported0 },
+        },
+        { id: 1, type: KeyringAccountType.HDAccount }
+      )
+    ).toEqual([
+      { account: hd1, accountType: KeyringAccountType.HDAccount },
+      { account: hd0, accountType: KeyringAccountType.HDAccount },
+      { account: imported0, accountType: KeyringAccountType.Imported },
+    ]);
+  });
+
+  it('ignores active passkey accounts when selecting software gas payer candidates', () => {
+    const hd0 = {
+      address: '0x1111111111111111111111111111111111111111',
+      id: 0,
+    };
+    const passkey = {
+      address: '0x4444444444444444444444444444444444444444',
+      id: 0,
+    };
+
+    expect(
+      getPasskeyGasPayerCandidates(
+        {
+          [KeyringAccountType.HDAccount]: { 0: hd0 },
+          [KeyringAccountType.PasskeySmartAccount]: { 0: passkey },
+        },
+        { id: 0, type: KeyringAccountType.PasskeySmartAccount }
+      )
+    ).toEqual([{ account: hd0, accountType: KeyringAccountType.HDAccount }]);
+  });
+
+  it('selects an unfunded deterministic gas payer candidate for address prediction', () => {
+    const hd0 = {
+      address: '0x1111111111111111111111111111111111111111',
+      id: 0,
+    };
+
+    expect(
+      selectPasskeyGasPayerCandidate({
+        [KeyringAccountType.HDAccount]: { 0: hd0 },
+      })
+    ).toEqual({ account: hd0, accountType: KeyringAccountType.HDAccount });
+  });
+
+  it('throws if no software gas payer candidate exists for address prediction', () => {
+    expect(() =>
+      selectPasskeyGasPayerCandidate({
+        [KeyringAccountType.PasskeySmartAccount]: {
+          0: {
+            address: '0x4444444444444444444444444444444444444444',
+            id: 0,
+          },
+        },
+      })
+    ).toThrow('No software account is available');
+  });
+
+  it('selects the first gas payer candidate that satisfies the required balance predicate', async () => {
+    const hd0 = {
+      address: '0x1111111111111111111111111111111111111111',
+      id: 0,
+    };
+    const imported0 = {
+      address: '0x3333333333333333333333333333333333333333',
+      id: 0,
+    };
+    const hasRequiredBalance = jest
+      .fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+
+    await expect(
+      selectFundedPasskeyGasPayerCandidate(
+        {
+          [KeyringAccountType.HDAccount]: { 0: hd0 },
+          [KeyringAccountType.Imported]: { 0: imported0 },
+        },
+        undefined,
+        hasRequiredBalance
+      )
+    ).resolves.toEqual({
+      account: imported0,
+      accountType: KeyringAccountType.Imported,
+    });
+    expect(hasRequiredBalance).toHaveBeenCalledWith(hd0.address);
+    expect(hasRequiredBalance).toHaveBeenCalledWith(imported0.address);
+  });
+
+  it('fails funded gas payer selection when no candidate satisfies required balance', async () => {
+    await expect(
+      selectFundedPasskeyGasPayerCandidate(
+        {
+          [KeyringAccountType.HDAccount]: {
+            0: {
+              address: '0x1111111111111111111111111111111111111111',
+              id: 0,
+            },
+          },
+        },
+        undefined,
+        jest.fn().mockResolvedValue(false)
+      )
+    ).rejects.toThrow('No funded software account is available');
+  });
+
+  it('uses a typed error for relayed transaction hashes that are not observed', () => {
+    const error = new PasskeyRelayedTransactionNotFoundError();
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe('PasskeyRelayedTransactionNotFoundError');
+    expect(error.message).toBe(
+      'Sponsor relayed transaction was not found on-chain'
+    );
+  });
+
+  it('rejects relayed payloads that do not match the prepared execution', () => {
+    const execution = {
+      data: '0x1234',
+      deadline: 123,
+      nonce: '7',
+      target: '0x1111111111111111111111111111111111111111',
+      value: '42',
+    };
+    const proof = {
+      authenticatorData: '0xabcd',
+      challengeOffset: 12,
+      clientDataJSON: '0xef',
+      originOffset: 48,
+      r: '0x01',
+      s: '0x02',
+      typeOffset: 9,
+    };
+
+    expect(() =>
+      assertPasskeyRelayPayloadMatches(execution, proof, execution, proof)
+    ).not.toThrow();
+    expect(() =>
+      assertPasskeyRelayPayloadMatches(
+        { ...execution, target: '0x2222222222222222222222222222222222222222' },
+        proof,
+        execution,
+        proof
+      )
+    ).toThrow('Sponsor relayed a different passkey execution');
+  });
+
+  it('validates WebAuthn clientDataJSON type, challenge, origin, and crossOrigin', () => {
+    const challenge = 'expectedChallenge';
+    const origin = 'chrome-extension://pali';
+    const encodeClientData = (overrides: Record<string, unknown> = {}) =>
+      new TextEncoder().encode(
+        JSON.stringify({
+          challenge,
+          origin,
+          type: 'webauthn.get',
+          ...overrides,
+        })
+      );
+
+    const offsets = validatePasskeyClientDataJSON(
+      encodeClientData(),
+      challenge,
+      origin
+    );
+    expect(offsets.challengeOffset).toBeGreaterThanOrEqual(0);
+    expect(offsets.originOffset).toBeGreaterThanOrEqual(0);
+    expect(offsets.typeOffset).toBeGreaterThanOrEqual(0);
+    expect(() =>
+      validatePasskeyClientDataJSON(
+        encodeClientData({ challenge: 'bad' }),
+        challenge,
+        origin
+      )
+    ).toThrow('unexpected challenge');
+    expect(() =>
+      validatePasskeyClientDataJSON(
+        encodeClientData({ crossOrigin: true }),
+        challenge,
+        origin
+      )
+    ).toThrow('Cross-origin WebAuthn assertions are not supported');
+    expect(() =>
+      validatePasskeyClientDataJSON(
+        encodeClientData({ origin: 'https://evil.example' }),
+        challenge,
+        origin
+      )
+    ).toThrow('unexpected origin');
+    expect(() =>
+      validatePasskeyClientDataJSON(
+        encodeClientData({ type: 'webauthn.create' }),
+        challenge,
+        origin
+      )
+    ).toThrow('unexpected type');
+  });
+});

--- a/source/utils/passkey/validation.spec.ts
+++ b/source/utils/passkey/validation.spec.ts
@@ -377,6 +377,29 @@ describe('passkey validation utilities', () => {
     expect(offsets.challengeOffset).toBeGreaterThanOrEqual(0);
     expect(offsets.originOffset).toBeGreaterThanOrEqual(0);
     expect(offsets.typeOffset).toBeGreaterThanOrEqual(0);
+
+    const spacedClientData = new TextEncoder().encode(
+      `{
+        "challenge" : "${challenge}",
+        "origin" : "${origin}",
+        "type" : "webauthn.get"
+      }`
+    );
+    const spacedOffsets = validatePasskeyClientDataJSON(
+      spacedClientData,
+      challenge,
+      origin
+    );
+    expect(
+      spacedOffsets.clientDataText.slice(spacedOffsets.challengeOffset)
+    ).toContain(challenge);
+    expect(
+      spacedOffsets.clientDataText.slice(spacedOffsets.originOffset)
+    ).toContain(origin);
+    expect(
+      spacedOffsets.clientDataText.slice(spacedOffsets.typeOffset)
+    ).toContain('webauthn.get');
+
     expect(() =>
       validatePasskeyClientDataJSON(
         encodeClientData({ challenge: 'bad' }),

--- a/source/utils/passkey/validation.spec.ts
+++ b/source/utils/passkey/validation.spec.ts
@@ -242,6 +242,37 @@ describe('passkey validation utilities', () => {
     ).toEqual([{ account: hd0, accountType: KeyringAccountType.HDAccount }]);
   });
 
+  it('filters non-EVM software accounts from gas payer candidates', () => {
+    const hd0 = {
+      address: '0x1111111111111111111111111111111111111111',
+      id: 0,
+    };
+    const importedUtxo = {
+      address: 'sys1q2d4h3j5k6l7m8n9p0q2d4h3j5k6l7m8n9p0q',
+      id: 0,
+    };
+    const importedEvm = {
+      address: '0x3333333333333333333333333333333333333333',
+      id: 1,
+    };
+
+    expect(
+      getPasskeyGasPayerCandidates(
+        {
+          [KeyringAccountType.HDAccount]: { 0: hd0 },
+          [KeyringAccountType.Imported]: {
+            0: importedUtxo,
+            1: importedEvm,
+          },
+        },
+        { id: 0, type: KeyringAccountType.Imported }
+      )
+    ).toEqual([
+      { account: hd0, accountType: KeyringAccountType.HDAccount },
+      { account: importedEvm, accountType: KeyringAccountType.Imported },
+    ]);
+  });
+
   it('selects an unfunded deterministic gas payer candidate for address prediction', () => {
     const hd0 = {
       address: '0x1111111111111111111111111111111111111111',

--- a/source/utils/passkey/validation.ts
+++ b/source/utils/passkey/validation.ts
@@ -271,13 +271,25 @@ export const validatePasskeyClientDataJSON = (
     throw new Error('WebAuthn client data has an unexpected origin');
   }
 
+  const getByteOffset = (textOffset: number) =>
+    new TextEncoder().encode(clientDataText.slice(0, textOffset)).length;
+
+  const escapeRegExp = (value: string) =>
+    value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
   const findStringValueOffset = (fieldName: string, expectedValue: string) => {
-    const needle = `"${fieldName}":"${expectedValue}"`;
-    const fieldOffset = clientDataText.indexOf(needle);
-    if (fieldOffset < 0) {
+    const fieldPattern = new RegExp(
+      `${escapeRegExp(JSON.stringify(fieldName))}\\s*:\\s*${escapeRegExp(
+        JSON.stringify(expectedValue)
+      )}`
+    );
+    const match = fieldPattern.exec(clientDataText);
+    if (!match || match.index === undefined) {
       throw new Error(`WebAuthn client data is missing ${fieldName}`);
     }
-    return fieldOffset + fieldName.length + 4;
+
+    const valueOffset = match.index + match[0].lastIndexOf(expectedValue);
+    return getByteOffset(valueOffset);
   };
 
   const challengeOffset = findStringValueOffset('challenge', expectedChallenge);
@@ -286,11 +298,19 @@ export const validatePasskeyClientDataJSON = (
     ? findStringValueOffset('origin', expectedOrigin)
     : (() => {
         const encodedOrigin = JSON.stringify(clientData.origin);
-        const fieldOffset = clientDataText.indexOf(`"origin":${encodedOrigin}`);
-        if (fieldOffset < 0) {
+        const fieldPattern = new RegExp(
+          `${escapeRegExp(JSON.stringify('origin'))}\\s*:\\s*${escapeRegExp(
+            encodedOrigin
+          )}`
+        );
+        const match = fieldPattern.exec(clientDataText);
+        if (!match || match.index === undefined) {
           throw new Error('WebAuthn client data is missing origin');
         }
-        return fieldOffset + '"origin":'.length + 1;
+
+        const originValueOffset =
+          match.index + match[0].lastIndexOf(String(clientData.origin));
+        return getByteOffset(originValueOffset);
       })();
   if (challengeOffset < 0) {
     throw new Error(

--- a/source/utils/passkey/validation.ts
+++ b/source/utils/passkey/validation.ts
@@ -1,0 +1,302 @@
+import { arrayify, splitSignature } from '@ethersproject/bytes';
+import { hashMessage } from '@ethersproject/hash';
+import { recoverAddress } from '@ethersproject/transactions';
+
+import {
+  IPasskeySmartAccountMetadata,
+  KeyringAccountType,
+  PasskeySponsorMode,
+} from 'types/network';
+
+export type PasskeySponsorProof = { r: string; s: string; v: number };
+
+export type PasskeyExecution = {
+  data: string;
+  deadline: number;
+  nonce: string;
+  target: string;
+  value: string;
+};
+
+export type PasskeyWebAuthnProof = {
+  authenticatorData: string;
+  challengeOffset: number;
+  clientDataJSON: string;
+  originOffset: number;
+  r: string;
+  s: string;
+  typeOffset: number;
+};
+
+export class PasskeyRelayedTransactionNotFoundError extends Error {
+  constructor() {
+    super('Sponsor relayed transaction was not found on-chain');
+    this.name = 'PasskeyRelayedTransactionNotFoundError';
+  }
+}
+
+export const normalizePasskeySponsorProof = (
+  proofOrSignature?:
+    | string
+    | {
+        r?: string;
+        s?: string;
+        signature?: string;
+        v?: number | string;
+      }
+    | null
+): PasskeySponsorProof | null => {
+  if (!proofOrSignature) {
+    return null;
+  }
+
+  if (typeof proofOrSignature === 'string') {
+    const signature = splitSignature(proofOrSignature);
+    return { v: signature.v, r: signature.r, s: signature.s };
+  }
+
+  if (proofOrSignature.signature) {
+    const signature = splitSignature(proofOrSignature.signature);
+    return { v: signature.v, r: signature.r, s: signature.s };
+  }
+
+  if (
+    proofOrSignature.v === undefined ||
+    !proofOrSignature.r ||
+    !proofOrSignature.s
+  ) {
+    return null;
+  }
+
+  const v =
+    typeof proofOrSignature.v === 'string'
+      ? Number(proofOrSignature.v)
+      : proofOrSignature.v;
+  if (!Number.isInteger(v) || (v !== 27 && v !== 28)) {
+    throw new Error('Invalid passkey sponsor signature recovery id');
+  }
+
+  return { v, r: proofOrSignature.r, s: proofOrSignature.s };
+};
+
+export const verifyPasskeySponsorProof = (
+  actionHash: string,
+  sponsorProof: PasskeySponsorProof,
+  metadata: IPasskeySmartAccountMetadata
+) => {
+  if (metadata.sponsor?.mode !== PasskeySponsorMode.Required) {
+    return;
+  }
+  if (!metadata.sponsor.signer) {
+    throw new Error('Passkey sponsor signer is not configured');
+  }
+
+  const sponsorDigest = hashMessage(arrayify(actionHash));
+  const recovered = recoverAddress(sponsorDigest, sponsorProof);
+  if (recovered.toLowerCase() !== metadata.sponsor.signer.toLowerCase()) {
+    throw new Error(
+      'Passkey sponsor signature does not match configured signer'
+    );
+  }
+};
+
+export const verifyPasskeyRelayedSponsorProof = (
+  actionHash: string,
+  sponsorProof: unknown,
+  metadata: IPasskeySmartAccountMetadata
+) => {
+  if (metadata.sponsor?.mode !== PasskeySponsorMode.Required) {
+    return;
+  }
+
+  const normalizedSponsorProof = normalizePasskeySponsorProof(
+    sponsorProof as Parameters<typeof normalizePasskeySponsorProof>[0]
+  );
+  if (!normalizedSponsorProof) {
+    throw new Error(
+      'Sponsor relayed a passkey transaction without sponsor proof'
+    );
+  }
+
+  verifyPasskeySponsorProof(actionHash, normalizedSponsorProof, metadata);
+};
+
+export const selectPasskeyDeploymentGasPayer = (
+  accounts: Record<string, Record<number, any>>,
+  metadata: IPasskeySmartAccountMetadata,
+  getDefaultPasskeyGasPayer: () => {
+    account: any;
+    accountType: KeyringAccountType;
+  }
+) => {
+  const gasPayer = metadata.deploymentGasPayer;
+  if (gasPayer) {
+    const account = accounts[gasPayer.type]?.[gasPayer.id] as any;
+    if (
+      account?.address &&
+      account.address.toLowerCase() === gasPayer.address.toLowerCase()
+    ) {
+      return { account, accountType: gasPayer.type };
+    }
+    throw new Error(
+      'Passkey deployment gas payer is no longer available in this wallet'
+    );
+  }
+
+  return getDefaultPasskeyGasPayer();
+};
+
+export const getPasskeyGasPayerCandidates = (
+  accounts: Record<string, Record<number, any>>,
+  activeAccount?: { id: number; type: KeyringAccountType }
+) => {
+  const accountTypes = [
+    KeyringAccountType.HDAccount,
+    KeyringAccountType.Imported,
+  ];
+  const candidates: Array<{
+    account: any;
+    accountType: KeyringAccountType;
+  }> = [];
+  const isSoftwareAccount = (accountType?: KeyringAccountType) =>
+    accountType === KeyringAccountType.HDAccount ||
+    accountType === KeyringAccountType.Imported;
+
+  if (activeAccount && isSoftwareAccount(activeAccount.type)) {
+    const activeGasPayer =
+      accounts[activeAccount.type]?.[activeAccount.id] || null;
+    if (activeGasPayer?.address) {
+      candidates.push({
+        account: activeGasPayer,
+        accountType: activeAccount.type,
+      });
+    }
+  }
+
+  for (const accountType of accountTypes) {
+    for (const account of Object.values(accounts[accountType] || {}) as any[]) {
+      if (
+        account?.address &&
+        !candidates.some(
+          (candidate) =>
+            candidate.accountType === accountType &&
+            candidate.account.id === account.id
+        )
+      ) {
+        candidates.push({ account, accountType });
+      }
+    }
+  }
+
+  return candidates;
+};
+
+export const selectPasskeyGasPayerCandidate = (
+  accounts: Record<string, Record<number, any>>,
+  activeAccount?: { id: number; type: KeyringAccountType }
+) => {
+  const [candidate] = getPasskeyGasPayerCandidates(accounts, activeAccount);
+  if (!candidate) {
+    throw new Error(
+      'No software account is available to anchor passkey account deployment'
+    );
+  }
+  return candidate;
+};
+
+export const selectFundedPasskeyGasPayerCandidate = async (
+  accounts: Record<string, Record<number, any>>,
+  activeAccount: { id: number; type: KeyringAccountType } | undefined,
+  hasRequiredBalance: (address: string) => Promise<boolean>
+) => {
+  for (const candidate of getPasskeyGasPayerCandidates(
+    accounts,
+    activeAccount
+  )) {
+    if (await hasRequiredBalance(candidate.account.address)) {
+      return candidate;
+    }
+  }
+
+  throw new Error(
+    'No funded software account is available to pay passkey account gas'
+  );
+};
+
+export const assertPasskeyRelayPayloadMatches = (
+  execution: any,
+  proof: any,
+  expectedExecution: PasskeyExecution,
+  expectedProof: PasskeyWebAuthnProof
+) => {
+  const sameHex = (left: string, right: string) =>
+    String(left || '').toLowerCase() === String(right || '').toLowerCase();
+  if (
+    String(execution.target).toLowerCase() !==
+      expectedExecution.target.toLowerCase() ||
+    execution.value.toString() !== expectedExecution.value.toString() ||
+    !sameHex(execution.data, expectedExecution.data) ||
+    execution.nonce.toString() !== expectedExecution.nonce.toString() ||
+    execution.deadline.toString() !== expectedExecution.deadline.toString() ||
+    !sameHex(proof.authenticatorData, expectedProof.authenticatorData) ||
+    !sameHex(proof.clientDataJSON, expectedProof.clientDataJSON) ||
+    proof.challengeOffset.toString() !==
+      expectedProof.challengeOffset.toString() ||
+    proof.originOffset.toString() !== expectedProof.originOffset.toString() ||
+    proof.typeOffset.toString() !== expectedProof.typeOffset.toString() ||
+    !sameHex(proof.r, expectedProof.r) ||
+    !sameHex(proof.s, expectedProof.s)
+  ) {
+    throw new Error('Sponsor relayed a different passkey execution');
+  }
+};
+
+export const validatePasskeyClientDataJSON = (
+  clientDataJSON: Uint8Array,
+  expectedChallenge: string,
+  expectedOrigin?: string
+) => {
+  const clientDataText = new TextDecoder().decode(clientDataJSON);
+  const clientData = JSON.parse(clientDataText);
+  if (clientData.type !== 'webauthn.get') {
+    throw new Error('WebAuthn client data has an unexpected type');
+  }
+  if (clientData.challenge !== expectedChallenge) {
+    throw new Error('WebAuthn client data has an unexpected challenge');
+  }
+  if (clientData.crossOrigin === true) {
+    throw new Error('Cross-origin WebAuthn assertions are not supported');
+  }
+  if (expectedOrigin && clientData.origin !== expectedOrigin) {
+    throw new Error('WebAuthn client data has an unexpected origin');
+  }
+
+  const findStringValueOffset = (fieldName: string, expectedValue: string) => {
+    const needle = `"${fieldName}":"${expectedValue}"`;
+    const fieldOffset = clientDataText.indexOf(needle);
+    if (fieldOffset < 0) {
+      throw new Error(`WebAuthn client data is missing ${fieldName}`);
+    }
+    return fieldOffset + fieldName.length + 4;
+  };
+
+  const challengeOffset = findStringValueOffset('challenge', expectedChallenge);
+  const typeOffset = findStringValueOffset('type', 'webauthn.get');
+  const originOffset = expectedOrigin
+    ? findStringValueOffset('origin', expectedOrigin)
+    : (() => {
+        const encodedOrigin = JSON.stringify(clientData.origin);
+        const fieldOffset = clientDataText.indexOf(`"origin":${encodedOrigin}`);
+        if (fieldOffset < 0) {
+          throw new Error('WebAuthn client data is missing origin');
+        }
+        return fieldOffset + '"origin":'.length + 1;
+      })();
+  if (challengeOffset < 0) {
+    throw new Error(
+      'WebAuthn client data does not contain the expected challenge'
+    );
+  }
+
+  return { challengeOffset, clientDataText, originOffset, typeOffset };
+};

--- a/source/utils/passkey/validation.ts
+++ b/source/utils/passkey/validation.ts
@@ -1,4 +1,4 @@
-import { arrayify, splitSignature } from '@ethersproject/bytes';
+import { arrayify, isHexString, splitSignature } from '@ethersproject/bytes';
 import { hashMessage } from '@ethersproject/hash';
 import { recoverAddress } from '@ethersproject/transactions';
 
@@ -161,11 +161,12 @@ export const getPasskeyGasPayerCandidates = (
   const isSoftwareAccount = (accountType?: KeyringAccountType) =>
     accountType === KeyringAccountType.HDAccount ||
     accountType === KeyringAccountType.Imported;
+  const hasEvmAddress = (account: any) => isHexString(account?.address, 20);
 
   if (activeAccount && isSoftwareAccount(activeAccount.type)) {
     const activeGasPayer =
       accounts[activeAccount.type]?.[activeAccount.id] || null;
-    if (activeGasPayer?.address) {
+    if (hasEvmAddress(activeGasPayer)) {
       candidates.push({
         account: activeGasPayer,
         accountType: activeAccount.type,
@@ -176,7 +177,7 @@ export const getPasskeyGasPayerCandidates = (
   for (const accountType of accountTypes) {
     for (const account of Object.values(accounts[accountType] || {}) as any[]) {
       if (
-        account?.address &&
+        hasEvmAddress(account) &&
         !candidates.some(
           (candidate) =>
             candidate.accountType === accountType &&

--- a/source/utils/passkey/webauthn.ts
+++ b/source/utils/passkey/webauthn.ts
@@ -1,0 +1,277 @@
+import { id as hashText } from '@ethersproject/hash';
+import { toUtf8Bytes } from '@ethersproject/strings';
+
+import {
+  base64UrlToBytes,
+  bytesToBase64Url,
+  bytesToHex,
+  hexToBytes,
+} from './base64url';
+import { asCborBytes, asCborMap, decodeCbor } from './cbor';
+import { validatePasskeyClientDataJSON } from './validation';
+
+export type PasskeyPublicKey = {
+  credentialId: string;
+  credentialIdHash: string;
+  originHash: string;
+  originLength: number;
+  rpIdHash: string;
+  x: string;
+  y: string;
+};
+
+export type PasskeyRegistrationResult = PasskeyPublicKey & {
+  rawId: string;
+};
+
+export type PasskeyAssertionResult = {
+  authenticatorData: string;
+  challengeOffset: number;
+  clientDataJSON: string;
+  digest: string;
+  originOffset: number;
+  r: string;
+  s: string;
+  typeOffset: number;
+};
+
+export type PasskeyCredentialRequest = {
+  accountName: string;
+  challengeHex: string;
+  rpId?: string;
+  rpName?: string;
+  userDisplayName?: string;
+  userId?: Uint8Array;
+};
+
+const ES256_ALGORITHM = -7;
+const P256_CRV = 1;
+const AUTH_DATA_FIXED_LENGTH = 37;
+const ATTESTED_CREDENTIAL_DATA_FLAG = 0x40;
+const P256_N = BigInt(
+  '0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551'
+);
+const P256_HALF_N = BigInt(
+  '0x7fffffff800000007fffffffffffffffde737d56d38bcf4279dce5617e3192a8'
+);
+
+const sha256 = async (data: Uint8Array): Promise<Uint8Array> =>
+  new Uint8Array(await crypto.subtle.digest('SHA-256', toArrayBuffer(data)));
+
+const toArrayBuffer = (bytes: Uint8Array): ArrayBuffer => {
+  const buffer = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(buffer).set(bytes);
+  return buffer;
+};
+
+const concatBytes = (a: Uint8Array, b: Uint8Array): Uint8Array => {
+  const out = new Uint8Array(a.length + b.length);
+  out.set(a, 0);
+  out.set(b, a.length);
+  return out;
+};
+
+const toBytes = (value: ArrayBuffer): Uint8Array => new Uint8Array(value);
+
+const bytesToBigInt = (bytes: Uint8Array): bigint =>
+  BigInt(`0x${bytesToHex(bytes).slice(2) || '0'}`);
+
+const bigIntToBytes32 = (value: bigint): Uint8Array => {
+  const hex = value.toString(16).padStart(64, '0');
+  return hexToBytes(`0x${hex}`);
+};
+
+const normalizeP256S = (s: Uint8Array): Uint8Array => {
+  const value = bytesToBigInt(s);
+  if (value > P256_HALF_N) {
+    return bigIntToBytes32(P256_N - value);
+  }
+
+  return s;
+};
+
+const parseDerSignature = (signature: Uint8Array) => {
+  if (signature[0] !== 0x30) throw new Error('Invalid DER signature');
+  let offset = 2;
+
+  if (signature[1] & 0x80) {
+    offset = 2 + (signature[1] & 0x7f);
+  }
+
+  const readInteger = () => {
+    if (signature[offset] !== 0x02)
+      throw new Error('Invalid DER signature integer');
+    const length = signature[offset + 1];
+    offset += 2;
+    let value = signature.slice(offset, offset + length);
+    offset += length;
+
+    while (value.length > 32 && value[0] === 0) {
+      value = value.slice(1);
+    }
+    if (value.length > 32)
+      throw new Error('Invalid P-256 signature integer length');
+
+    const padded = new Uint8Array(32);
+    padded.set(value, 32 - value.length);
+    return padded;
+  };
+
+  return { r: readInteger(), s: normalizeP256S(readInteger()) };
+};
+
+const extractCredentialPublicKey = async (
+  attestationObject: Uint8Array,
+  expectedOrigin: string
+): Promise<PasskeyPublicKey> => {
+  const attestation = asCborMap(decodeCbor(attestationObject).value);
+  const authData = asCborBytes(attestation.get('authData'));
+
+  if (
+    authData.length < AUTH_DATA_FIXED_LENGTH ||
+    (authData[32] & ATTESTED_CREDENTIAL_DATA_FLAG) === 0
+  ) {
+    throw new Error('Authenticator did not return attested credential data');
+  }
+
+  let offset = AUTH_DATA_FIXED_LENGTH + 16; // rpIdHash + flags + signCount + AAGUID
+  const credentialIdLength = (authData[offset] << 8) | authData[offset + 1];
+  offset += 2;
+
+  const credentialIdBytes = authData.slice(offset, offset + credentialIdLength);
+  offset += credentialIdLength;
+
+  const coseKey = asCborMap(decodeCbor(authData, offset).value);
+  const alg = coseKey.get(3);
+  const crv = coseKey.get(-1);
+  const x = asCborBytes(coseKey.get(-2));
+  const y = asCborBytes(coseKey.get(-3));
+
+  if (
+    alg !== ES256_ALGORITHM ||
+    crv !== P256_CRV ||
+    x.length !== 32 ||
+    y.length !== 32
+  ) {
+    throw new Error('Passkey must use ES256 / P-256');
+  }
+
+  const credentialIdHash = await sha256(credentialIdBytes);
+  const rpIdHash = authData.slice(0, 32);
+
+  return {
+    credentialId: bytesToBase64Url(credentialIdBytes),
+    credentialIdHash: bytesToHex(credentialIdHash),
+    originHash: hashText(expectedOrigin),
+    originLength: toUtf8Bytes(expectedOrigin).length,
+    rpIdHash: bytesToHex(rpIdHash),
+    x: bytesToHex(x),
+    y: bytesToHex(y),
+  };
+};
+
+export const createPasskeyCredential = async ({
+  accountName,
+  challengeHex,
+  rpId,
+  rpName = 'Pali Wallet',
+  userDisplayName,
+  userId,
+}: PasskeyCredentialRequest): Promise<PasskeyRegistrationResult> => {
+  const challenge = hexToBytes(challengeHex);
+  const userIdBytes = userId || crypto.getRandomValues(new Uint8Array(32));
+  const credential = (await navigator.credentials.create({
+    publicKey: {
+      attestation: 'none',
+      authenticatorSelection: {
+        residentKey: 'preferred',
+        userVerification: 'required',
+      },
+      challenge: toArrayBuffer(challenge),
+      pubKeyCredParams: [{ type: 'public-key', alg: ES256_ALGORITHM }],
+      rp: {
+        name: rpName,
+        ...(rpId ? { id: rpId } : {}),
+      },
+      timeout: 120_000,
+      user: {
+        id: toArrayBuffer(userIdBytes),
+        name: accountName,
+        displayName: userDisplayName || accountName,
+      },
+    },
+  })) as PublicKeyCredential | null;
+
+  if (!credential) throw new Error('Passkey creation was cancelled');
+  const response = credential.response as AuthenticatorAttestationResponse;
+  const expectedOrigin =
+    typeof window !== 'undefined' && window.location?.origin
+      ? window.location.origin
+      : '';
+  if (!expectedOrigin) {
+    throw new Error('WebAuthn origin is unavailable');
+  }
+  const publicKey = await extractCredentialPublicKey(
+    toBytes(response.attestationObject),
+    expectedOrigin
+  );
+
+  return {
+    ...publicKey,
+    rawId: bytesToBase64Url(toBytes(credential.rawId)),
+  };
+};
+
+export const getPasskeyAssertion = async (
+  credentialId: string,
+  challengeHex: string,
+  rpId?: string
+): Promise<PasskeyAssertionResult> => {
+  const challenge = hexToBytes(challengeHex);
+  const challengeText = bytesToBase64Url(challenge);
+  const credential = (await navigator.credentials.get({
+    publicKey: {
+      allowCredentials: [
+        {
+          id: toArrayBuffer(base64UrlToBytes(credentialId)),
+          type: 'public-key',
+        },
+      ],
+      challenge: toArrayBuffer(challenge),
+      ...(rpId ? { rpId } : {}),
+      timeout: 120_000,
+      userVerification: 'required',
+    },
+  })) as PublicKeyCredential | null;
+
+  if (!credential) throw new Error('Passkey approval was cancelled');
+  const response = credential.response as AuthenticatorAssertionResponse;
+  const authenticatorData = toBytes(response.authenticatorData);
+  const clientDataJSON = toBytes(response.clientDataJSON);
+  const signature = toBytes(response.signature);
+  const expectedOrigin =
+    typeof window !== 'undefined' && window.location?.origin
+      ? window.location.origin
+      : undefined;
+  const { challengeOffset, originOffset, typeOffset } =
+    validatePasskeyClientDataJSON(
+      clientDataJSON,
+      challengeText,
+      expectedOrigin
+    );
+
+  const clientDataHash = await sha256(clientDataJSON);
+  const digest = await sha256(concatBytes(authenticatorData, clientDataHash));
+  const { r, s } = parseDerSignature(signature);
+
+  return {
+    authenticatorData: bytesToHex(authenticatorData),
+    challengeOffset,
+    clientDataJSON: bytesToHex(clientDataJSON),
+    digest: bytesToHex(digest),
+    originOffset,
+    r: bytesToHex(r),
+    s: bytesToHex(s),
+    typeOffset,
+  };
+};

--- a/source/utils/validateTransactionDataValue.ts
+++ b/source/utils/validateTransactionDataValue.ts
@@ -1,11 +1,11 @@
 import { formatBytes32String } from '@ethersproject/strings';
 
 export const validateTransactionDataValue = (data: string | undefined) => {
-  if (!data) return '';
+  if (!data) return '0x';
 
   return data.length > 0
     ? data.substring(0, 2) === '0x'
       ? data
       : formatBytes32String(data)
-    : '';
+    : '0x';
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2580,10 +2580,10 @@
   resolved "https://registry.yarnpkg.com/@sidhujag/sysweb3-core/-/sysweb3-core-1.0.28.tgz#05daaf0a9411febfe36d96a43f76767a5bcd5d03"
   integrity sha512-YN3qdoPNyFFdseO/iaUmr0gSWpKbVEPA6I9ePd8Sny2BhY11SsXkj1x+acL9RfmtsfZ7kh+tzo3//OOGCw+PLA==
 
-"@sidhujag/sysweb3-keyring@^1.0.587":
-  version "1.0.587"
-  resolved "https://registry.yarnpkg.com/@sidhujag/sysweb3-keyring/-/sysweb3-keyring-1.0.587.tgz#bff08aeb326097281a9f928d017c6a41214e219c"
-  integrity sha512-gHiWugB8M98dTZaCan5UWSSEt+EAVBM+jyj+syNRQsgNeZUJVErD0dAfyNsc+pvrX5thVxk8ERZlrik0VJ+59w==
+"@sidhujag/sysweb3-keyring@^1.0.588":
+  version "1.0.588"
+  resolved "https://registry.yarnpkg.com/@sidhujag/sysweb3-keyring/-/sysweb3-keyring-1.0.588.tgz#73ac63334e3804ca49434ab84269e566b43074d8"
+  integrity sha512-yWqceo8fVEHu8fVECux+3qglreAKPeOkYFS+AcCZUMI+yeOPMnYhO+o46EWQoWmvLhqwP2ygNLpox2ESsqzBXw==
   dependencies:
     "@bitcoinerlab/secp256k1" "^1.2.0"
     "@ethersproject/abstract-provider" "^5.8.0"


### PR DESCRIPTION
## Summary
- Add zkSYS Passkey Account creation, display, deployment, and execution flows backed by WebAuthn/P256 smart accounts.
- Wrap passkey account sends, dapp transactions, EIP-1271 signing, and single-call `wallet_sendCalls` through the smart account execution path.
- Add sponsor policy metadata, Required/GasOnly sponsor handling, relayed transaction validation, localized passkey UI copy, and keyring dependency/version updates.

## Review context
- Contract/context PR: https://github.com/syscoin/zksync-os-server/pull/222
- sysweb3 keyring PR: https://github.com/sidhujag/sysweb3/pull/4
- This Pali PR depends on the sysweb3 keyring metadata changes and targets the deployed passkey factory from the contract PR.

## Test plan
- Local focused prettier + ESLint on touched passkey/i18n files.
- Local `yarn test:unit --runInBand source/utils/passkey/validation.spec.ts`.
- Remote `yarn test:unit --runInBand source/utils/passkey/validation.spec.ts`.
- Remote `yarn lint`.
- Remote `yarn build:chrome`.


Made with [Cursor](https://cursor.com)