### PR TITLE
docs: enable clean URLs on Vercel

### DIFF
--- a/docs/portal/vercel.json
+++ b/docs/portal/vercel.json
@@ -1,0 +1,3 @@
+{
+  "cleanUrls": true
+}


### PR DESCRIPTION
## Summary
- Add `docs/portal/vercel.json` with `cleanUrls: true` so Vercel serves Docusaurus `.html` outputs at extensionless routes.
- Fixes direct loads and locale selector navigation for routes like `/docs`, `/ru/docs`, and `/ru/docs/developers/testing-with-pali`.

## Test plan
- Confirmed deployed `.html` routes return 200 while extensionless routes return 404 before this config.
- `ReadLints` on `docs/portal/vercel.json`.


Made with [Cursor](https://cursor.com)