### PR TITLE
perf(utxo): reduce Blockbook calls per poll cycle and rapid poll

### DIFF
--- a/source/scripts/Background/controllers/assets/index.ts
+++ b/source/scripts/Background/controllers/assets/index.ts
@@ -4,10 +4,18 @@ import {
 } from '@sidhujag/sysweb3-keyring';
 
 import { IAccountAssets } from 'state/vault/types';
+import { CHAIN_IDS } from 'utils/constants';
 
 import EvmAssetsController from './evm';
 import SysAssetsController from './syscoin';
 import { IAssetsManager, IAssetsManagerUtilsResponse } from './types';
+
+// SPT assets only exist on Syscoin UTXO chains; other UTXO networks
+// (e.g. Bitcoin) have no token layer, so skip the Blockbook token call there.
+const SPT_CAPABLE_UTXO_CHAIN_IDS = new Set<number>([
+  CHAIN_IDS.SYSCOIN_MAINNET,
+  CHAIN_IDS.SYSCOIN_TESTNET,
+]);
 
 const AssetsManager = (): IAssetsManager => {
   const updateAssetsFromCurrentAccount = async (
@@ -20,6 +28,11 @@ const AssetsManager = (): IAssetsManager => {
   ): Promise<IAssetsManagerUtilsResponse> => {
     switch (isBitcoinBased) {
       case true:
+        if (!SPT_CAPABLE_UTXO_CHAIN_IDS.has(networkChainId)) {
+          // Non-Syscoin UTXO chain (e.g. BTC): no SPT tokens to fetch
+          return { ...currentAssets };
+        }
+
         const getSysAssets = await SysAssetsController().getSysAssetsByXpub(
           currentAccount.xpub,
           activeNetworkUrl,

--- a/source/scripts/Background/controllers/assets/sptGating.spec.ts
+++ b/source/scripts/Background/controllers/assets/sptGating.spec.ts
@@ -1,0 +1,74 @@
+const getSysAssetsByXpubMock = jest.fn();
+
+jest.mock('./syscoin', () => ({
+  __esModule: true,
+  default: () => ({
+    getSysAssetsByXpub: (...args: any[]) => getSysAssetsByXpubMock(...args),
+  }),
+}));
+
+jest.mock('./evm', () => ({
+  __esModule: true,
+  default: () => ({
+    updateAllEvmTokens: jest.fn().mockResolvedValue([]),
+  }),
+}));
+
+import AssetsManager from './index';
+
+const ACCOUNT = { xpub: 'zpub-test', address: 'sys1q...' } as any;
+const CURRENT_ASSETS = {
+  ethereum: [],
+  syscoin: [{ assetGuid: '123', balance: 1 }],
+} as any;
+
+describe('AssetsManager SPT gating by chain', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getSysAssetsByXpubMock.mockResolvedValue([
+      { assetGuid: '123', balance: 2 },
+    ]);
+  });
+
+  it('fetches SPT assets on Syscoin mainnet (57)', async () => {
+    const result = await AssetsManager().utils.updateAssetsFromCurrentAccount(
+      ACCOUNT,
+      true,
+      'https://blockbook.syscoin.org/',
+      57,
+      undefined as any,
+      CURRENT_ASSETS
+    );
+
+    expect(getSysAssetsByXpubMock).toHaveBeenCalledTimes(1);
+    expect(result.syscoin).toEqual([{ assetGuid: '123', balance: 2 }]);
+  });
+
+  it('fetches SPT assets on Syscoin testnet (5700)', async () => {
+    await AssetsManager().utils.updateAssetsFromCurrentAccount(
+      ACCOUNT,
+      true,
+      'https://blockbook-dev.syscoin.org/',
+      5700,
+      undefined as any,
+      CURRENT_ASSETS
+    );
+
+    expect(getSysAssetsByXpubMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the SPT Blockbook call on non-Syscoin UTXO chains (e.g. BTC)', async () => {
+    const result = await AssetsManager().utils.updateAssetsFromCurrentAccount(
+      ACCOUNT,
+      true,
+      'https://btc1.trezor.io/',
+      0,
+      undefined as any,
+      CURRENT_ASSETS
+    );
+
+    expect(getSysAssetsByXpubMock).not.toHaveBeenCalled();
+    // Existing assets are preserved untouched
+    expect(result).toEqual(CURRENT_ASSETS);
+  });
+});

--- a/source/scripts/Background/controllers/transactions/index.ts
+++ b/source/scripts/Background/controllers/transactions/index.ts
@@ -77,7 +77,8 @@ const TransactionsManager = (): ITransactionsManager => {
     if (isBitcoinBased) {
       result = await SysTransactionController().pollingSysTransactions(
         currentAccount.xpub,
-        activeNetworkUrl
+        activeNetworkUrl,
+        isRapidPolling
       );
     } else {
       // Always pull the latest provider at call time (prevents stale references across network switches)

--- a/source/scripts/Background/controllers/transactions/syscoin.ts
+++ b/source/scripts/Background/controllers/transactions/syscoin.ts
@@ -7,6 +7,55 @@ import { TransactionsType } from 'state/vault/types';
 import { ISysTransaction, ISysTransactionsController } from './types';
 import { treatAndSortTransactions } from './utils';
 
+// Snapshot of the Blockbook account summary captured at the last full
+// `details=txs` fetch. Used by rapid polling to detect whether anything
+// changed via a cheap `details=basic` probe before paying for a full fetch.
+interface IAccountActivitySnapshot {
+  balance: string;
+  txs: number;
+  unconfirmedBalance: string;
+  unconfirmedTxs: number;
+}
+
+const MAX_SNAPSHOT_ENTRIES = 20;
+const accountActivitySnapshots = new Map<string, IAccountActivitySnapshot>();
+
+const getSnapshotKey = (networkUrl: string, xpubOrAddress: string) =>
+  `${networkUrl}::${xpubOrAddress}`;
+
+const buildActivitySnapshot = (accountData: any): IAccountActivitySnapshot => ({
+  balance: String(accountData?.balance ?? ''),
+  txs: Number(accountData?.txs ?? 0),
+  unconfirmedBalance: String(accountData?.unconfirmedBalance ?? ''),
+  unconfirmedTxs: Number(accountData?.unconfirmedTxs ?? 0),
+});
+
+const snapshotsEqual = (
+  a: IAccountActivitySnapshot,
+  b: IAccountActivitySnapshot
+) =>
+  a.txs === b.txs &&
+  a.unconfirmedTxs === b.unconfirmedTxs &&
+  a.balance === b.balance &&
+  a.unconfirmedBalance === b.unconfirmedBalance;
+
+const storeActivitySnapshot = (
+  key: string,
+  snapshot: IAccountActivitySnapshot
+) => {
+  // Simple insertion-order eviction to keep the map bounded
+  if (
+    !accountActivitySnapshots.has(key) &&
+    accountActivitySnapshots.size >= MAX_SNAPSHOT_ENTRIES
+  ) {
+    const oldestKey = accountActivitySnapshots.keys().next().value;
+    if (oldestKey !== undefined) {
+      accountActivitySnapshots.delete(oldestKey);
+    }
+  }
+  accountActivitySnapshots.set(key, snapshot);
+};
+
 const SysTransactionController = (): ISysTransactionsController => {
   const getInitialUserTransactionsByXpub = async (
     xpubOrAddress: string,
@@ -20,6 +69,13 @@ const SysTransactionController = (): ISysTransactionsController => {
       requestOptions,
       true
     );
+
+    // Record the account summary so rapid polling can detect changes cheaply
+    storeActivitySnapshot(
+      getSnapshotKey(networkUrl, xpubOrAddress),
+      buildActivitySnapshot(accountData)
+    );
+
     const transactions = (accountData as any)?.transactions as
       | ISysTransaction[]
       | undefined;
@@ -30,15 +86,11 @@ const SysTransactionController = (): ISysTransactionsController => {
 
   const pollingSysTransactions = async (
     xpubOrAddress: string,
-    networkUrl: string
+    networkUrl: string,
+    isRapidPolling = false
   ): Promise<ISysTransaction[]> => {
     const { activeAccount, activeNetwork, accountTransactions } =
       store.getState().vault;
-
-    const getSysTxs = await getInitialUserTransactionsByXpub(
-      xpubOrAddress,
-      networkUrl
-    );
 
     // Ensure syscoinUserTransactions is always an array
     const syscoinUserTransactions = clone(
@@ -46,6 +98,46 @@ const SysTransactionController = (): ISysTransactionsController => {
         TransactionsType.Syscoin
       ]?.[activeNetwork.chainId] || []
     ) as ISysTransaction[];
+
+    // Rapid polling (post-send confirmation checks) probes the cheap
+    // `details=basic` summary first and only pays for the full
+    // `details=txs` fetch when the account actually changed since the
+    // last full fetch. The basic probe shares the same request the
+    // balance controller fires in the same cycle (deduplicated).
+    if (isRapidPolling) {
+      const snapshotKey = getSnapshotKey(networkUrl, xpubOrAddress);
+      const previousSnapshot = accountActivitySnapshots.get(snapshotKey);
+
+      if (previousSnapshot) {
+        try {
+          const basicData = await fetchBackendAccountCached(
+            networkUrl,
+            xpubOrAddress,
+            'details=basic&pageSize=0',
+            true
+          );
+          const currentSnapshot = buildActivitySnapshot(basicData);
+
+          if (snapshotsEqual(previousSnapshot, currentSnapshot)) {
+            // Nothing changed on the backend - keep current local state
+            return Array.isArray(syscoinUserTransactions)
+              ? syscoinUserTransactions
+              : [];
+          }
+        } catch (error) {
+          // Probe failed - fall through to the full fetch below
+          console.warn(
+            '[SysTransactionController] Rapid poll basic probe failed, falling back to full fetch:',
+            error
+          );
+        }
+      }
+    }
+
+    const getSysTxs = await getInitialUserTransactionsByXpub(
+      xpubOrAddress,
+      networkUrl
+    );
 
     // Ensure both values are arrays before spreading
     const validGetSysTxs = Array.isArray(getSysTxs) ? getSysTxs : [];

--- a/source/scripts/Background/controllers/transactions/syscoinPolling.spec.ts
+++ b/source/scripts/Background/controllers/transactions/syscoinPolling.spec.ts
@@ -1,0 +1,195 @@
+const fetchBackendAccountCachedMock = jest.fn();
+
+jest.mock('../utils/fetchBackendAccountWrapper', () => ({
+  fetchBackendAccountCached: (...args: any[]) =>
+    fetchBackendAccountCachedMock(...args),
+}));
+
+let vaultState: any;
+
+jest.mock('state/store', () => ({
+  __esModule: true,
+  default: {
+    dispatch: jest.fn(),
+    getState: () => ({ vault: vaultState }),
+  },
+}));
+
+import SysTransactionController from './syscoin';
+
+const CHAIN_ID = 57;
+const URL = 'https://blockbook.test/';
+
+const buildVaultState = (localTxs: any[]) => ({
+  activeAccount: { type: 'HDAccount', id: 0 },
+  activeNetwork: { chainId: CHAIN_ID },
+  accountTransactions: {
+    HDAccount: {
+      0: {
+        syscoin: {
+          [CHAIN_ID]: localTxs,
+        },
+      },
+    },
+  },
+});
+
+const txsResponse = (overrides: any = {}) => ({
+  balance: '100000000',
+  unconfirmedBalance: '0',
+  txs: 1,
+  unconfirmedTxs: 0,
+  transactions: [
+    {
+      txid: 'tx1',
+      confirmations: 10,
+      blockTime: 1700000000,
+      value: '100000000',
+    },
+  ],
+  ...overrides,
+});
+
+describe('SysTransactionController rapid polling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    vaultState = buildVaultState([]);
+  });
+
+  it('regular polling always performs the full details=txs fetch', async () => {
+    // Use a unique xpub per test: the activity snapshot map is module-level
+    const xpub = 'zpub-regular-poll';
+    fetchBackendAccountCachedMock.mockResolvedValueOnce(txsResponse());
+
+    const controller = SysTransactionController();
+    const result = await controller.pollingSysTransactions(xpub, URL, false);
+
+    expect(fetchBackendAccountCachedMock).toHaveBeenCalledTimes(1);
+    expect(fetchBackendAccountCachedMock).toHaveBeenCalledWith(
+      URL,
+      xpub,
+      'details=txs&pageSize=30',
+      true
+    );
+    expect(result.map((tx: any) => tx.txid)).toEqual(['tx1']);
+  });
+
+  it('rapid polling skips the full fetch when the basic summary is unchanged', async () => {
+    const xpub = 'zpub-rapid-unchanged';
+    const controller = SysTransactionController();
+
+    // Seed the activity snapshot with a full fetch
+    fetchBackendAccountCachedMock.mockResolvedValueOnce(txsResponse());
+    await controller.pollingSysTransactions(xpub, URL, false);
+
+    const localTxs = [{ txid: 'tx1', confirmations: 10 }];
+    vaultState = buildVaultState(localTxs);
+
+    // Rapid poll: basic probe reports the same summary -> no txs fetch
+    fetchBackendAccountCachedMock.mockClear();
+    fetchBackendAccountCachedMock.mockResolvedValueOnce({
+      balance: '100000000',
+      unconfirmedBalance: '0',
+      txs: 1,
+      unconfirmedTxs: 0,
+    });
+
+    const result = await controller.pollingSysTransactions(xpub, URL, true);
+
+    expect(fetchBackendAccountCachedMock).toHaveBeenCalledTimes(1);
+    expect(fetchBackendAccountCachedMock).toHaveBeenCalledWith(
+      URL,
+      xpub,
+      'details=basic&pageSize=0',
+      true
+    );
+    // Local state is returned untouched
+    expect(result).toEqual(localTxs);
+  });
+
+  it('rapid polling performs the full fetch when the summary changed', async () => {
+    const xpub = 'zpub-rapid-changed';
+    const controller = SysTransactionController();
+
+    fetchBackendAccountCachedMock.mockResolvedValueOnce(txsResponse());
+    await controller.pollingSysTransactions(xpub, URL, false);
+
+    fetchBackendAccountCachedMock.mockClear();
+    // Basic probe: a new unconfirmed tx appeared
+    fetchBackendAccountCachedMock
+      .mockResolvedValueOnce({
+        balance: '100000000',
+        unconfirmedBalance: '-50000000',
+        txs: 1,
+        unconfirmedTxs: 1,
+      })
+      .mockResolvedValueOnce(
+        txsResponse({
+          txs: 1,
+          unconfirmedTxs: 1,
+          unconfirmedBalance: '-50000000',
+          transactions: [
+            { txid: 'tx2', confirmations: 0, blockTime: 1700000100 },
+            {
+              txid: 'tx1',
+              confirmations: 10,
+              blockTime: 1700000000,
+            },
+          ],
+        })
+      );
+
+    const result = await controller.pollingSysTransactions(xpub, URL, true);
+
+    expect(fetchBackendAccountCachedMock).toHaveBeenCalledTimes(2);
+    expect(fetchBackendAccountCachedMock).toHaveBeenNthCalledWith(
+      1,
+      URL,
+      xpub,
+      'details=basic&pageSize=0',
+      true
+    );
+    expect(fetchBackendAccountCachedMock).toHaveBeenNthCalledWith(
+      2,
+      URL,
+      xpub,
+      'details=txs&pageSize=30',
+      true
+    );
+    expect(result.some((tx: any) => tx.txid === 'tx2')).toBe(true);
+  });
+
+  it('rapid polling without a prior snapshot goes straight to the full fetch', async () => {
+    const xpub = 'zpub-rapid-no-snapshot';
+    fetchBackendAccountCachedMock.mockResolvedValueOnce(txsResponse());
+
+    const controller = SysTransactionController();
+    await controller.pollingSysTransactions(xpub, URL, true);
+
+    expect(fetchBackendAccountCachedMock).toHaveBeenCalledTimes(1);
+    expect(fetchBackendAccountCachedMock).toHaveBeenCalledWith(
+      URL,
+      xpub,
+      'details=txs&pageSize=30',
+      true
+    );
+  });
+
+  it('rapid polling falls back to the full fetch when the basic probe fails', async () => {
+    const xpub = 'zpub-rapid-probe-fail';
+    const controller = SysTransactionController();
+
+    fetchBackendAccountCachedMock.mockResolvedValueOnce(txsResponse());
+    await controller.pollingSysTransactions(xpub, URL, false);
+
+    fetchBackendAccountCachedMock.mockClear();
+    fetchBackendAccountCachedMock
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValueOnce(txsResponse());
+
+    const result = await controller.pollingSysTransactions(xpub, URL, true);
+
+    expect(fetchBackendAccountCachedMock).toHaveBeenCalledTimes(2);
+    expect(result.map((tx: any) => tx.txid)).toEqual(['tx1']);
+  });
+});

--- a/source/scripts/Background/controllers/transactions/types.ts
+++ b/source/scripts/Background/controllers/transactions/types.ts
@@ -204,7 +204,8 @@ export interface ISysTransactionsController {
   ) => Promise<ISysTransaction[]>;
   pollingSysTransactions: (
     xpub: string,
-    networkUrl: string
+    networkUrl: string,
+    isRapidPolling?: boolean
   ) => Promise<ISysTransaction[]>;
 }
 

--- a/source/scripts/Background/controllers/utils/fetchBackendAccountWrapper.spec.ts
+++ b/source/scripts/Background/controllers/utils/fetchBackendAccountWrapper.spec.ts
@@ -1,0 +1,113 @@
+const fetchBackendAccountMock = jest.fn();
+
+jest.mock('syscoinjs-lib', () => ({
+  utils: {
+    fetchBackendAccount: (...args: any[]) => fetchBackendAccountMock(...args),
+  },
+}));
+
+import {
+  fetchBackendAccountCached,
+  clearFetchBackendAccountCache,
+} from './fetchBackendAccountWrapper';
+
+const XPUB = 'zpub6rABCDEF0123456789';
+const URL = 'https://blockbook.test/';
+
+const deferred = () => {
+  let resolve!: (value: any) => void;
+  let reject!: (reason?: any) => void;
+  const promise = new Promise<any>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+describe('fetchBackendAccountCached', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearFetchBackendAccountCache();
+  });
+
+  it('deduplicates identical in-flight requests', async () => {
+    const d = deferred();
+    fetchBackendAccountMock.mockReturnValueOnce(d.promise);
+
+    const p1 = fetchBackendAccountCached(
+      URL,
+      XPUB,
+      'details=txs&pageSize=30',
+      true
+    );
+    const p2 = fetchBackendAccountCached(
+      URL,
+      XPUB,
+      'details=txs&pageSize=30',
+      true
+    );
+
+    expect(fetchBackendAccountMock).toHaveBeenCalledTimes(1);
+
+    d.resolve({ balance: '1' });
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1).toEqual({ balance: '1' });
+    expect(r2).toEqual({ balance: '1' });
+  });
+
+  it('satisfies a basic request from an in-flight higher-level request (same xpub)', async () => {
+    const d = deferred();
+    fetchBackendAccountMock.mockReturnValueOnce(d.promise);
+
+    const txsPromise = fetchBackendAccountCached(
+      URL,
+      XPUB,
+      'details=txs&pageSize=30',
+      true
+    );
+    const basicPromise = fetchBackendAccountCached(
+      URL,
+      XPUB,
+      'details=basic&pageSize=0',
+      true
+    );
+
+    // Only ONE network call for both the heavy txs fetch and the basic probe
+    expect(fetchBackendAccountMock).toHaveBeenCalledTimes(1);
+
+    d.resolve({ balance: '5', txs: 2, transactions: [] });
+    const [txsResult, basicResult] = await Promise.all([
+      txsPromise,
+      basicPromise,
+    ]);
+    // The basic probe receives the full higher-level response (a superset)
+    expect(basicResult).toEqual(txsResult);
+    expect(basicResult.balance).toBe('5');
+  });
+
+  it('does NOT upgrade a basic in-flight request to satisfy a txs request', async () => {
+    const basicD = deferred();
+    const txsD = deferred();
+    fetchBackendAccountMock
+      .mockReturnValueOnce(basicD.promise)
+      .mockReturnValueOnce(txsD.promise);
+
+    fetchBackendAccountCached(URL, XPUB, 'details=basic&pageSize=0', true);
+    fetchBackendAccountCached(URL, XPUB, 'details=txs&pageSize=30', true);
+
+    // basic cannot serve txs (txs has fields basic lacks), so a second call fires
+    expect(fetchBackendAccountMock).toHaveBeenCalledTimes(2);
+
+    basicD.resolve({ balance: '1' });
+    txsD.resolve({ balance: '1', transactions: [] });
+  });
+
+  it('does not share requests across different xpubs', async () => {
+    fetchBackendAccountMock.mockReturnValue(deferred().promise);
+
+    fetchBackendAccountCached(URL, XPUB, 'details=txs', true);
+    fetchBackendAccountCached(URL, 'zpubDIFFERENT', 'details=basic', true);
+
+    expect(fetchBackendAccountMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/source/scripts/Background/controllers/utils/fetchBackendAccountWrapper.ts
+++ b/source/scripts/Background/controllers/utils/fetchBackendAccountWrapper.ts
@@ -5,7 +5,9 @@ const requestCache = new Map<
   string,
   {
     abortController?: AbortController;
+    detailsLevel: number;
     promise: Promise<any>;
+    scopeKey: string;
     timestamp: number;
   }
 >();
@@ -25,20 +27,47 @@ const cleanupCache = () => {
   });
 };
 
-// Create a unique key for the request
-const createRequestKey = (
+// Blockbook `details=` levels are strictly cumulative: every level includes the
+// summary fields (balance, unconfirmedBalance, txs, unconfirmedTxs, ...) that a
+// `details=basic` response carries. This lets a basic request piggyback on any
+// in-flight higher-level request for the same xpub/address.
+const DETAILS_LEVEL_RANK: Record<string, number> = {
+  basic: 1,
+  tokens: 2,
+  tokenBalances: 3,
+  txids: 4,
+  txslight: 5,
+  txs: 6,
+};
+
+const BASIC_LEVEL = DETAILS_LEVEL_RANK.basic;
+
+const parseDetailsLevel = (requestOptions: string): number => {
+  const match = /(?:^|&)details=([^&]*)/.exec(requestOptions);
+  // Blockbook defaults to txids when details is omitted
+  if (!match) return DETAILS_LEVEL_RANK.txids;
+  return DETAILS_LEVEL_RANK[match[1]] ?? 0;
+};
+
+// Scope key identifies the account being queried, regardless of detail options
+const createScopeKey = (
   networkUrl: string,
   xpubOrAddress: string,
-  requestOptions: string,
   isXpub: boolean
-): string =>
-  `${networkUrl}::${
-    isXpub ? 'xpub' : 'addr'
-  }::${xpubOrAddress}::${requestOptions}`;
+): string => `${networkUrl}::${isXpub ? 'xpub' : 'addr'}::${xpubOrAddress}`;
+
+// Create a unique key for the request
+const createRequestKey = (scopeKey: string, requestOptions: string): string =>
+  `${scopeKey}::${requestOptions}`;
 
 /**
  * Wrapper around sys.utils.fetchBackendAccount that provides request deduplication
- * This prevents multiple identical requests from being made simultaneously
+ * This prevents multiple identical requests from being made simultaneously.
+ *
+ * It is also level-aware: a `details=basic` request is satisfied by any in-flight
+ * request for the same xpub/address at a higher detail level (Blockbook levels are
+ * cumulative), consolidating the balance fetch with the heavier transaction/token
+ * fetches fired in the same poll cycle.
  */
 export const fetchBackendAccountCached = async (
   networkUrl: string,
@@ -58,12 +87,9 @@ export const fetchBackendAccountCached = async (
     );
   const isXpub = looksLikeXpub || looksLikeDescriptor;
 
-  const cacheKey = createRequestKey(
-    networkUrl,
-    xpubOrAddress,
-    requestOptions,
-    isXpub
-  );
+  const scopeKey = createScopeKey(networkUrl, xpubOrAddress, isXpub);
+  const cacheKey = createRequestKey(scopeKey, requestOptions);
+  const detailsLevel = parseDetailsLevel(requestOptions);
 
   // Check if we have an in-flight request for the same parameters
   const cachedEntry = requestCache.get(cacheKey);
@@ -72,6 +98,19 @@ export const fetchBackendAccountCached = async (
       `[fetchBackendAccountWrapper] Using in-flight request for ${cacheKey}`
     );
     return cachedEntry.promise;
+  }
+
+  // Level-aware reuse: a basic request only needs the summary fields, which every
+  // Blockbook response includes, so any in-flight request for this account works.
+  if (detailsLevel === BASIC_LEVEL) {
+    for (const entry of requestCache.values()) {
+      if (entry.scopeKey === scopeKey && entry.detailsLevel >= BASIC_LEVEL) {
+        console.log(
+          `[fetchBackendAccountWrapper] Satisfying basic request from in-flight higher-level request for ${scopeKey}`
+        );
+        return entry.promise;
+      }
+    }
   }
 
   // Create abort controller for this request
@@ -104,6 +143,8 @@ export const fetchBackendAccountCached = async (
     promise: requestPromise,
     timestamp: Date.now(),
     abortController,
+    detailsLevel,
+    scopeKey,
   });
 
   // Clean up cache entry after request completes


### PR DESCRIPTION
## Summary

- **Level-aware request reuse** in `fetchBackendAccountCached`: `details=basic` piggybacks on any in-flight higher-level request for the same xpub (Blockbook detail levels are cumulative), so the balance fetch shares the txs/tokenBalances request fired in the same poll cycle (3 calls -> 2 per cycle, 1 on BTC).
- **Rapid polling probe**: post-send confirmation checks probe `details=basic` and only pay for the full `details=txs&pageSize=30` fetch when the account summary (txs/unconfirmedTxs/balances) changed since the last full fetch; the probe dedups with the balance call.
- **SPT gating**: skip the `details=tokenBalances&tokens=nonzero` asset poll on non-Syscoin UTXO chains (BTC has no token layer).

Pairs with sidhujag/sysweb3 PR "perf(keyring,utils): reduce Blockbook round trips in UTXO flows" (fee/raw-tx caches + account fetch dedup).

## Test plan

- [x] New specs: fetchBackendAccountWrapper.spec.ts, syscoinPolling.spec.ts, sptGating.spec.ts
- [x] Full jest suite: 304 tests green; only pre-existing failures are the Playwright e2e/journeys specs picked up by jest (fail identically on clean master)
- [x] eslint + tsc --noEmit clean
- [ ] Manual: SYS/BTC polling + post-send rapid poll against public Blockbook after sysweb3 link
