### PR TITLE
docs: isolate portal postcss config

### DIFF
--- a/docs/portal/postcss.config.js
+++ b/docs/portal/postcss.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: {},
+};


### PR DESCRIPTION
## Summary
- Add a docs-local PostCSS config so Vercel builds rooted at `docs/portal` do not inherit the wallet root Tailwind PostCSS plugin.
- Fixes Vercel deploy failures where `tailwindcss` is not installed in the isolated docs portal dependency tree.

## Test plan
- `ReadLints` on `docs/portal/postcss.config.js`
- Not run: full docs build; deployment failure root cause is PostCSS config resolution in Vercel.


Made with [Cursor](https://cursor.com)