### PR TITLE
Refine passkey sponsor UX and canary extension identity

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Pali Wallet",
-  "version": "4.0.20",
+  "version": "4.0.21",
   "icons": {
     "16": "assets/all_assets/favicon-16.png",
     "32": "assets/all_assets/favicon-32.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paliwallet",
-  "version": "4.0.20",
+  "version": "4.0.21",
   "description": "A Non-Custodial Crypto Wallet",
   "private": true,
   "repository": {

--- a/source/config/consts.js
+++ b/source/config/consts.js
@@ -73,10 +73,14 @@ const MV2_OPTIONS = {
   },
 };
 
+// Non-production public key used to keep canary extension IDs stable.
+const CANARY_EXTENSION_KEY =
+  'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArYLCXWBGnwp1giU5pIbXuqrbzJDzkGgPXXefSLdhpOrZc5rdTcpq8hcJJqRSJBESoLpuCrqvd/HPwtwo6h0hjWvB+pOPIJmPwWlYs+zKAKOUZIZcSqJmJCkv9FztuCcbQqlOWJ/2PvEyDvPKcc54aH6IAYlhnth9tWuiYVmzHQqornSKNWBQeukzWvxTuYhqz2RDFeUdiCh1Y9Bf8/3BrOJjI7FESTRd5iHDqd6LrIs91a6hUuWgCF5//57lG9Zr2KRLkl+3ibEQBGQMTWYRfBbdnZYXPDdspoaEaUi179R/7iFd3laA9EhMcGhnwH3x/FQxNMH6z+FS+ojAEkCLyQIDAQAB';
+
 const MV3_OPTIONS = {
   manifest_version: 3,
   name: 'Pali Wallet',
-  version: '4.0.20',
+  version: '4.0.21',
   icons: {
     16: 'assets/all_assets/favicon-16.png',
     32: 'assets/all_assets/favicon-32.png',
@@ -154,6 +158,7 @@ const MV3_OPTIONS = {
 };
 
 module.exports = {
+  CANARY_EXTENSION_KEY,
   MV2_OPTIONS,
   MV3_OPTIONS,
 };

--- a/source/config/generateManifest.js
+++ b/source/config/generateManifest.js
@@ -4,7 +4,11 @@ const dotenv = require('dotenv');
 const fs = require('fs');
 
 const packageJson = require('../../package.json');
-const { MV2_OPTIONS, MV3_OPTIONS } = require('./consts.js');
+const {
+  CANARY_EXTENSION_KEY,
+  MV2_OPTIONS,
+  MV3_OPTIONS,
+} = require('./consts.js');
 
 dotenv.config();
 
@@ -39,6 +43,9 @@ function generateManifest() {
       'Pali Wallet',
       'Pali Wallet Canary'
     );
+    if (manifestOptions.manifest_version === 3) {
+      manifestOptions.key = CANARY_EXTENSION_KEY;
+    }
     if (manifestOptions.permissions) {
       manifestOptions.permissions = filterWebRequest(
         manifestOptions.permissions

--- a/source/pages/Connections/CreatePasskeyAccount.tsx
+++ b/source/pages/Connections/CreatePasskeyAccount.tsx
@@ -109,9 +109,10 @@ export const CreatePasskeyAccount = () => {
     );
   })();
   const isSponsorSignerValid =
-    Boolean(normalizedSponsorSigner) &&
-    !isSponsorSignerPasskeyAccount &&
-    (!isSponsorRequired || Boolean(trimmedSponsorUrl) || isLocalSponsorSigner);
+    Boolean(normalizedSponsorSigner) && !isSponsorSignerPasskeyAccount;
+  const sponsorUrlRequired =
+    sponsorMode === 'gasOnly' ||
+    (isSponsorRequired && isSponsorSignerValid && !isLocalSponsorSigner);
   const sponsorSignerError =
     isSponsorRequired && !trimmedSponsorSigner
       ? t('settings.sponsorSignerRequired')
@@ -119,7 +120,7 @@ export const CreatePasskeyAccount = () => {
       ? t('settings.invalidSponsorSignerAddress')
       : '';
   const sponsorUrlError =
-    sponsorMode === 'gasOnly' && !trimmedSponsorUrl
+    sponsorUrlRequired && !trimmedSponsorUrl
       ? t('settings.sponsorServiceUrlRequired')
       : trimmedSponsorUrl && !isSponsorUrlValid
       ? t('settings.invalidSponsorUrl')

--- a/source/pages/Settings/PasskeyAccountPolicy.tsx
+++ b/source/pages/Settings/PasskeyAccountPolicy.tsx
@@ -124,16 +124,17 @@ const PasskeyAccountPolicy = () => {
     normalizeSponsorSignerInput(trimmedSponsorSigner);
   const isSponsorSignerValid = Boolean(trimmedSponsorSigner)
     ? Boolean(normalizedSponsorSigner) &&
-      !isSponsorSignerPasskeyAccount(trimmedSponsorSigner) &&
-      (policyMode !== PasskeySponsorMode.Required ||
-        Boolean(trimmedSponsorUrl) ||
-        isLocalSponsorSigner(trimmedSponsorSigner))
+      !isSponsorSignerPasskeyAccount(trimmedSponsorSigner)
     : false;
+  const sponsorUrlRequired =
+    policyMode === PasskeySponsorMode.GasOnly ||
+    (policyMode === PasskeySponsorMode.Required &&
+      isSponsorSignerValid &&
+      !isLocalSponsorSigner(trimmedSponsorSigner));
   const isPolicySubmitDisabled =
     loading ||
     !policyHasChanges ||
-    (policyMode === PasskeySponsorMode.GasOnly &&
-      (!trimmedSponsorUrl || !isSponsorUrlValid)) ||
+    (sponsorUrlRequired && !trimmedSponsorUrl) ||
     (policyMode === PasskeySponsorMode.Required &&
       (!trimmedSponsorSigner || !isSponsorSignerValid || !isSponsorUrlValid));
   const hasKnownBackupStatus = Boolean(backupStatus);
@@ -410,17 +411,14 @@ const PasskeyAccountPolicy = () => {
               <Form.Item
                 name="sponsorUrl"
                 className="md:w-full mb-0 px-1"
-                hasFeedback={
-                  policyMode === PasskeySponsorMode.GasOnly ||
-                  Boolean(trimmedSponsorUrl)
-                }
+                hasFeedback
                 rules={[
                   () => ({
                     validator(_, value) {
                       const trimmedValue =
                         typeof value === 'string' ? value.trim() : '';
                       if (!trimmedValue) {
-                        return policyMode === PasskeySponsorMode.GasOnly
+                        return sponsorUrlRequired
                           ? Promise.reject(
                               new Error(t('settings.sponsorServiceUrlRequired'))
                             )
@@ -461,10 +459,7 @@ const PasskeyAccountPolicy = () => {
                         }
                         if (
                           normalizeSponsorSignerInput(trimmedValue) &&
-                          !isSponsorSignerPasskeyAccount(trimmedValue) &&
-                          (policyMode !== PasskeySponsorMode.Required ||
-                            Boolean(trimmedSponsorUrl) ||
-                            isLocalSponsorSigner(trimmedValue))
+                          !isSponsorSignerPasskeyAccount(trimmedValue)
                         ) {
                           return Promise.resolve();
                         }

--- a/source/scripts/Background/controllers/passkey/index.ts
+++ b/source/scripts/Background/controllers/passkey/index.ts
@@ -1161,9 +1161,7 @@ class PasskeyController {
       !sponsor.url &&
       !this.getLocalSponsorSignerAccount(sponsor.signer)
     ) {
-      throw new Error(
-        'Passkey sponsor signer must be available in this wallet when no sponsor URL is configured'
-      );
+      throw new Error('Use a local signer or sponsor URL.');
     }
   }
 
@@ -2302,9 +2300,7 @@ class PasskeyController {
           );
           return { sponsorProof: localSponsorProof, type: 'local' };
         }
-        throw new Error(
-          'This passkey account requires sponsor authorization, but the sponsor signer is not available in this wallet and no sponsor URL is configured'
-        );
+        throw new Error('Sponsor signer is not in this wallet.');
       }
       return { sponsorProof: emptyProof, type: 'local' };
     }


### PR DESCRIPTION
## Summary
- Keep MV3 canary builds on a stable non-production extension ID while leaving the default committed manifest keyless.
- Refine passkey sponsor policy validation so external valid signers are accepted as addresses while still requiring a sponsor URL when needed.
- Shorten sponsor authorization errors for faster toast readability.

## Test plan
- yarn type-check
- yarn lint
- Verified default manifest remains keyless and canary mode has a stable key path.


Made with [Cursor](https://cursor.com)