### PR TITLE
fix(smartAccount): Avoid SYS reimbursement for zkSYS tank gas

### DIFF
--- a/source/pages/Connections/PrepareSmartAccount.tsx
+++ b/source/pages/Connections/PrepareSmartAccount.tsx
@@ -554,8 +554,8 @@ export const PrepareSmartAccount = () => {
         ['wallet', 'getSmartAccountNativeGasStatus'],
         [{ accountId: account.id }],
         300000
-      )) as { hasNativeGas: boolean };
-      if (!gasStatus.hasNativeGas) {
+      )) as { hasNativeGas: boolean; hasZkSysGasTankGas?: boolean };
+      if (!gasStatus.hasNativeGas && !gasStatus.hasZkSysGasTankGas) {
         throw new Error('PALI_NATIVE_GAS_REQUIRED');
       }
 

--- a/source/pages/Settings/SmartAccountPolicy.tsx
+++ b/source/pages/Settings/SmartAccountPolicy.tsx
@@ -764,9 +764,9 @@ const SmartAccountPolicy = () => {
       ['wallet', 'getSmartAccountNativeGasStatus'],
       [{ accountId: account.id }],
       300000
-    )) as { hasNativeGas: boolean };
+    )) as { hasNativeGas: boolean; hasZkSysGasTankGas?: boolean };
 
