### PR TITLE
fix(smart-account): reset local recovery state when the scheduled operation expired on-chain

### DIFF
--- a/source/assets/locales/de.json
+++ b/source/assets/locales/de.json
@@ -636,6 +636,7 @@
     "smartAccountGuardianRecoveryAlreadyStarted": "Für dieses Konto steht bereits eine Wiederherstellung aus. Schließen Sie sie ab, falls noch möglich, oder warten Sie, bis sie abläuft, bevor Sie eine neue starten.",
     "smartAccountGuardianRecoveryFinalized": "Wiederherstellung abgeschlossen und dieses Konto ist bereit.",
     "smartAccountGuardianRecoveryFinalizeFailed": "Wiederherstellung konnte nicht abgeschlossen werden.",
+    "smartAccountGuardianRecoveryExpired": "Diese Wiederherstellungsanfrage ist abgelaufen, bevor sie abgeschlossen wurde. Starten Sie die Wiederherstellung erneut.",
     "invalidAddress": "Ungültige Adresse"
   },
   "start": {

--- a/source/assets/locales/en.json
+++ b/source/assets/locales/en.json
@@ -636,6 +636,7 @@
     "smartAccountGuardianRecoveryAlreadyStarted": "A recovery is already pending for this account. Finish it if you still can, or wait for it to expire before starting a new one.",
     "smartAccountGuardianRecoveryFinalized": "Recovery finished and this account is ready.",
     "smartAccountGuardianRecoveryFinalizeFailed": "Failed to finish recovery.",
+    "smartAccountGuardianRecoveryExpired": "This recovery request expired before it was finished. Start recovery again.",
     "invalidAddress": "Invalid address"
   },
   "start": {

--- a/source/assets/locales/es.json
+++ b/source/assets/locales/es.json
@@ -636,6 +636,7 @@
     "smartAccountGuardianRecoveryAlreadyStarted": "Ya hay una recuperación pendiente para esta cuenta. Finalícela si aún puede, o espere a que expire antes de iniciar una nueva.",
     "smartAccountGuardianRecoveryFinalized": "Recuperación finalizada y esta cuenta está lista.",
     "smartAccountGuardianRecoveryFinalizeFailed": "No se pudo finalizar la recuperación.",
+    "smartAccountGuardianRecoveryExpired": "Esta solicitud de recuperación expiró antes de finalizarse. Inicie la recuperación de nuevo.",
     "invalidAddress": "Dirección inválida"
   },
   "start": {

--- a/source/assets/locales/fr.json
+++ b/source/assets/locales/fr.json
@@ -636,6 +636,7 @@
     "smartAccountGuardianRecoveryAlreadyStarted": "Une récupération est déjà en attente pour ce compte. Terminez-la si vous le pouvez encore, ou attendez son expiration avant d'en lancer une nouvelle.",
     "smartAccountGuardianRecoveryFinalized": "Récupération terminée et ce compte est prêt.",
     "smartAccountGuardianRecoveryFinalizeFailed": "Impossible de terminer la récupération.",
+    "smartAccountGuardianRecoveryExpired": "Cette demande de récupération a expiré avant d'être terminée. Relancez la récupération.",
     "invalidAddress": "Adresse invalide"
   },
   "start": {

--- a/source/assets/locales/ja.json
+++ b/source/assets/locales/ja.json
@@ -636,6 +636,7 @@
     "smartAccountGuardianRecoveryAlreadyStarted": "このアカウントには保留中の復元がすでにあります。可能であればそれを完了するか、期限切れになるのを待ってから新しい復元を開始してください。",
     "smartAccountGuardianRecoveryFinalized": "復元が完了し、このアカウントを使用できます。",
     "smartAccountGuardianRecoveryFinalizeFailed": "復元を完了できませんでした。",
+    "smartAccountGuardianRecoveryExpired": "この復元リクエストは完了前に期限切れになりました。もう一度復元を開始してください。",
     "invalidAddress": "無効なアドレスです"
   },
   "start": {

--- a/source/assets/locales/ko.json
+++ b/source/assets/locales/ko.json
@@ -636,6 +636,7 @@
     "smartAccountGuardianRecoveryAlreadyStarted": "이 계정에 대한 복구가 이미 대기 중입니다. 가능하면 완료하시고, 그렇지 않으면 만료될 때까지 기다린 후 새 복구를 시작하세요.",
     "smartAccountGuardianRecoveryFinalized": "복구가 완료되었고 이 계정을 사용할 수 있습니다.",
     "smartAccountGuardianRecoveryFinalizeFailed": "복구를 완료하지 못했습니다.",
+    "smartAccountGuardianRecoveryExpired": "이 복구 요청은 완료되기 전에 만료되었습니다. 복구를 다시 시작하세요.",
     "invalidAddress": "유효하지 않은 주소입니다"
   },
   "start": {

--- a/source/assets/locales/pt.json
+++ b/source/assets/locales/pt.json
@@ -636,6 +636,7 @@
     "smartAccountGuardianRecoveryAlreadyStarted": "Já existe uma recuperação pendente para esta conta. Conclua-a se ainda puder, ou aguarde que expire antes de iniciar uma nova.",
     "smartAccountGuardianRecoveryFinalized": "Recuperação finalizada e esta conta está pronta.",
     "smartAccountGuardianRecoveryFinalizeFailed": "Falha ao finalizar a recuperação.",
+    "smartAccountGuardianRecoveryExpired": "Este pedido de recuperação expirou antes de ser concluído. Inicie a recuperação novamente.",
     "invalidAddress": "Endereço inválido"
   },
   "start": {

--- a/source/assets/locales/ru.json
+++ b/source/assets/locales/ru.json
@@ -636,6 +636,7 @@
     "smartAccountGuardianRecoveryAlreadyStarted": "Для этого аккаунта уже есть ожидающее восстановление. Завершите его, если можете, или дождитесь его истечения, прежде чем начинать новое.",
     "smartAccountGuardianRecoveryFinalized": "Восстановление завершено, аккаунт готов.",
     "smartAccountGuardianRecoveryFinalizeFailed": "Не удалось завершить восстановление.",
+    "smartAccountGuardianRecoveryExpired": "Срок этого запроса на восстановление истёк до его завершения. Начните восстановление заново.",
     "invalidAddress": "Недействительный адрес"
   },
   "start": {

--- a/source/assets/locales/zh.json
+++ b/source/assets/locales/zh.json
@@ -636,6 +636,7 @@
     "smartAccountGuardianRecoveryAlreadyStarted": "此账户已有待处理的恢复。如果仍然可以，请完成它；否则请等待其过期后再开始新的恢复。",
     "smartAccountGuardianRecoveryFinalized": "恢复已完成，此账户已可使用。",
     "smartAccountGuardianRecoveryFinalizeFailed": "完成恢复失败。",
+    "smartAccountGuardianRecoveryExpired": "此恢复请求在完成前已过期。请重新开始恢复。",
     "invalidAddress": "无效地址"
   },
   "start": {

--- a/source/pages/Settings/SmartAccountPolicy.tsx
+++ b/source/pages/Settings/SmartAccountPolicy.tsx
@@ -53,6 +53,7 @@ import type {
 import {
   getSmartAccountActionErrorMessage,
   isGuardianRecoveryAlreadyScheduledError,
+  isGuardianRecoveryExpiredError,
   isGuardianRecoveryNotReadyError,
   isNativeGasError,
   isSmartAccountPrefundError,
@@ -1268,6 +1269,18 @@ const SmartAccountPolicy = () => {
     } catch (error: any) {
       const wasHandled = handleWalletLockedError(error);
       if (!wasHandled) {
+        if (isGuardianRecoveryExpiredError(error)) {
+          // The scheduled operation expired on-chain and can never be
+          // executed. Drop it from local state (keeping the replacement
+          // credential so a retry reuses the already-created passkey) so
+          // the user can start a fresh recovery.
+          storeGuardianReplacementCredential({
+            ...activeGuardianReplacement,
+            recoveryOperation: undefined,
+          });
+          alert.error(t('settings.smartAccountGuardianRecoveryExpired'));
+          return;
+        }
         const errorMessage = isGuardianRecoveryNotReadyError(error)
           ? activeGuardianReplacement.recoveryOperation.readyAt * 1000 <=
             Date.now()

--- a/source/scripts/Background/controllers/smartAccount/index.ts
+++ b/source/scripts/Background/controllers/smartAccount/index.ts
@@ -146,6 +146,9 @@ const GUARDIAN_RECOVERY_NOT_READY_SELECTOR = '0x201b632a';
 const GUARDIAN_RECOVERY_ALREADY_SCHEDULED_ERROR =
   'PALI_GUARDIAN_RECOVERY_ALREADY_SCHEDULED';
 const GUARDIAN_RECOVERY_ALREADY_SCHEDULED_SELECTOR = '0x684d1639';
+// RecoveryExpired(bytes32) on the guardian recovery module.
+const GUARDIAN_RECOVERY_EXPIRED_ERROR = 'PALI_GUARDIAN_RECOVERY_EXPIRED';
+const GUARDIAN_RECOVERY_EXPIRED_SELECTOR = '0x80ba2533';
 const NATIVE_GAS_REQUIRED_ERROR = 'PALI_NATIVE_GAS_REQUIRED';
 const SMART_ACCOUNT_SIGNATURE_ERROR = 'PALI_SMART_ACCOUNT_SIGNATURE_ERROR';
 const ENTRYPOINT_FAILED_OP_SELECTOR = '0x220266b6';
@@ -220,6 +223,9 @@ const hasGuardianRecoveryNotReadyRevert = (error: unknown): boolean =>
 
 const hasGuardianRecoveryAlreadyScheduledRevert = (error: unknown): boolean =>
   getErrorText(error).includes(GUARDIAN_RECOVERY_ALREADY_SCHEDULED_SELECTOR);
+
+const hasGuardianRecoveryExpiredRevert = (error: unknown): boolean =>
+  getErrorText(error).includes(GUARDIAN_RECOVERY_EXPIRED_SELECTOR);
 
 const getEntryPointFailedOpReason = (error: unknown): string => {
   const message = getErrorText(error);
@@ -1472,6 +1478,9 @@ class SmartAccountController {
     } catch (error) {
       if (hasGuardianRecoveryNotReadyRevert(error)) {
         throw new Error(GUARDIAN_RECOVERY_NOT_READY_ERROR);
+      }
+      if (hasGuardianRecoveryExpiredRevert(error)) {
+        throw new Error(GUARDIAN_RECOVERY_EXPIRED_ERROR);
       }
       if (hasNativeGasFailure(error)) {
         throw new Error(NATIVE_GAS_REQUIRED_ERROR);

--- a/source/scripts/Background/handlers/handleMasterControllerResponses.ts
+++ b/source/scripts/Background/handlers/handleMasterControllerResponses.ts
@@ -12,6 +12,8 @@ const GUARDIAN_RECOVERY_ALREADY_SCHEDULED_ERROR =
   'PALI_GUARDIAN_RECOVERY_ALREADY_SCHEDULED';
 const GUARDIAN_RECOVERY_NOT_READY_SELECTOR = '0x201b632a';
 const GUARDIAN_RECOVERY_NOT_READY_ERROR = 'PALI_GUARDIAN_RECOVERY_NOT_READY';
+const GUARDIAN_RECOVERY_EXPIRED_SELECTOR = '0x80ba2533';
+const GUARDIAN_RECOVERY_EXPIRED_ERROR = 'PALI_GUARDIAN_RECOVERY_EXPIRED';
 
 const stringifyControllerError = (error: unknown): string => {
   if (!error || typeof error !== 'object') {
@@ -82,6 +84,9 @@ const normalizeControllerErrorMessage = (error: unknown): string => {
   }
   if (errorText.includes(GUARDIAN_RECOVERY_NOT_READY_SELECTOR)) {
     return GUARDIAN_RECOVERY_NOT_READY_ERROR;
+  }
+  if (errorText.includes(GUARDIAN_RECOVERY_EXPIRED_SELECTOR)) {
+    return GUARDIAN_RECOVERY_EXPIRED_ERROR;
   }
 
   return extractErrorMessage(error, 'Unknown error');

--- a/source/utils/smartAccountErrors.ts
+++ b/source/utils/smartAccountErrors.ts
@@ -146,6 +146,11 @@ export const isGuardianRecoveryAlreadyScheduledError = (
   getErrorText(error).includes('0x684d1639') ||
   getErrorText(error).includes('PALI_GUARDIAN_RECOVERY_ALREADY_SCHEDULED');
 
+/** RecoveryExpired(bytes32) from the guardian recovery module. */
+export const isGuardianRecoveryExpiredError = (error: unknown): boolean =>
+  getErrorText(error).includes('0x80ba2533') ||
+  getErrorText(error).includes('PALI_GUARDIAN_RECOVERY_EXPIRED');
+
 /** AA24: the userOp signature was rejected by the account's validator. */
 export const isSmartAccountSignatureError = (error: unknown): boolean => {
   const message = getErrorText(error);


### PR DESCRIPTION
## Summary
- A guardian recovery past its expiration window (`delay + expiration`) can never execute: `executeRecovery` reverts with `RecoveryExpired(bytes32)` (`0x80ba2533`). The wallet only stored `readyAt` locally and disabled "Start recovery" whenever a local recovery operation existed — so an expired recovery left the user wedged: Finish always failed with the generic message and Start stayed disabled, even though the module accepts a fresh `scheduleRecovery` over an expired one.
- Detect `RecoveryExpired` via selector + `PALI_GUARDIAN_RECOVERY_EXPIRED` sentinel in the background finalize flow and at the controller message boundary (same pattern as `RecoveryNotReady` / `RecoveryAlreadyScheduled` from #792).
- On expiry, drop the stored `recoveryOperation` (keeping the replacement credential so a retry reuses the already-created passkey instead of minting another) and surface a dedicated "recovery expired, start again" message in all 9 locales. "Start recovery" becomes available again immediately.
- Reset is reactive (driven by the on-chain revert) rather than predicted from local clocks: the expiration window isn't stored locally and the chain is the source of truth.

## Test plan
- [ ] Schedule a recovery, let it pass `delay + expiration`, press Finish → expired message, pending banner clears, Start recovery re-enabled
- [ ] Start a fresh recovery afterwards → schedules successfully over the expired operation
- [ ] Finalize before `readyAt` → still shows the "ready at ..." message
- [ ] Normal finalize within the window → unchanged behavior

Made with [Cursor](https://cursor.com)