### PR TITLE
fix(syscoin): stabilize txsummary polling and pagination

### DIFF
--- a/source/pages/Home/Panel/components/Transactions/UTXO/UtxoList.tsx
+++ b/source/pages/Home/Panel/components/Transactions/UTXO/UtxoList.tsx
@@ -512,6 +512,8 @@ export const UtxoTransactionsList = ({
                       setNextPage((p) => p + 1);
                       if (newTxs.length < SERVER_PAGE_SIZE)
                         setHasMoreServer(false);
+                    } else if (newTxs.length >= SERVER_PAGE_SIZE) {
+                      setNextPage((p) => p + 1);
                     } else {
                       setHasMoreServer(false);
                     }

--- a/source/pages/Home/Panel/components/Transactions/UTXO/UtxoList.tsx
+++ b/source/pages/Home/Panel/components/Transactions/UTXO/UtxoList.tsx
@@ -32,6 +32,8 @@ import {
 } from 'utils/syscoinTransactionUtils';
 import { isTransactionInBlock } from 'utils/transactionUtils';
 
+const SERVER_PAGE_SIZE = 30;
+
 const getSummaryAccountDelta = (tx: any): string | null => {
   if (tx?.addressValueIn === undefined && tx?.addressValueOut === undefined) {
     return null;
@@ -455,9 +457,15 @@ export const UtxoTransactionsList = ({
   useEffect(() => {
     setExtraTransactions([]);
     setNextPage(2);
-    setHasMoreServer(true);
+    setHasMoreServer(userTransactions.length >= SERVER_PAGE_SIZE);
     setVisibleCount(50);
-  }, [currentAccount?.address, currentAccount?.xpub, chainId, networkUrl]);
+  }, [
+    currentAccount?.address,
+    currentAccount?.xpub,
+    chainId,
+    networkUrl,
+    userTransactions.length,
+  ]);
 
   return (
     <>
@@ -484,13 +492,26 @@ export const UtxoTransactionsList = ({
                       throw new Error('Missing account identifier');
                     const res = (await controllerEmitter(
                       ['wallet', 'getSysTransactionsPage'],
-                      [accountKey, networkUrl, nextPage, 30]
+                      [accountKey, networkUrl, nextPage, SERVER_PAGE_SIZE]
                     )) as any[];
                     const newTxs = Array.isArray(res) ? res : [];
-                    if (newTxs.length > 0) {
-                      setExtraTransactions((prev) => [...prev, ...newTxs]);
+                    const knownTxids = new Set(
+                      [...userTransactions, ...extraTransactions]
+                        .map((tx) => tx.txid)
+                        .filter(Boolean)
+                    );
+                    const uniqueNewTxs = newTxs.filter(
+                      (tx) => tx?.txid && !knownTxids.has(tx.txid)
+                    );
+
+                    if (uniqueNewTxs.length > 0) {
+                      setExtraTransactions((prev) => [
+                        ...prev,
+                        ...uniqueNewTxs,
+                      ]);
                       setNextPage((p) => p + 1);
-                      if (newTxs.length < 30) setHasMoreServer(false);
+                      if (newTxs.length < SERVER_PAGE_SIZE)
+                        setHasMoreServer(false);
                     } else {
                       setHasMoreServer(false);
                     }

--- a/source/pages/Home/Panel/components/Transactions/UTXO/UtxoList.tsx
+++ b/source/pages/Home/Panel/components/Transactions/UTXO/UtxoList.tsx
@@ -359,6 +359,10 @@ export const UtxoTransactionsList = ({
   const [extraTransactions, setExtraTransactions] = useState<
     ITransactionInfoUtxo[]
   >([]);
+  const baseTransactionsKey = useMemo(
+    () => userTransactions.map((tx) => tx.txid).join('|'),
+    [userTransactions]
+  );
   const combined = useMemo(() => {
     if (!extraTransactions.length) return userTransactions;
     const seen = new Set<string>();
@@ -465,6 +469,7 @@ export const UtxoTransactionsList = ({
     chainId,
     networkUrl,
     userTransactions.length,
+    baseTransactionsKey,
   ]);
 
   return (
@@ -512,8 +517,6 @@ export const UtxoTransactionsList = ({
                       setNextPage((p) => p + 1);
                       if (newTxs.length < SERVER_PAGE_SIZE)
                         setHasMoreServer(false);
-                    } else if (newTxs.length >= SERVER_PAGE_SIZE) {
-                      setNextPage((p) => p + 1);
                     } else {
                       setHasMoreServer(false);
                     }

--- a/source/scripts/Background/controllers/transactions/syscoin.ts
+++ b/source/scripts/Background/controllers/transactions/syscoin.ts
@@ -41,7 +41,10 @@ const getHistoryRequestOptions = (
 
 const buildActivitySnapshot = (accountData: any): IAccountActivitySnapshot => ({
   balance: String(accountData?.balance ?? ''),
-  txs: Number(accountData?.txs ?? 0),
+  // XPUB `details=basic` may expose the per-address aggregate count while
+  // history details expose deduplicated wallet transactions. Compare the stable
+  // aggregate when Blockbook provides it.
+  txs: Number(accountData?.addrTxCount ?? accountData?.txs ?? 0),
   unconfirmedBalance: String(accountData?.unconfirmedBalance ?? ''),
   unconfirmedTxs: Number(accountData?.unconfirmedTxs ?? 0),
 });

--- a/source/scripts/Background/controllers/transactions/syscoinPolling.spec.ts
+++ b/source/scripts/Background/controllers/transactions/syscoinPolling.spec.ts
@@ -262,6 +262,50 @@ describe('SysTransactionController rapid polling', () => {
     expect(result).toEqual(localTxs);
   });
 
+  it('rapid polling compares addrTxCount when txsummary deduplicates xpub transactions', async () => {
+    const xpub = 'zpub-rapid-xpub-deduped-count';
+    const controller = SysTransactionController();
+
+    fetchBackendAccountCachedMock.mockResolvedValueOnce(
+      txsResponse({
+        txs: 9,
+        addrTxCount: 10,
+        transactions: [
+          {
+            txid: 'tx1',
+            confirmations: 10,
+            blockTime: 1700000000,
+            value: '100000000',
+          },
+        ],
+      })
+    );
+    await controller.pollingSysTransactions(xpub, URL, false);
+
+    const localTxs = [{ txid: 'tx1', confirmations: 10 }];
+    vaultState = buildVaultState(localTxs);
+
+    fetchBackendAccountCachedMock.mockClear();
+    fetchBackendAccountCachedMock.mockResolvedValueOnce({
+      balance: '100000000',
+      unconfirmedBalance: '0',
+      txs: 10,
+      addrTxCount: 10,
+      unconfirmedTxs: 0,
+    });
+
+    const result = await controller.pollingSysTransactions(xpub, URL, true);
+
+    expect(fetchBackendAccountCachedMock).toHaveBeenCalledTimes(1);
+    expect(fetchBackendAccountCachedMock).toHaveBeenCalledWith(
+      URL,
+      xpub,
+      'details=basic&pageSize=0',
+      true
+    );
+    expect(result).toEqual(localTxs);
+  });
+
   it('rapid polling performs the history fetch when the summary changed', async () => {
     const xpub = 'zpub-rapid-changed';
     const controller = SysTransactionController();


### PR DESCRIPTION
## Summary
- Compare Syscoin rapid-poll snapshots using `addrTxCount` when Blockbook provides it, avoiding false changes when `txsummary` deduplicates xpub transactions but `basic` reports aggregate address counts.
- Harden UTXO Load More pagination by hiding it for short first pages and ignoring duplicate-only page responses.

## Test plan
- `npm test -- source/scripts/Background/controllers/transactions/syscoinPolling.spec.ts --runInBand`
- `lint-staged` via pre-commit hook


Made with [Cursor](https://cursor.com)