-    if (!gasStatus.hasNativeGas) {
+    if (!gasStatus.hasNativeGas && !gasStatus.hasZkSysGasTankGas) {
       throw new Error('PALI_NATIVE_GAS_REQUIRED');
     }
   };

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -2726,6 +2726,7 @@ class MainController {
     balance: string;
     gasUnitsReserve: string;
     hasNativeGas: boolean;
+    hasZkSysGasTankGas: boolean;
     requiredBalance: string;
   }> {
     return this.smartAccount.getSmartAccountNativeGasStatus(params);
@@ -2789,6 +2790,11 @@ class MainController {
       target: string;
       value: string;
     }>;
+    gasPayer: {
+      address: string;
+      id: number;
+      type: KeyringAccountType;
+    };
     mode: string;
     userOperation: SmartAccountPackedUserOperation;
     validator: string;
@@ -2819,6 +2825,11 @@ class MainController {
       target: string;
       value: string;
     }>;
+    gasPayer: {
+      address: string;
+      id: number;
+      type: KeyringAccountType;
+    };
     mode: string;
     userOperation: SmartAccountPackedUserOperation;
     validator: string;
@@ -2839,6 +2850,11 @@ class MainController {
       target: string;
       value: string;
     }>;
+    gasPayer?: {
+      address: string;
+      id: number;
+      type: KeyringAccountType;
+    };
     mode?: string;
     signature: string;
     userOperation?: SmartAccountPackedUserOperation;

--- a/source/scripts/Background/controllers/smartAccount/index.ts
+++ b/source/scripts/Background/controllers/smartAccount/index.ts
@@ -36,7 +36,6 @@ import {
   encodeCompositeValidatorInitData,
   encodeEcdsaValidatorInitData,
   encodeGuardianRecoveryInitData,
-  encodeSmartAccountGasFees,
   encodeSmartAccountGasLimits,
   CustomValidatorPreflightResult,
   estimateSmartAccountUserOpGas,
@@ -45,12 +44,15 @@ import {
   getPaliSmartAccountFactoryAddress,
   getPaliSmartAccountDescriptor,
   getSmartAccountGasUnitsReserve,
+  getSmartAccountUserOpGasFees,
   getSmartAccountUserOpRequiredPrefund,
   getSmartAccountValidatorProfile,
+  getZkSysGasTankAddress,
   PaliAuthConfig,
   PaliRecoveryTarget,
   PALI_SMART_ACCOUNT_VERSION,
   PaliSmartAccountAuthenticatorSetup,
+  SMART_ACCOUNT_ZERO_GAS_FEES,
   ERC7579_MODULE_TYPE_VALIDATOR,
   PALI_CREATE2_DEPLOYER_ADDRESS,
   PALI_CREATE2_DEPLOYER_MIN_RUNTIME_BYTE_LENGTH,
@@ -66,6 +68,7 @@ import {
   paliSmartAccountInterface,
   SmartAccountExecution,
   SmartAccountPackedUserOperation,
+  SmartAccountUserOpGasEstimate,
   getAvailablePaliModules,
   SmartAccountAuthenticatorBuildResult,
   toPaliSmartAccount,
@@ -171,6 +174,12 @@ const ENTRYPOINT_FAILED_OP_SELECTOR = '0x220266b6';
 const AA21_PREFUND_REASON_HEX =
   '41413231206469646e2774207061792070726566756e64';
 const HYDRATED_METADATA_TTL_MS = 30_000;
+const ZKSYS_GAS_TANK_ABI = [
+  'function creditOf(address account) view returns (uint256)',
+] as const;
+// Conservative cover for outer transaction overhead not represented by the
+// inner UserOp gas limits.
+const SMART_ACCOUNT_GAS_TANK_OUTER_GAS_BUFFER = 50_000;
 
 const randomBytes32Hex = () => {
   const bytes = new Uint8Array(32);
@@ -1021,10 +1030,6 @@ class SmartAccountController {
     ).toString();
     const callData = smartAccount.encodeCalls(params);
     const feeData = await provider.getFeeData();
-    const gasFees = encodeSmartAccountGasFees({
-      maxFeePerGas: (feeData.maxFeePerGas || feeData.gasPrice || 0).toString(),
-      maxPriorityFeePerGas: (feeData.maxPriorityFeePerGas || 0).toString(),
-    });
     // Estimate tight limits: callGasLimit via eth_estimateGas with a margin
     // under the v0.9 unused-gas penalty threshold; verificationGasLimit from
     // the per-validator table (limits are inside the signed hash).
@@ -1036,6 +1041,23 @@ class SmartAccountController {
       isDeployed: code !== '0x',
       sender: active.account.address,
       validatorKind: validatorProfile.validatorKind,
+    });
+    const maxFeePerGas = BigNumber.from(
+      feeData.maxFeePerGas || feeData.gasPrice || 0
+    );
+    const gasPayer = await this.getWalletGasPayerAccount(
+      active.metadata.deploymentGasPayer
+    );
+    const useZkSysGasTank = await this.canUseZkSysGasTankForSmartAccountTx({
+      chainId: active.metadata.chainId,
+      gasEstimate,
+      gasPayerAddress: gasPayer.address,
+      maxFeePerGas,
+    });
+    const gasFees = getSmartAccountUserOpGasFees({
+      maxFeePerGas: maxFeePerGas.toString(),
+      maxPriorityFeePerGas: (feeData.maxPriorityFeePerGas || 0).toString(),
+      useZkSysGasTank,
     });
     const unsignedUserOperation = buildSmartAccountUserOperation({
       accountGasLimits: encodeSmartAccountGasLimits({
@@ -1050,8 +1072,8 @@ class SmartAccountController {
       preVerificationGas: String(gasEstimate.preVerificationGas),
       sender: active.account.address,
     });
-    // zkSYS gas payment is native to the chain (bootloader-level gas tank),
-    // so user operations are always self-funded; there is no paymaster.
+    // In verified tank mode, the outer transaction pays at the bootloader
+    // layer, so the inner UserOp must not reimburse the submitter in SYS.
     const userOperation = unsignedUserOperation;
     const actionHash = await entryPoint.getUserOpHash(userOperation);
 
@@ -1166,12 +1188,29 @@ class SmartAccountController {
     );
 
     try {
+      const requiredPrefund =
+        getSmartAccountUserOpRequiredPrefund(signedUserOperation);
+      const usesZkSysGasTank =
+        Boolean(getZkSysGasTankAddress(active.metadata.chainId)) &&
+        signedUserOperation.gasFees === SMART_ACCOUNT_ZERO_GAS_FEES;
+      if (usesZkSysGasTank) {
+        await this.assertZkSysGasTankCoversTransaction({
+          chainId: active.metadata.chainId,
+          gasPayerAddress: gasPayer.address,
+          transaction: {
+            data: callData,
+            to: entryPointAddress,
+            value: '0x0',
+          },
+        });
+      }
       // Self-funded first-UserOp deployment: an op carrying initCode validates
       // before anything executes, so the counterfactual account must already
       // cover the EntryPoint prefund.
       if (
         signedUserOperation.initCode &&
-        signedUserOperation.initCode !== '0x'
+        signedUserOperation.initCode !== '0x' &&
+        !requiredPrefund.isZero()
       ) {
         await this.ensureSmartAccountDeploymentPrefund(
           active.account.address,
@@ -1216,6 +1255,77 @@ class SmartAccountController {
         throw new Error(SMART_ACCOUNT_SIGNATURE_ERROR);
       }
       throw error;
+    }
+  }
+
+  private async canUseZkSysGasTankForSmartAccountTx({
+    chainId,
+    gasEstimate,
+    gasPayerAddress,
+    maxFeePerGas,
+  }: {
+    chainId: number;
+    gasEstimate: SmartAccountUserOpGasEstimate;
+    gasPayerAddress: string;
+    maxFeePerGas: BigNumber;
+  }): Promise<boolean> {
+    if (maxFeePerGas.isZero()) {
+      return false;
+    }
+    const tankAddress = getZkSysGasTankAddress(chainId);
+    if (!tankAddress) {
+      return false;
+    }
+    const provider = this.ethereumTransaction?.web3Provider;
+    if (!provider) {
+      return false;
+    }
+    try {
+      const tank = new Contract(tankAddress, ZKSYS_GAS_TANK_ABI, provider);
+      const credit = (await tank.creditOf(gasPayerAddress)) as BigNumber;
+      const requiredCredit = BigNumber.from(
+        gasEstimate.totalGasUnits + SMART_ACCOUNT_GAS_TANK_OUTER_GAS_BUFFER
+      ).mul(maxFeePerGas);
+      return credit.gte(requiredCredit);
+    } catch {
+      return false;
+    }
+  }
+
+  private async assertZkSysGasTankCoversTransaction({
+    chainId,
+    gasPayerAddress,
+    transaction,
+  }: {
+    chainId: number;
+    gasPayerAddress: string;
+    transaction: { data?: string; to: string; value?: string };
+  }): Promise<void> {
+    const provider = this.ethereumTransaction?.web3Provider;
+    const tankAddress = getZkSysGasTankAddress(chainId);
+    if (!provider || !tankAddress) {
+      throw new Error('PALI_ZKSYS_GAS_TANK_REQUIRED');
+    }
+    const [feeData, gasLimit, credit] = await Promise.all([
+      provider.getFeeData(),
+      provider.estimateGas({
+        data: transaction.data || '0x',
+        from: gasPayerAddress,
+        to: transaction.to,
+        value: transaction.value || '0x0',
+      }),
+      new Contract(tankAddress, ZKSYS_GAS_TANK_ABI, provider).creditOf(
+        gasPayerAddress
+      ) as Promise<BigNumber>,
+    ]);
+    const maxFeePerGas = BigNumber.from(
+      feeData.maxFeePerGas || feeData.gasPrice || 0
+    );
+    const requiredCredit = gasLimit
+      .add(SMART_ACCOUNT_GAS_TANK_OUTER_GAS_BUFFER)
+      .mul(maxFeePerGas);
+    if (credit.lt(requiredCredit)) {
+      throw new Error('PALI_ZKSYS_GAS_TANK_REQUIRED');
     }
   }
 

--- a/source/scripts/Background/controllers/smartAccount/index.ts
+++ b/source/scripts/Background/controllers/smartAccount/index.ts
@@ -1046,7 +1046,13 @@ class SmartAccountController {
       feeData.maxFeePerGas || feeData.gasPrice || 0
     );
     const gasPayer = await this.getWalletGasPayerAccount(
-      active.metadata.deploymentGasPayer
+      active.metadata.deploymentGasPayer,
+      undefined,
+      {
+        chainId: active.metadata.chainId,
+        gasEstimate,
+        maxFeePerGas,
+      }
     );
     const useZkSysGasTank = await this.canUseZkSysGasTankForSmartAccountTx({
       chainId: active.metadata.chainId,
@@ -2529,6 +2535,11 @@ class SmartAccountController {
       data?: string;
       to: string;
       value?: string;
+    },
+    tankPayment?: {
+      chainId: number;
+      gasEstimate: SmartAccountUserOpGasEstimate;
+      maxFeePerGas: BigNumber;
     }
   ): Promise<{
     address: string;
@@ -2601,6 +2612,21 @@ class SmartAccountController {
     }) => ({ address, id, type });
 
     if (provider) {
+      if (tankPayment) {
+        for (const candidate of gasPayers) {
+          if (
+            await this.canUseZkSysGasTankForSmartAccountTx({
+              chainId: tankPayment.chainId,
+              gasEstimate: tankPayment.gasEstimate,
+              gasPayerAddress: candidate.address,
+              maxFeePerGas: tankPayment.maxFeePerGas,
+            })
+          ) {
+            return toGasPayer(candidate);
+          }
+        }
+      }
+
       if (transaction) {
         // Shared lookups hoisted out of the candidate loop: one fee-data call
         // and one batched balance fetch instead of repeating both per

--- a/source/scripts/Background/controllers/smartAccount/index.ts
+++ b/source/scripts/Background/controllers/smartAccount/index.ts
@@ -2647,7 +2647,8 @@ class SmartAccountController {
 
     if (provider) {
       if (tankPayment) {
-        for (const candidate of gasPayers) {
+        const tankCandidates = gasPayers.slice(0, 1);
+        for (const candidate of tankCandidates) {
           if (
             await this.canUseZkSysGasTankForSmartAccountTx({
               chainId: tankPayment.chainId,

--- a/source/scripts/Background/controllers/smartAccount/index.ts
+++ b/source/scripts/Background/controllers/smartAccount/index.ts
@@ -932,31 +932,23 @@ class SmartAccountController {
     // limits the userOp builder will sign for a simple execution.
     const gasUnitsReserve = getSmartAccountGasUnitsReserve(active.metadata);
     const requiredBalance = gasUnitsReserve.mul(maxFeePerGas);
-    const gasPayer = await this.getWalletGasPayerAccount(
-      active.metadata.deploymentGasPayer,
-      undefined,
-      {
-        chainId: active.metadata.chainId,
-        gasEstimate: {
-          callGasLimit: 0,
-          preVerificationGas: 0,
-          totalGasUnits: gasUnitsReserve.toNumber(),
-          verificationGasLimit: 0,
-        },
-        maxFeePerGas,
-      }
-    );
-    const hasZkSysGasTankGas = await this.canUseZkSysGasTankForSmartAccountTx({
-      chainId: active.metadata.chainId,
-      gasEstimate: {
-        callGasLimit: 0,
-        preVerificationGas: 0,
-        totalGasUnits: gasUnitsReserve.toNumber(),
-        verificationGasLimit: 0,
-      },
-      gasPayerAddress: gasPayer.address,
-      maxFeePerGas,
-    });
+    const primaryGasPayer = this.getWalletGasPayerCandidates(
+      active.metadata.deploymentGasPayer
+    )[0];
+    const statusGasEstimate = {
+      callGasLimit: 0,
+      preVerificationGas: 0,
+      totalGasUnits: gasUnitsReserve.toNumber(),
+      verificationGasLimit: 0,
+    };
+    const hasZkSysGasTankGas = primaryGasPayer
+      ? await this.canUseZkSysGasTankForSmartAccountTx({
+          chainId: active.metadata.chainId,
+          gasEstimate: statusGasEstimate,
+          gasPayerAddress: primaryGasPayer.address,
+          maxFeePerGas,
+        })
+      : false;
 
     return {
       balance: balance.toString(),
@@ -2580,60 +2572,8 @@ class SmartAccountController {
     id: number;
     type: PaliKeyringAccountType;
   }> {
-    const { accounts, activeAccount } = store.getState().vault;
     const provider = this.ethereumTransaction?.web3Provider;
-    const candidates: Array<{ id: number; type: PaliKeyringAccountType }> = [];
-    if (
-      preferred?.type &&
-      preferred.type !== PaliKeyringAccountType.SmartAccount
-    ) {
-      candidates.push({ id: preferred.id, type: preferred.type });
-    }
-    if (activeAccount.type !== PaliKeyringAccountType.SmartAccount) {
-      candidates.push({ id: activeAccount.id, type: activeAccount.type });
-    }
-    candidates.push({ id: 0, type: PaliKeyringAccountType.HDAccount });
-    candidates.push(
-      ...Object.keys(accounts[PaliKeyringAccountType.Imported] || {}).map(
-        (id) => ({
-          id: Number(id),
-          type: PaliKeyringAccountType.Imported,
-        })
-      )
-    );
-
-    const seen = new Set<string>();
-    const gasPayers: Array<{
-      account: any;
-      address: string;
-      id: number;
-      type: PaliKeyringAccountType;
-    }> = [];
-
-    for (const candidate of candidates) {
-      const candidateKey = `${candidate.type}:${candidate.id}`;
-      if (seen.has(candidateKey)) {
-        continue;
-      }
-      seen.add(candidateKey);
-      const account = accounts[candidate.type]?.[candidate.id];
-      if (account?.address) {
-        if (
-          preferred &&
-          candidate.id === preferred.id &&
-          candidate.type === preferred.type &&
-          getAddress(account.address) !== getAddress(preferred.address)
-        ) {
-          continue;
-        }
-        gasPayers.push({
-          account,
-          address: getAddress(account.address),
-          id: candidate.id,
-          type: candidate.type,
-        });
-      }
-    }
+    const gasPayers = this.getWalletGasPayerCandidates(preferred);
 
     const toGasPayer = ({
       address,
@@ -2730,6 +2670,72 @@ class SmartAccountController {
     throw new Error(
       'A local EVM account is required to submit ERC-4337 operations'
     );
+  }
+
+  private getWalletGasPayerCandidates(preferred?: {
+    address: string;
+    id: number;
+    type: PaliKeyringAccountType;
+  }): Array<{
+    account: any;
+    address: string;
+    id: number;
+    type: PaliKeyringAccountType;
+  }> {
+    const { accounts, activeAccount } = store.getState().vault;
+    const candidates: Array<{ id: number; type: PaliKeyringAccountType }> = [];
+    if (
+      preferred?.type &&
+      preferred.type !== PaliKeyringAccountType.SmartAccount
+    ) {
+      candidates.push({ id: preferred.id, type: preferred.type });
+    }
+    if (activeAccount.type !== PaliKeyringAccountType.SmartAccount) {
+      candidates.push({ id: activeAccount.id, type: activeAccount.type });
+    }
+    candidates.push({ id: 0, type: PaliKeyringAccountType.HDAccount });
+    candidates.push(
+      ...Object.keys(accounts[PaliKeyringAccountType.Imported] || {}).map(
+        (id) => ({
+          id: Number(id),
+          type: PaliKeyringAccountType.Imported,
+        })
+      )
+    );
+
+    const seen = new Set<string>();
+    const gasPayers: Array<{
+      account: any;
+      address: string;
+      id: number;
+      type: PaliKeyringAccountType;
+    }> = [];
+
+    for (const candidate of candidates) {
+      const candidateKey = `${candidate.type}:${candidate.id}`;
+      if (seen.has(candidateKey)) {
+        continue;
+      }
+      seen.add(candidateKey);
+      const account = accounts[candidate.type]?.[candidate.id];
+      if (account?.address) {
+        if (
+          preferred &&
+          candidate.id === preferred.id &&
+          candidate.type === preferred.type &&
+          getAddress(account.address) !== getAddress(preferred.address)
+        ) {
+          continue;
+        }
+        gasPayers.push({
+          account,
+          address: getAddress(account.address),
+          id: candidate.id,
+          type: candidate.type,
+        });
+      }
+    }
+    return gasPayers;
   }
 
   private async getNativeBalances(

--- a/source/scripts/Background/controllers/smartAccount/index.ts
+++ b/source/scripts/Background/controllers/smartAccount/index.ts
@@ -1203,7 +1203,10 @@ class SmartAccountController {
       );
     }
     const gasPayer = await this.getWalletGasPayerAccount(
-      params.gasPayer || active.metadata.deploymentGasPayer
+      params.gasPayer || active.metadata.deploymentGasPayer,
+      undefined,
+      undefined,
+      { requirePreferred: Boolean(params.gasPayer) }
     );
     const entryPointAddress = getPaliEntryPointAddress(active.metadata.chainId);
     const entryPoint = new Contract(entryPointAddress, PALI_ENTRYPOINT_V09_ABI);
@@ -2566,7 +2569,8 @@ class SmartAccountController {
       chainId: number;
       gasEstimate: SmartAccountUserOpGasEstimate;
       maxFeePerGas: BigNumber;
-    }
+    },
+    options: { requirePreferred?: boolean } = {}
   ): Promise<{
     address: string;
     id: number;
@@ -2584,6 +2588,22 @@ class SmartAccountController {
       id: number;
       type: PaliKeyringAccountType;
     }) => ({ address, id, type });
+
+    if (options.requirePreferred) {
+      const selected = gasPayers[0];
+      if (
+        !preferred ||
+        !selected ||
+        selected.id !== preferred.id ||
+        selected.type !== preferred.type ||
+        getAddress(selected.address) !== getAddress(preferred.address)
+      ) {
+        throw new Error(
+          'The selected gas payer is no longer available for this smart-account transaction'
+        );
+      }
+      return toGasPayer(selected);
+    }
 
     if (provider) {
       if (tankPayment) {

--- a/source/scripts/Background/controllers/smartAccount/index.ts
+++ b/source/scripts/Background/controllers/smartAccount/index.ts
@@ -660,6 +660,7 @@ class SmartAccountController {
         response = await this.submitSmartAccountExecution({
           accountId: params.accountId,
           executions: prepared.executions,
+          gasPayer: prepared.gasPayer,
           signature,
           skipRapidPolling: true,
           userOperation: prepared.userOperation,
@@ -900,6 +901,7 @@ class SmartAccountController {
     balance: string;
     gasUnitsReserve: string;
     hasNativeGas: boolean;
+    hasZkSysGasTankGas: boolean;
     requiredBalance: string;
   }> {
     const active = this.getSmartAccountById(params.accountId);
@@ -930,10 +932,36 @@ class SmartAccountController {
     // limits the userOp builder will sign for a simple execution.
     const gasUnitsReserve = getSmartAccountGasUnitsReserve(active.metadata);
     const requiredBalance = gasUnitsReserve.mul(maxFeePerGas);
+    const gasPayer = await this.getWalletGasPayerAccount(
+      active.metadata.deploymentGasPayer,
+      undefined,
+      {
+        chainId: active.metadata.chainId,
+        gasEstimate: {
+          callGasLimit: 0,
+          preVerificationGas: 0,
+          totalGasUnits: gasUnitsReserve.toNumber(),
+          verificationGasLimit: 0,
+        },
+        maxFeePerGas,
+      }
+    );
+    const hasZkSysGasTankGas = await this.canUseZkSysGasTankForSmartAccountTx({
+      chainId: active.metadata.chainId,
+      gasEstimate: {
+        callGasLimit: 0,
+        preVerificationGas: 0,
+        totalGasUnits: gasUnitsReserve.toNumber(),
+        verificationGasLimit: 0,
+      },
+      gasPayerAddress: gasPayer.address,
+      maxFeePerGas,
+    });
 
     return {
       balance: balance.toString(),
       gasUnitsReserve: gasUnitsReserve.toString(),
+      hasZkSysGasTankGas,
       hasNativeGas: maxFeePerGas.isZero()
         ? !balance.isZero()
         : balance.gte(requiredBalance),
@@ -1093,6 +1121,7 @@ class SmartAccountController {
       execution: executions[0],
       executionCalldata: prepared.executionCalldata,
       executions,
+      gasPayer,
       mode: prepared.mode,
       smartAccount: active.metadata,
       userOperation,
@@ -1153,6 +1182,11 @@ class SmartAccountController {
     accountId?: number;
     executionCalldata?: string;
     executions?: SmartAccountExecution[];
+    gasPayer?: {
+      address: string;
+      id: number;
+      type: PaliKeyringAccountType;
+    };
     mode?: string;
     signature: string;
     skipRapidPolling?: boolean;
@@ -1177,7 +1211,7 @@ class SmartAccountController {
       );
     }
     const gasPayer = await this.getWalletGasPayerAccount(
-      active.metadata.deploymentGasPayer
+      params.gasPayer || active.metadata.deploymentGasPayer
     );
     const entryPointAddress = getPaliEntryPointAddress(active.metadata.chainId);
     const entryPoint = new Contract(entryPointAddress, PALI_ENTRYPOINT_V09_ABI);

--- a/source/utils/smartAccount/account.spec.ts
+++ b/source/utils/smartAccount/account.spec.ts
@@ -29,9 +29,11 @@ import {
   getPaliSmartAccountDeploymentSalt,
   getPaliSmartAccountDescriptor,
   getSmartAccountAuthHash,
+  getSmartAccountUserOpGasFees,
   getSmartAccountUserOpRequiredPrefund,
   encodeSmartAccountGasFees,
   encodeSmartAccountGasLimits,
+  SMART_ACCOUNT_ZERO_GAS_FEES,
 } from './account';
 import { toPaliSmartAccount } from './adapter';
 import { buildHydratedSLHDSAAuthenticator } from './authenticators';
@@ -199,6 +201,42 @@ describe('ERC-7579 smart account helpers', () => {
     expect(getSmartAccountUserOpRequiredPrefund(userOperation).toString()).toBe(
       // (1_100_000 + 250_000 + 50_000) * 2.5 gwei
       (BigInt(1_400_000) * BigInt(2_500_000_000)).toString()
+    );
+  });
+
+  it('zeros EntryPoint gas fees only for verified gas-tank mode', () => {
+    const gasFees = getSmartAccountUserOpGasFees({
+      maxFeePerGas: 2_500_000_000,
+      maxPriorityFeePerGas: 1_000_000_000,
+      useZkSysGasTank: true,
+    });
+    const userOperation = {
+      accountGasLimits: encodeSmartAccountGasLimits({
+        callGasLimit: 250_000,
+        verificationGasLimit: 1_100_000,
+      }),
+      gasFees,
+      preVerificationGas: '50000',
+    };
+
+    expect(gasFees).toBe(SMART_ACCOUNT_ZERO_GAS_FEES);
+    expect(getSmartAccountUserOpRequiredPrefund(userOperation).isZero()).toBe(
+      true
+    );
+  });
+
+  it('keeps EntryPoint gas fees outside gas-tank mode', () => {
+    expect(
+      getSmartAccountUserOpGasFees({
+        maxFeePerGas: 2_500_000_000,
+        maxPriorityFeePerGas: 1_000_000_000,
+        useZkSysGasTank: false,
+      })
+    ).toBe(
+      encodeSmartAccountGasFees({
+        maxFeePerGas: 2_500_000_000,
+        maxPriorityFeePerGas: 1_000_000_000,
+      })
     );
   });
 

--- a/source/utils/smartAccount/account.ts
+++ b/source/utils/smartAccount/account.ts
@@ -406,6 +406,27 @@ export const encodeSmartAccountGasFees = ({
     hexZeroPad(BigNumber.from(maxFeePerGas).toHexString(), 16),
   ]);
 
+export const SMART_ACCOUNT_ZERO_GAS_FEES = encodeSmartAccountGasFees({
+  maxFeePerGas: 0,
+  maxPriorityFeePerGas: 0,
+});
+
+export const getSmartAccountUserOpGasFees = ({
+  maxFeePerGas,
+  maxPriorityFeePerGas,
+  useZkSysGasTank,
+}: {
+  maxFeePerGas: string | number;
+  maxPriorityFeePerGas: string | number;
+  useZkSysGasTank?: boolean;
+}) =>
+  useZkSysGasTank
+    ? SMART_ACCOUNT_ZERO_GAS_FEES
+    : encodeSmartAccountGasFees({
+        maxFeePerGas,
+        maxPriorityFeePerGas,
+      });
+
 /**
  * Required EntryPoint prefund for a self-funded (no paymaster) packed userOp:
  * maxFeePerGas * (verificationGasLimit + callGasLimit + preVerificationGas).

--- a/source/utils/smartAccount/deployment.ts
+++ b/source/utils/smartAccount/deployment.ts
@@ -271,6 +271,16 @@ export const getPaliCanonicalEntryPointAddress = (chainId?: number): string =>
 export const getPaliCanonicalFactoryAddress = (chainId?: number): string =>
   getPaliInfrastructureById(chainId).factory.address;
 
+// Chain-specific zkSYS gas-tank deployments. These are protocol deployment
+// addresses, not user-editable RPC metadata; fill per network after launch
+// config records l2.zksys_gas_tank_addr.
+export const ZKSYS_GAS_TANK_ADDRESSES: Partial<Record<number, string>> = {
+  57057: '0xB9fEFf70EC42b6B5Af5A690b4DBc332a2D1F3BeB',
+};
+
+export const getZkSysGasTankAddress = (chainId?: number): string | undefined =>
+  chainId === undefined ? undefined : ZKSYS_GAS_TANK_ADDRESSES[chainId];
+
 export const PALI_MODULE_CANONICAL_ADDRESSES: Partial<
   Record<PaliAuthenticatorModuleId, string>
 > = {

--- a/source/utils/smartAccount/execution.ts
+++ b/source/utils/smartAccount/execution.ts
@@ -873,6 +873,7 @@ export const signAndSubmitSmartAccountExecutions = async (
           executionCalldata: prepared.executionCalldata,
           executions: prepared.executions,
           accountId,
+          gasPayer: prepared.gasPayer,
           mode: prepared.mode,
           signature: signature.signature,
           skipRapidPolling,


### PR DESCRIPTION
## Summary
- Zero ERC-4337 UserOp gas fees only when the selected gas payer has enough zkSYS gas-tank credit, preventing EntryPoint SYS reimbursement for tank-paid submissions.
- Recheck the signed `handleOps` outer transaction against the gas payer tank credit before broadcast, with a conservative gas buffer.
- Register the zkTanenbaum gas tank deployment and add helper coverage for zero-fee tank mode vs normal native fee mode.

## Test plan
- `yarn --ignore-engines type-check`
- `yarn --ignore-engines test source/utils/smartAccount/account.spec.ts --runInBand`


Made with [Cursor](https://cursor.com)