### PR TITLE
Decode passkey smart account execution methods

### DIFF
--- a/source/assets/locales/de.json
+++ b/source/assets/locales/de.json
@@ -796,7 +796,11 @@
       "delegateBySig": "Durch Signatur delegieren",
       "bridge": "Brücke",
       "bridgeAsset": "Asset-Brücke",
-      "swapAndBridge": "Tauschen und überbrücken"
+      "swapAndBridge": "Tauschen und überbrücken",
+      "execute": "Mit Passkey ausführen",
+      "createAccount": "Passkey-Konto erstellen",
+      "createAccountAndExecute": "Passkey-Konto erstellen und ausführen",
+      "setSponsor": "Passkey-Sponsor festlegen"
     }
   },
   "switchNetworkPage": {

--- a/source/assets/locales/en.json
+++ b/source/assets/locales/en.json
@@ -796,7 +796,11 @@
       "delegateBySig": "Delegate By Signature",
       "bridge": "Bridge",
       "bridgeAsset": "Bridge Asset",
-      "swapAndBridge": "Swap And Bridge"
+      "swapAndBridge": "Swap And Bridge",
+      "execute": "Passkey Execute",
+      "createAccount": "Create Passkey Account",
+      "createAccountAndExecute": "Create Passkey Account And Execute",
+      "setSponsor": "Set Passkey Sponsor"
     }
   },
   "switchNetworkPage": {

--- a/source/assets/locales/es.json
+++ b/source/assets/locales/es.json
@@ -796,7 +796,11 @@
       "delegateBySig": "Delegar Por Firma",
       "bridge": "Puente",
       "bridgeAsset": "Activo de Puente",
-      "swapAndBridge": "Intercambiar y Puente"
+      "swapAndBridge": "Intercambiar y Puente",
+      "execute": "Ejecutar con Passkey",
+      "createAccount": "Crear Cuenta Passkey",
+      "createAccountAndExecute": "Crear Cuenta Passkey y Ejecutar",
+      "setSponsor": "Configurar Patrocinador Passkey"
     }
   },
   "switchNetworkPage": {

--- a/source/assets/locales/fr.json
+++ b/source/assets/locales/fr.json
@@ -796,7 +796,11 @@
       "delegateBySig": "Déléguer par signature",
       "bridge": "Pont",
       "bridgeAsset": "Actif de pont",
-      "swapAndBridge": "Échanger et ponter"
+      "swapAndBridge": "Échanger et ponter",
+      "execute": "Exécuter avec Passkey",
+      "createAccount": "Créer un compte Passkey",
+      "createAccountAndExecute": "Créer un compte Passkey et exécuter",
+      "setSponsor": "Définir le sponsor Passkey"
     }
   },
   "switchNetworkPage": {

--- a/source/assets/locales/ja.json
+++ b/source/assets/locales/ja.json
@@ -796,7 +796,11 @@
       "delegateBySig": "署名による委任",
       "bridge": "ブリッジ",
       "bridgeAsset": "アセットブリッジ",
-      "swapAndBridge": "交換とブリッジ"
+      "swapAndBridge": "交換とブリッジ",
+      "execute": "パスキーで実行",
+      "createAccount": "パスキーアカウントを作成",
+      "createAccountAndExecute": "パスキーアカウントを作成して実行",
+      "setSponsor": "パスキースポンサーを設定"
     }
   },
   "switchNetworkPage": {

--- a/source/assets/locales/ko.json
+++ b/source/assets/locales/ko.json
@@ -796,7 +796,11 @@
       "delegateBySig": "서명으로 위임",
       "bridge": "브리지",
       "bridgeAsset": "브리지 자산",
-      "swapAndBridge": "교환 및 브리지"
+      "swapAndBridge": "교환 및 브리지",
+      "execute": "패스키로 실행",
+      "createAccount": "패스키 계정 생성",
+      "createAccountAndExecute": "패스키 계정 생성 및 실행",
+      "setSponsor": "패스키 스폰서 설정"
     }
   },
   "switchNetworkPage": {

--- a/source/assets/locales/pt.json
+++ b/source/assets/locales/pt.json
@@ -791,7 +791,11 @@
       "delegateBySig": "Delegar Por Assinatura",
       "bridge": "Ponte",
       "bridgeAsset": "Ativo de Ponte",
-      "swapAndBridge": "Trocar e Ponte"
+      "swapAndBridge": "Trocar e Ponte",
+      "execute": "Executar com Passkey",
+      "createAccount": "Criar Conta Passkey",
+      "createAccountAndExecute": "Criar Conta Passkey e Executar",
+      "setSponsor": "Definir Patrocinador Passkey"
     }
   },
   "switchNetworkPage": {

--- a/source/assets/locales/ru.json
+++ b/source/assets/locales/ru.json
@@ -796,7 +796,11 @@
       "delegateBySig": "Делегировать по подписи",
       "bridge": "Мост",
       "bridgeAsset": "Мост активов",
-      "swapAndBridge": "Обменять и перебросить"
+      "swapAndBridge": "Обменять и перебросить",
+      "execute": "Выполнить с Passkey",
+      "createAccount": "Создать аккаунт Passkey",
+      "createAccountAndExecute": "Создать аккаунт Passkey и выполнить",
+      "setSponsor": "Настроить спонсора Passkey"
     }
   },
   "switchNetworkPage": {

--- a/source/assets/locales/zh.json
+++ b/source/assets/locales/zh.json
@@ -593,7 +593,11 @@
       "delegateBySig": "通过签名委托",
       "bridge": "桥接",
       "bridgeAsset": "桥接资产",
-      "swapAndBridge": "交换并桥接"
+      "swapAndBridge": "交换并桥接",
+      "execute": "使用通行密钥执行",
+      "createAccount": "创建通行密钥账户",
+      "createAccountAndExecute": "创建通行密钥账户并执行",
+      "setSponsor": "设置通行密钥赞助方"
     }
   },
   "forgetWalletPage": {

--- a/source/pages/Send/SendTransaction.tsx
+++ b/source/pages/Send/SendTransaction.tsx
@@ -30,6 +30,7 @@ import {
 } from 'types/transactions';
 import { convertBigNumberToString } from 'utils/bigNumberUtils';
 import { dispatchBackgroundEvent } from 'utils/browser';
+import { formatMethodName } from 'utils/commonMethodSignatures';
 import { handleTransactionError } from 'utils/errorHandling';
 import { fetchGasAndDecodeFunction } from 'utils/fetchGasAndDecodeFunction';
 import { ellipsis } from 'utils/format';
@@ -1056,7 +1057,13 @@ export const SendTransaction = () => {
                 </div>
                 <div className="py-2 text-white text-xs flex w-full justify-between">
                   <p>{t('send.method')}</p>
-                  <p>{decodedTxData?.method}</p>
+                  <p>
+                    {formatMethodName(
+                      decodedTxData?.method || 'Contract Interaction',
+                      activeNetwork.currency,
+                      t
+                    )}
+                  </p>
                 </div>
 
                 {hasTxDataError && (

--- a/source/utils/ethUtil.ts
+++ b/source/utils/ethUtil.ts
@@ -241,7 +241,13 @@ export const decodeTransactionData = async (
   const zeroAddress = '0x0000000000000000000000000000000000000000';
   try {
     const { data } = params;
-    const dataValidation = Boolean(data && String(data).length > 0);
+    const normalizedData = typeof data === 'string' ? data.toLowerCase() : data;
+    const dataValidation = Boolean(
+      data &&
+        String(data).length > 0 &&
+        normalizedData !== '0x' &&
+        normalizedData !== '0x0'
+    );
 
     // Validate the Data as same as in the SendTransaction Component. If we let the data come as normal string will break all the decode Validation,
     // so we need to transform it on Bytes32.
@@ -320,10 +326,10 @@ export const decodeTransactionData = async (
       return decoderValue;
     }
 
-    //Return Contract Interaction if address is contract but don't have Data
-    if (!dataValidation) {
+    // Return Send Method when there is a destination and no calldata.
+    if (!dataValidation && params?.to && params?.to !== zeroAddress) {
       const emptyDecoderObject = {
-        method: 'Contract Interaction',
+        method: 'Send',
         types: [],
         inputs: [],
         names: [],
@@ -331,10 +337,11 @@ export const decodeTransactionData = async (
       return emptyDecoderObject;
     }
 
-    // Return Send Method if address is a wallet
-    if (params?.to && params?.to !== zeroAddress) {
+    // Return Contract Interaction when calldata is absent and the tx is not a
+    // normal transfer shape.
+    if (!dataValidation) {
       const emptyDecoderObject = {
-        method: 'Send',
+        method: 'Contract Interaction',
         types: [],
         inputs: [],
         names: [],

--- a/source/utils/ethUtil.ts
+++ b/source/utils/ethUtil.ts
@@ -1,10 +1,15 @@
 import { defaultAbiCoder } from '@ethersproject/abi';
 import InputDataDecoder from 'ethereum-input-data-decoder';
 
-import { ITransactionParams } from 'types/transactions';
+import { IDecodedTx, ITransactionParams } from 'types/transactions';
+import {
+  passkeyFactoryInterface,
+  passkeySmartAccountInterface,
+} from 'utils/passkey/contracts';
 import { retryableFetch } from 'utils/retryableFetch';
 import { getErc20Abi, getContractType } from 'utils/validations';
 
+import { getMethodName } from './commonMethodSignatures';
 import { pegasysABI } from './pegasys';
 import { validateTransactionDataValue } from './validateTransactionDataValue';
 import { wrapABI } from './wrapABI';
@@ -133,6 +138,100 @@ export const fetchFunctionSignature = async (
   return null;
 };
 
+const normalizeBytesValue = (value: unknown): string =>
+  typeof value === 'string' && value.length > 0 ? value : '0x';
+
+const getPasskeyExecutionValue = (execution: any, key: string, index: number) =>
+  execution?.[key] ?? execution?.[index];
+
+const decodePasskeyExecutions = (method: string, executionsArg: any) => {
+  const executions = Array.from(executionsArg || []);
+
+  if (executions.length === 1) {
+    const execution = executions[0];
+
+    return {
+      method,
+      types: ['address', 'uint256', 'bytes', 'uint256', 'uint256'],
+      inputs: [
+        getPasskeyExecutionValue(execution, 'target', 0),
+        getPasskeyExecutionValue(execution, 'value', 1),
+        normalizeBytesValue(getPasskeyExecutionValue(execution, 'data', 2)),
+        getPasskeyExecutionValue(execution, 'nonce', 3),
+        getPasskeyExecutionValue(execution, 'deadline', 4),
+      ],
+      names: ['target', 'value', 'data', 'nonce', 'deadline'],
+    };
+  }
+
+  return executions.reduce<IDecodedTx>(
+    (decoded, execution: any, index) => {
+      decoded.types.push('address', 'uint256', 'bytes', 'uint256', 'uint256');
+      decoded.inputs.push(
+        getPasskeyExecutionValue(execution, 'target', 0),
+        getPasskeyExecutionValue(execution, 'value', 1),
+        normalizeBytesValue(getPasskeyExecutionValue(execution, 'data', 2)),
+        getPasskeyExecutionValue(execution, 'nonce', 3),
+        getPasskeyExecutionValue(execution, 'deadline', 4)
+      );
+      decoded.names.push(
+        `execution${index + 1}Target`,
+        `execution${index + 1}Value`,
+        `execution${index + 1}Data`,
+        `execution${index + 1}Nonce`,
+        `execution${index + 1}Deadline`
+      );
+
+      return decoded;
+    },
+    {
+      method,
+      inputs: [executions.length],
+      names: ['executionCount'],
+      types: ['uint256'],
+    }
+  );
+};
+
+const decodePasskeyTransactionData = (data: string) => {
+  for (const passkeyInterface of [
+    passkeySmartAccountInterface,
+    passkeyFactoryInterface,
+  ]) {
+    try {
+      const parsed = passkeyInterface.parseTransaction({ data });
+
+      if (parsed.name === 'execute') {
+        return decodePasskeyExecutions(parsed.name, parsed.args.executions);
+      }
+
+      if (parsed.name === 'createAccountAndExecute') {
+        return decodePasskeyExecutions(parsed.name, parsed.args.executions);
+      }
+
+      if (parsed.name === 'setSponsor') {
+        return {
+          method: parsed.name,
+          types: ['uint8', 'address', 'string'],
+          inputs: [parsed.args.mode, parsed.args.signer, parsed.args.url],
+          names: ['mode', 'signer', 'url'],
+        };
+      }
+
+      return {
+        method: parsed.name,
+        types: [],
+        inputs: [],
+        names: [],
+      };
+    } catch {
+      // Try the next passkey ABI before falling through to generic decoding.
+    }
+  }
+
+  return null;
+};
+
 export const decodeTransactionData = async (
   params: ITransactionParams,
   web3Provider?: any,
@@ -199,9 +298,18 @@ export const decodeTransactionData = async (
       if (decoderValue.method !== null) return decoderValue;
       const decoderInstance = new InputDataDecoder(JSON.stringify(pegasysABI));
       decoderValue = decoderInstance.decodeData(validatedData);
+      if (decoderValue.method !== null) return decoderValue;
+      const passkeyDecoderValue = decodePasskeyTransactionData(validatedData);
+      if (passkeyDecoderValue) return passkeyDecoderValue;
       if (decoderValue.method === null) {
-        // Try to fetch function signature from 4byte.directory
         const methodId = data.slice(0, 10); // Get first 4 bytes (0x + 8 chars)
+        const knownMethodName = getMethodName(methodId);
+        if (knownMethodName) {
+          decoderValue.method = knownMethodName;
+          return decoderValue;
+        }
+
+        // Try to fetch function signature from 4byte.directory
         const signature = await fetchFunctionSignature(methodId);
         if (signature) {
           decoderValue.method = signature;


### PR DESCRIPTION
## Summary
- Decode Pali passkey smart-account execution calldata before falling back to generic contract interaction.
- Use the existing method-name formatter in the dapp send confirmation popup so decoded methods render through i18n.
- Add localized passkey method names for execute, account creation, account creation plus execution, and sponsor updates.

## Test plan
- yarn type-check
- yarn lint


Made with [Cursor](https://cursor.com)