### PR TITLE
fix: handle stale pending nonce gaps

### DIFF
--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -4319,19 +4319,97 @@ class MainController {
     }
   }
 
+  public async getRecommendedEvmNonce(address: string): Promise<number> {
+    try {
+      const provider = this.ethereumTransaction?.web3Provider;
+      if (!provider) {
+        throw new Error('Web3 provider not available');
+      }
+
+      const [latestNonce, pendingNonce] = await Promise.all([
+        provider.getTransactionCount(address, 'latest'),
+        provider.getTransactionCount(address, 'pending'),
+      ]);
+
+      if (pendingNonce <= latestNonce) {
+        return latestNonce;
+      }
+
+      const normalizedAddress = address.toLowerCase();
+      const { accounts, accountTransactions, activeNetwork } =
+        store.getState().vault;
+      let accountType: keyof typeof accounts | undefined;
+      let accountId: number | undefined;
+
+      for (const type of Object.keys(accounts) as Array<
+        keyof typeof accounts
+      >) {
+        const accountsById = accounts[type];
+        for (const [id, account] of Object.entries(accountsById)) {
+          if (
+            account?.address &&
+            account.address.toLowerCase() === normalizedAddress
+          ) {
+            accountType = type;
+            accountId = Number(id);
+            break;
+          }
+        }
+        if (accountType !== undefined) {
+          break;
+        }
+      }
+
+      const localPendingNonces = new Set<number>();
+      const localTransactions =
+        accountType !== undefined && accountId !== undefined
+          ? accountTransactions?.[accountType]?.[accountId]?.ethereum?.[
+              activeNetwork.chainId
+            ] || []
+          : [];
+
+      // If the provider advertises a pending range that Pali cannot account for
+      // locally, fill the first uncovered nonce instead of trusting txpool state.
+      for (const tx of localTransactions as any[]) {
+        if (isTransactionInBlock(tx)) {
+          continue;
+        }
+        if (tx.from && tx.from.toLowerCase() !== normalizedAddress) {
+          continue;
+        }
+        if (tx.nonce === undefined || tx.nonce === null) {
+          continue;
+        }
+
+        const nonce =
+          typeof tx.nonce === 'string'
+            ? tx.nonce.startsWith('0x')
+              ? parseInt(tx.nonce, 16)
+              : Number(tx.nonce)
+            : Number(tx.nonce);
+        if (Number.isFinite(nonce)) {
+          localPendingNonces.add(nonce);
+        }
+      }
+
+      for (let nonce = latestNonce; nonce < pendingNonce; nonce += 1) {
+        if (!localPendingNonces.has(nonce)) {
+          return nonce;
+        }
+      }
+
+      return pendingNonce;
+    } catch (error) {
+      return await this.ethereumTransaction.getRecommendedNonce(address);
+    }
+  }
+
   /**
    * Get recommended nonce for batch transactions
    * Safely calls the ethereum transaction method to get the next nonce
    */
   public async getRecommendedNonceForBatch(address: string): Promise<number> {
-    try {
-      const controller = getController();
-      return await controller.wallet.ethereumTransaction.getRecommendedNonce(
-        address
-      );
-    } catch (error) {
-      throw error;
-    }
+    return this.getRecommendedEvmNonce(address);
   }
 
   /**

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -4326,14 +4326,7 @@ class MainController {
         throw new Error('Web3 provider not available');
       }
 
-      const [latestNonce, pendingNonce] = await Promise.all([
-        provider.getTransactionCount(address, 'latest'),
-        provider.getTransactionCount(address, 'pending'),
-      ]);
-
-      if (pendingNonce <= latestNonce) {
-        return latestNonce;
-      }
+      const latestNonce = await provider.getTransactionCount(address, 'latest');
 
       const normalizedAddress = address.toLowerCase();
       const { accounts, accountTransactions, activeNetwork } =
@@ -4360,6 +4353,7 @@ class MainController {
         }
       }
 
+      let localConfirmedNextNonce = 0;
       const localPendingNonces = new Set<number>();
       const localTransactions =
         accountType !== undefined && accountId !== undefined
@@ -4368,12 +4362,9 @@ class MainController {
             ] || []
           : [];
 
-      // If the provider advertises a pending range that Pali cannot account for
-      // locally, fill the first uncovered nonce instead of trusting txpool state.
+      // Match MetaMask's nonce model: start from canonical/latest chain state
+      // plus local confirmed history, then skip nonces Pali has locally pending.
       for (const tx of localTransactions as any[]) {
-        if (isTransactionInBlock(tx)) {
-          continue;
-        }
         if (tx.from && tx.from.toLowerCase() !== normalizedAddress) {
           continue;
         }
@@ -4388,17 +4379,23 @@ class MainController {
               : Number(tx.nonce)
             : Number(tx.nonce);
         if (Number.isFinite(nonce)) {
-          localPendingNonces.add(nonce);
+          if (isTransactionInBlock(tx)) {
+            localConfirmedNextNonce = Math.max(
+              localConfirmedNextNonce,
+              nonce + 1
+            );
+          } else {
+            localPendingNonces.add(nonce);
+          }
         }
       }
 
-      for (let nonce = latestNonce; nonce < pendingNonce; nonce += 1) {
-        if (!localPendingNonces.has(nonce)) {
-          return nonce;
-        }
+      let nextNonce = Math.max(latestNonce, localConfirmedNextNonce);
+      while (localPendingNonces.has(nextNonce)) {
+        nextNonce += 1;
       }
 
-      return pendingNonce;
+      return nextNonce;
     } catch (error) {
       return await this.ethereumTransaction.getRecommendedNonce(address);
     }

--- a/source/utils/fetchGasAndDecodeFunction.ts
+++ b/source/utils/fetchGasAndDecodeFunction.ts
@@ -75,7 +75,7 @@ export const fetchGasAndDecodeFunction = async (
       ); // 1 Gwei fallback
 
   const nonce = (await controllerEmitter(
-    ['wallet', 'ethereumTransaction', 'getRecommendedNonce'],
+    ['wallet', 'getRecommendedEvmNonce'],
     [dataTx.from]
   )) as number; // This also need possibility for customization //todo: adjust to get from new keyringmanager
 


### PR DESCRIPTION
## Summary
- Add a Pali-side EVM nonce recommender that uses canonical `latest` chain state plus Pali local transaction history.
- Advance through locally pending Pali transactions instead of trusting provider `pending` txpool state.
- Route single-send and batch-send nonce preparation through the same helper.

## Test plan
- `yarn type-check`