### PR TITLE
fix(evm): Harden send calls and smart account signing

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@heroicons/react": "^1.0.6",
     "@reduxjs/toolkit": "^2.8.2",
     "@sidhujag/sysweb3-core": "^1.0.28",
-    "@sidhujag/sysweb3-keyring": "^1.0.608",
+    "@sidhujag/sysweb3-keyring": "^1.0.609",
     "@sidhujag/sysweb3-network": "^1.0.109",
     "@sidhujag/sysweb3-utils": "^1.1.277",
     "@tippyjs/react": "^4.2.6",

--- a/source/helpers/errors/errors.spec.ts
+++ b/source/helpers/errors/errors.spec.ts
@@ -69,24 +69,25 @@ describe('ethError.rpc.server', () => {
 });
 
 describe('ethError.rpc', () => {
-  it.each(Object.entries(ethErrors.rpc).filter(([key]) => key !== 'server'))(
-    '%s returns appropriate value',
-    (key, value) => {
-      const createError = value as any;
-      const error = createError({
-        message: null,
-        data: Object.assign({}, dummyData),
-      });
+  it.each(
+    Object.entries(ethErrors.rpc).filter(
+      ([key]) => key !== 'server' && key !== 'custom'
+    )
+  )('%s returns appropriate value', (key, value) => {
+    const createError = value as any;
+    const error = createError({
+      message: null,
+      data: Object.assign({}, dummyData),
+    });
 
-      const rpcCode = errorCodes.rpc[key];
-      expect(
-        Object.values(errorCodes.rpc).includes(error.code) ||
-          (error.code <= -32000 && error.code >= -32099)
-      ).toBe(true);
-      expect(error.code).toBe(rpcCode);
-      expect(error.message).toBe(getMessageFromCode(rpcCode));
-    }
-  );
+    const rpcCode = errorCodes.rpc[key];
+    expect(
+      Object.values(errorCodes.rpc).includes(error.code) ||
+        (error.code <= -32000 && error.code >= -32099)
+    ).toBe(true);
+    expect(error.code).toBe(rpcCode);
+    expect(error.message).toBe(getMessageFromCode(rpcCode));
+  });
 
   it('server returns appropriate value', () => {
     const error = ethErrors.rpc.server({
@@ -96,6 +97,35 @@ describe('ethError.rpc', () => {
 
     expect(error.code <= -32000 && error.code >= -32099).toBe(true);
     expect(error.message).toBe(JSON_RPC_SERVER_ERROR_MESSAGE);
+  });
+
+  it('custom allows method-specific positive RPC error codes', () => {
+    const error = ethErrors.rpc.custom({
+      code: 5700,
+      message: CUSTOM_ERROR_MESSAGE,
+      data: Object.assign({}, dummyData),
+    });
+
+    expect(error.code).toBe(5700);
+    expect(error.message).toBe(CUSTOM_ERROR_MESSAGE);
+  });
+
+  it('custom throws if the value is invalid', () => {
+    expect(() => {
+      // @ts-expect-error Invalid input
+      ethErrors.rpc.custom('bar');
+    }).toThrow(
+      'Ethereum RPC custom errors must provide single object argument.'
+    );
+
+    expect(() => {
+      // @ts-expect-error Invalid input
+      ethErrors.rpc.custom({ code: '5700', message: CUSTOM_ERROR_MESSAGE });
+    }).toThrow('"code" must be an integer');
+
+    expect(() => {
+      ethErrors.rpc.custom({ code: 5700, message: '' });
+    }).toThrow('"message" must be a nonempty string');
   });
 });
 

--- a/source/helpers/errors/errorsHandlers.ts
+++ b/source/helpers/errors/errorsHandlers.ts
@@ -142,6 +142,30 @@ export const ethErrors = {
      */
     limitExceeded: <T extends Json>(arg?: EthErrorsArg<T>) =>
       getEthJsonRpcError(errorCodes.rpc.limitExceeded, arg),
+
+    /**
+     * Get a custom JSON-RPC error for method-specific specifications.
+     *
+     * Some wallet RPC specs define positive custom error codes outside the
+     * EIP-1193 provider range, e.g. EIP-5792's 57xx errors.
+     */
+    custom: <T extends Json>(opts: CustomErrorArg<T>) => {
+      if (!opts || typeof opts !== 'object' || Array.isArray(opts)) {
+        throw new Error(
+          'Ethereum RPC custom errors must provide single object argument.'
+        );
+      }
+
+      const { code, message, data } = opts;
+
+      if (!Number.isInteger(code)) {
+        throw new Error('"code" must be an integer');
+      }
+      if (!message || typeof message !== 'string') {
+        throw new Error('"message" must be a nonempty string');
+      }
+      return new EthereumRpcErrorHandler(code, message, data);
+    },
   },
 
   provider: {

--- a/source/pages/Transactions/SignEth.tsx
+++ b/source/pages/Transactions/SignEth.tsx
@@ -36,6 +36,33 @@ type SmartAccountTypedDataRequest = {
   actionHash: string;
 };
 
+const getTypedDataBaseType = (type: string) => type.replace(/\[.*\]$/, '');
+
+const getReachableTypedDataTypes = (
+  types: Record<string, Array<{ name: string; type: string }>>,
+  primaryType?: string
+) => {
+  const sanitizedTypes = { ...types };
+  delete sanitizedTypes.EIP712Domain;
+
+  if (!primaryType || !sanitizedTypes[primaryType]) {
+    return sanitizedTypes;
+  }
+
+  const reachableTypes: typeof sanitizedTypes = {};
+  const visit = (typeName: string) => {
+    if (!sanitizedTypes[typeName] || reachableTypes[typeName]) return;
+
+    reachableTypes[typeName] = sanitizedTypes[typeName];
+    for (const field of sanitizedTypes[typeName]) {
+      visit(getTypedDataBaseType(field.type));
+    }
+  };
+
+  visit(primaryType);
+  return reachableTypes;
+};
+
 const smartAccountTypedDataPrimaryTypes = new Set([
   'PaliSmartAccountExecution',
   'PaliSmartAccountPolicyUpdate',
@@ -277,12 +304,10 @@ const EthSign: React.FC<ISign> = () => {
         };
       }
 
-      const { domain, types, message: typedMessage } = typedData;
-      const sanitizedTypes = { ...types };
-      delete sanitizedTypes.EIP712Domain;
+      const { domain, message: typedMessage, primaryType, types } = typedData;
       return _TypedDataEncoder.hash(
         domain || {},
-        sanitizedTypes,
+        getReachableTypedDataTypes(types || {}, primaryType),
         typedMessage || {}
       );
     }

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -106,7 +106,7 @@ import { namehash } from 'utils/ethersV6Compat';
 import { Contract } from 'utils/ethersV6Compat';
 import { isHexString } from 'utils/ethersV6Compat';
 import { decodeTransactionData } from 'utils/ethUtil';
-import { getBlacklistTargetsForEvmCall } from 'utils/evmCallBlacklist';
+import { getBlacklistTargetsForEvmCallWithContractType } from 'utils/evmCallBlacklist';
 import { logError } from 'utils/logger';
 import { getNetworkChain } from 'utils/network';
 import { blacklistService } from 'utils/security/blacklistService';
@@ -4603,9 +4603,11 @@ class MainController {
       const controller = getController();
 
       // Check the call target and obvious calldata recipients/spenders.
-      for (const target of getBlacklistTargetsForEvmCall({
+      for (const target of await getBlacklistTargetsForEvmCallWithContractType({
+        controller: controller.wallet,
         data: params.data || params.input,
         to: params.to,
+        web3Provider: controller.wallet.ethereumTransaction.web3Provider,
       })) {
         const blacklistResult = await blacklistService.checkAddress(
           target.address

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -106,6 +106,7 @@ import { namehash } from 'utils/ethersV6Compat';
 import { Contract } from 'utils/ethersV6Compat';
 import { isHexString } from 'utils/ethersV6Compat';
 import { decodeTransactionData } from 'utils/ethUtil';
+import { getBlacklistTargetsForEvmCall } from 'utils/evmCallBlacklist';
 import { logError } from 'utils/logger';
 import { getNetworkChain } from 'utils/network';
 import { blacklistService } from 'utils/security/blacklistService';
@@ -4601,17 +4602,28 @@ class MainController {
     try {
       const controller = getController();
 
-      // Check recipient address against blacklist
-      if (params.to) {
-        const blacklistResult = await blacklistService.checkAddress(params.to);
+      // Check the call target and obvious calldata recipients/spenders.
+      for (const target of getBlacklistTargetsForEvmCall({
+        data: params.data || params.input,
+        to: params.to,
+      })) {
+        const blacklistResult = await blacklistService.checkAddress(
+          target.address
+        );
         if (
           blacklistResult.isBlacklisted &&
           (blacklistResult.severity === 'critical' ||
             blacklistResult.severity === 'high')
         ) {
+          const fallbackReason =
+            target.type === 'approval'
+              ? 'Spender address is blacklisted'
+              : target.type === 'token-recipient'
+              ? 'Recipient address is blacklisted'
+              : 'Recipient address is blacklisted';
           throw new Error(
             `Transaction blocked: ${
-              blacklistResult.reason || 'Recipient address is blacklisted'
+              blacklistResult.reason || fallbackReason
             }. Severity: ${blacklistResult.severity}`
           );
         }

--- a/source/scripts/Background/controllers/message-handler/method-handlers.ts
+++ b/source/scripts/Background/controllers/message-handler/method-handlers.ts
@@ -175,7 +175,7 @@ export class WalletMethodHandler implements IMethodHandler {
           !smartAccountAtomicSupported
         ) {
           throw cleanErrorStack(
-            ethErrors.provider.custom({
+            ethErrors.rpc.custom({
               code: 5700,
               message:
                 'Atomic wallet_sendCalls requires an active smart account on the selected chain.',
@@ -210,7 +210,7 @@ export class WalletMethodHandler implements IMethodHandler {
         });
         if (!reserved) {
           throw cleanErrorStack(
-            ethErrors.provider.custom({
+            ethErrors.rpc.custom({
               code: 5720,
               message:
                 'There is already a bundle submitted with this id (Duplicate ID).',

--- a/source/scripts/Background/controllers/message-handler/request-pipeline.ts
+++ b/source/scripts/Background/controllers/message-handler/request-pipeline.ts
@@ -5,9 +5,11 @@ import { getController } from 'scripts/Background';
 import store from 'state/store';
 import { INetworkType } from 'types/network';
 import cleanErrorStack from 'utils/cleanErrorStack';
-import { detectApprovalType } from 'utils/ethUtil';
+import {
+  getBlacklistTargetsForEvmCall,
+  IEvmCallBlacklistTarget,
+} from 'utils/evmCallBlacklist';
 import { blacklistService } from 'utils/security/blacklistService';
-import { getERC20Recipient } from 'utils/transactions';
 
 import { clearProviderCache } from './method-handlers';
 import {
@@ -1196,124 +1198,80 @@ export const blacklistCheckingMiddleware: Middleware = async (
 ) => {
   const { originalRequest } = context;
 
-  // Only check for transaction methods
-  if (
-    originalRequest.method === 'eth_sendTransaction' &&
-    originalRequest.params?.[0]
-  ) {
-    const txParams = originalRequest.params[0];
-
-    // Fast local check: Is this an approval transaction?
-    let approvalInfo;
-    if (txParams.data && txParams.to) {
-      try {
-        const controller = getController().wallet;
-        approvalInfo = await detectApprovalType(
-          txParams.data,
-          txParams.to,
-          controller.ethereumTransaction.web3Provider,
-          controller
-        );
-      } catch (error) {
-        console.debug('[Blacklist] Could not parse transaction data:', error);
-      }
-    }
-
-    // Decide which address to check based on transaction type
-    let addressToCheck: string;
-    let checkContext: {
-      approvalType?: string;
-      method?: string;
-      type: 'approval' | 'token-recipient' | 'recipient';
-    };
-
-    if (approvalInfo?.isApproval && approvalInfo.decodedData) {
-      // For approvals: Check the SPENDER address (who can steal tokens)
-      if (approvalInfo.approvalType === 'erc20-amount') {
-        addressToCheck = approvalInfo.decodedData.spender;
-      } else if (approvalInfo.approvalType === 'erc721-single') {
-        addressToCheck = approvalInfo.decodedData.to;
-      } else if (approvalInfo.approvalType === 'nft-all') {
-        addressToCheck = approvalInfo.decodedData.operator;
-      } else {
-        return next(); // Unknown approval type, skip blacklist check
-      }
-
-      checkContext = {
-        type: 'approval',
-        method: approvalInfo.method,
-        approvalType: approvalInfo.approvalType,
-      };
-    } else {
-      // Check if it's a token transfer (ERC-20 transfer/transferFrom)
-      const tokenRecipient = txParams.data
-        ? getERC20Recipient({
-            input: txParams.data,
-            to: txParams.to,
-          } as any)
-        : null;
-
-      if (tokenRecipient) {
-        // For token transfers: Check the token recipient (who receives tokens)
-        addressToCheck = tokenRecipient;
-        checkContext = { type: 'token-recipient' };
-      } else if (txParams.to) {
-        // For other transactions: Check the recipient address (ETH transfers, contract calls)
-        addressToCheck = txParams.to;
-        checkContext = { type: 'recipient' };
-      } else {
-        return next(); // No address to check (e.g., contract deployment)
-      }
-    }
-
-    // Single blacklist check
-    const blacklistResult = await blacklistService.checkAddress(addressToCheck);
-
-    if (
-      blacklistResult.isBlacklisted &&
-      (blacklistResult.severity === 'critical' ||
-        blacklistResult.severity === 'high')
-    ) {
-      console.warn(
-        `[Blacklist] ${
-          checkContext.type === 'approval'
-            ? 'Token approval'
-            : checkContext.type === 'token-recipient'
-            ? 'Token transfer'
-            : 'Transaction'
-        } blocked:`,
-        {
-          type: checkContext.type,
-          method: checkContext.method,
-          approvalType: checkContext.approvalType,
-          address: addressToCheck,
-          reason: blacklistResult.reason,
-          severity: blacklistResult.severity,
-        }
+  const assertTargetsAllowed = async (
+    targets: IEvmCallBlacklistTarget[],
+    contextLabel: string
+  ) => {
+    for (const target of targets) {
+      const blacklistResult = await blacklistService.checkAddress(
+        target.address
       );
 
-      let errorMessage: string;
-      if (checkContext.type === 'approval') {
-        errorMessage = `Token approval blocked (${checkContext.method}): ${
-          blacklistResult.reason || 'The spender address is blacklisted'
-        }. Severity: ${
-          blacklistResult.severity
-        }. This could be an attempt to steal your tokens.`;
-      } else if (checkContext.type === 'token-recipient') {
-        errorMessage = `Token transfer blocked: ${
-          blacklistResult.reason || 'The recipient address is blacklisted'
-        }. Severity: ${
-          blacklistResult.severity
-        }. Please verify the token recipient address before proceeding.`;
-      } else {
-        errorMessage = `Transaction blocked: ${
-          blacklistResult.reason || 'This address is blacklisted'
-        }. Severity: ${
-          blacklistResult.severity
-        }. Please verify the recipient address before proceeding.`;
-      }
+      if (
+        blacklistResult.isBlacklisted &&
+        (blacklistResult.severity === 'critical' ||
+          blacklistResult.severity === 'high')
+      ) {
+        console.warn('[Blacklist] EVM call blocked:', {
+          address: target.address,
+          context: contextLabel,
+          method: target.method,
+          reason: blacklistResult.reason,
+          severity: blacklistResult.severity,
+          type: target.type,
+        });
 
-      throw cleanErrorStack(ethErrors.provider.unauthorized(errorMessage));
+        let errorMessage: string;
+        if (target.type === 'approval') {
+          errorMessage = `Token approval blocked (${target.method}): ${
+            blacklistResult.reason || 'The spender address is blacklisted'
+          }. Severity: ${
+            blacklistResult.severity
+          }. This could be an attempt to steal your tokens.`;
+        } else if (target.type === 'token-recipient') {
+          errorMessage = `Token transfer blocked: ${
+            blacklistResult.reason || 'The recipient address is blacklisted'
+          }. Severity: ${
+            blacklistResult.severity
+          }. Please verify the token recipient address before proceeding.`;
+        } else {
+          errorMessage = `Transaction blocked: ${
+            blacklistResult.reason || 'This address is blacklisted'
+          }. Severity: ${
+            blacklistResult.severity
+          }. Please verify the recipient address before proceeding.`;
+        }
+
+        throw cleanErrorStack(ethErrors.provider.unauthorized(errorMessage));
+      }
+    }
+  };
+
+  if (originalRequest.method === 'eth_sendTransaction') {
+    const txParams = originalRequest.params?.[0];
+    if (txParams) {
+      await assertTargetsAllowed(
+        getBlacklistTargetsForEvmCall({
+          data: txParams.data || txParams.input,
+          to: txParams.to,
+        }),
+        'eth_sendTransaction'
+      );
+    }
+  }
+
+  if (originalRequest.method === 'wallet_sendCalls') {
+    const calls = originalRequest.params?.[0]?.calls;
+    if (Array.isArray(calls)) {
+      for (let index = 0; index < calls.length; index += 1) {
+        await assertTargetsAllowed(
+          getBlacklistTargetsForEvmCall({
+            data: calls[index]?.data,
+            to: calls[index]?.to,
+          }),
+          `wallet_sendCalls[${index}]`
+        );
+      }
     }
   }
 

--- a/source/scripts/Background/controllers/message-handler/request-pipeline.ts
+++ b/source/scripts/Background/controllers/message-handler/request-pipeline.ts
@@ -6,7 +6,7 @@ import store from 'state/store';
 import { INetworkType } from 'types/network';
 import cleanErrorStack from 'utils/cleanErrorStack';
 import {
-  getBlacklistTargetsForEvmCall,
+  getBlacklistTargetsForEvmCallWithContractType,
   IEvmCallBlacklistTarget,
 } from 'utils/evmCallBlacklist';
 import { blacklistService } from 'utils/security/blacklistService';
@@ -1250,10 +1250,13 @@ export const blacklistCheckingMiddleware: Middleware = async (
   if (originalRequest.method === 'eth_sendTransaction') {
     const txParams = originalRequest.params?.[0];
     if (txParams) {
+      const controller = getController().wallet;
       await assertTargetsAllowed(
-        getBlacklistTargetsForEvmCall({
+        await getBlacklistTargetsForEvmCallWithContractType({
+          controller,
           data: txParams.data || txParams.input,
           to: txParams.to,
+          web3Provider: controller.ethereumTransaction.web3Provider,
         }),
         'eth_sendTransaction'
       );
@@ -1263,11 +1266,14 @@ export const blacklistCheckingMiddleware: Middleware = async (
   if (originalRequest.method === 'wallet_sendCalls') {
     const calls = originalRequest.params?.[0]?.calls;
     if (Array.isArray(calls)) {
+      const controller = getController().wallet;
       for (let index = 0; index < calls.length; index += 1) {
         await assertTargetsAllowed(
-          getBlacklistTargetsForEvmCall({
+          await getBlacklistTargetsForEvmCallWithContractType({
+            controller,
             data: calls[index]?.data,
             to: calls[index]?.to,
+            web3Provider: controller.ethereumTransaction.web3Provider,
           }),
           `wallet_sendCalls[${index}]`
         );

--- a/source/scripts/Background/controllers/message-handler/sendCallsBundles.ts
+++ b/source/scripts/Background/controllers/message-handler/sendCallsBundles.ts
@@ -273,7 +273,7 @@ export const resolveCallsStatus = async (
   const provider = getProviderForChain(descriptor.chainId);
   if (!provider) {
     throw cleanErrorStack(
-      ethErrors.provider.custom({
+      ethErrors.rpc.custom({
         code: 5710,
         message: `This wallet has no RPC configured for the bundle's chain (chainId ${descriptor.chainId}).`,
       })

--- a/source/scripts/Background/controllers/smartAccount/index.ts
+++ b/source/scripts/Background/controllers/smartAccount/index.ts
@@ -15,6 +15,7 @@ import { getAddress } from 'utils/ethersV6Compat';
 import { BigNumber } from 'utils/ethersV6Compat';
 import { AddressZero } from 'utils/ethersV6Compat';
 import { Contract } from 'utils/ethersV6Compat';
+import { getBlacklistTargetsForEvmCall } from 'utils/evmCallBlacklist';
 import { blacklistService } from 'utils/security/blacklistService';
 import {
   getSLHDSAKeyId,
@@ -1151,21 +1152,35 @@ class SmartAccountController {
   }
 
   private async assertSmartAccountExecutionTargetsAllowed(
-    executions: Array<{ target: string }>
+    executions: Array<{ data?: string; target: string }>
   ): Promise<void> {
     for (const execution of executions) {
-      const target = getAddress(execution.target);
-      const blacklistResult = await blacklistService.checkAddress(target);
-      if (
-        blacklistResult.isBlacklisted &&
-        (blacklistResult.severity === 'critical' ||
-          blacklistResult.severity === 'high')
-      ) {
-        throw new Error(
-          `Smart account execution blocked: ${
-            blacklistResult.reason || 'Target address is blacklisted'
-          }. Severity: ${blacklistResult.severity}`
+      const targets = getBlacklistTargetsForEvmCall({
+        data: execution.data,
+        to: getAddress(execution.target),
+      });
+
+      for (const target of targets) {
+        const blacklistResult = await blacklistService.checkAddress(
+          target.address
         );
+        if (
+          blacklistResult.isBlacklisted &&
+          (blacklistResult.severity === 'critical' ||
+            blacklistResult.severity === 'high')
+        ) {
+          const fallbackReason =
+            target.type === 'approval'
+              ? 'Spender address is blacklisted'
+              : target.type === 'token-recipient'
+              ? 'Recipient address is blacklisted'
+              : 'Target address is blacklisted';
+          throw new Error(
+            `Smart account execution blocked: ${
+              blacklistResult.reason || fallbackReason
+            }. Severity: ${blacklistResult.severity}`
+          );
+        }
       }
     }
   }

--- a/source/scripts/Background/controllers/smartAccount/index.ts
+++ b/source/scripts/Background/controllers/smartAccount/index.ts
@@ -15,7 +15,7 @@ import { getAddress } from 'utils/ethersV6Compat';
 import { BigNumber } from 'utils/ethersV6Compat';
 import { AddressZero } from 'utils/ethersV6Compat';
 import { Contract } from 'utils/ethersV6Compat';
-import { getBlacklistTargetsForEvmCall } from 'utils/evmCallBlacklist';
+import { getBlacklistTargetsForEvmCallWithContractType } from 'utils/evmCallBlacklist';
 import { blacklistService } from 'utils/security/blacklistService';
 import {
   getSLHDSAKeyId,
@@ -1154,10 +1154,12 @@ class SmartAccountController {
   private async assertSmartAccountExecutionTargetsAllowed(
     executions: Array<{ data?: string; target: string }>
   ): Promise<void> {
+    const provider = this.ethereumTransaction?.web3Provider;
     for (const execution of executions) {
-      const targets = getBlacklistTargetsForEvmCall({
+      const targets = await getBlacklistTargetsForEvmCallWithContractType({
         data: execution.data,
         to: getAddress(execution.target),
+        web3Provider: provider,
       });
 
       for (const target of targets) {

--- a/source/utils/ethUtil.ts
+++ b/source/utils/ethUtil.ts
@@ -63,6 +63,13 @@ export const erc20DataDecoder = async (controller?: any) => {
   }
   return erc20DecoderInstance;
 };
+
+const knownTransactionDataDecoder = createDataDecoder([
+  'function safeTransferFrom(address from,address to,uint256 id,uint256 amount,bytes data)',
+  'function safeBatchTransferFrom(address from,address to,uint256[] ids,uint256[] amounts,bytes data)',
+  'function mintBatch(address to,uint256[] ids,uint256[] amounts,bytes data)',
+]);
+
 // Export approval detection for use in blacklist middleware and UI components
 export const detectApprovalType = async (
   data: string,
@@ -398,6 +405,8 @@ export const decodeTransactionData = async (
       const smartAccountDecoderValue =
         decodeSmartAccountTransactionData(validatedData);
       if (smartAccountDecoderValue) return smartAccountDecoderValue;
+      decoderValue = knownTransactionDataDecoder.decodeData(validatedData);
+      if (decoderValue.method !== null) return decoderValue;
       if (decoderValue.method === null) {
         const methodId = data.slice(0, 10); // Get first 4 bytes (0x + 8 chars)
         const knownMethodName = getMethodName(methodId);

--- a/source/utils/evmCallBlacklist.spec.ts
+++ b/source/utils/evmCallBlacklist.spec.ts
@@ -9,6 +9,8 @@ const RECIPIENT = '0x4444444444444444444444444444444444444444';
 
 const ERC20_INTERFACE = new Interface([
   'function approve(address spender,uint256 amount)',
+  'function decreaseAllowance(address spender,uint256 subtractedValue)',
+  'function increaseAllowance(address spender,uint256 addedValue)',
 ]);
 
 const ERC721_INTERFACE = new Interface([
@@ -30,6 +32,32 @@ describe('getBlacklistTargetsForEvmCall', () => {
       { address: TOKEN, type: 'target' },
       { address: SPENDER, method: 'approve', type: 'approval' },
     ]);
+  });
+
+  it('allows ERC20 allowance reductions and revocations', () => {
+    const revokeTargets = getBlacklistTargetsForEvmCall({
+      data: ERC20_INTERFACE.encodeFunctionData('approve', [SPENDER, 0]),
+      to: TOKEN,
+    });
+    expect(revokeTargets).toEqual([{ address: TOKEN, type: 'target' }]);
+
+    const decreaseTargets = getBlacklistTargetsForEvmCall({
+      data: ERC20_INTERFACE.encodeFunctionData('decreaseAllowance', [
+        SPENDER,
+        1,
+      ]),
+      to: TOKEN,
+    });
+    expect(decreaseTargets).toEqual([{ address: TOKEN, type: 'target' }]);
+
+    const zeroIncreaseTargets = getBlacklistTargetsForEvmCall({
+      data: ERC20_INTERFACE.encodeFunctionData('increaseAllowance', [
+        SPENDER,
+        0,
+      ]),
+      to: TOKEN,
+    });
+    expect(zeroIncreaseTargets).toEqual([{ address: TOKEN, type: 'target' }]);
   });
 
   it('includes approved NFT operators but ignores revocations', () => {

--- a/source/utils/evmCallBlacklist.spec.ts
+++ b/source/utils/evmCallBlacklist.spec.ts
@@ -37,6 +37,7 @@ describe('getBlacklistTargetsForEvmCall', () => {
   it('allows ERC20 allowance reductions and revocations', () => {
     const revokeTargets = getBlacklistTargetsForEvmCall({
       data: ERC20_INTERFACE.encodeFunctionData('approve', [SPENDER, 0]),
+      tokenStandard: 'ERC-20',
       to: TOKEN,
     });
     expect(revokeTargets).toEqual([{ address: TOKEN, type: 'target' }]);
@@ -58,6 +59,18 @@ describe('getBlacklistTargetsForEvmCall', () => {
       to: TOKEN,
     });
     expect(zeroIncreaseTargets).toEqual([{ address: TOKEN, type: 'target' }]);
+  });
+
+  it('does not treat unknown zero approve calls as ERC20 revocations', () => {
+    const targets = getBlacklistTargetsForEvmCall({
+      data: ERC20_INTERFACE.encodeFunctionData('approve', [SPENDER, 0]),
+      to: TOKEN,
+    });
+
+    expect(targets).toEqual([
+      { address: TOKEN, type: 'target' },
+      { address: SPENDER, method: 'approve', type: 'approval' },
+    ]);
   });
 
   it('includes approved NFT operators but ignores revocations', () => {

--- a/source/utils/evmCallBlacklist.spec.ts
+++ b/source/utils/evmCallBlacklist.spec.ts
@@ -1,0 +1,76 @@
+import { Interface } from 'utils/ethersV6Compat';
+
+import { getBlacklistTargetsForEvmCall } from './evmCallBlacklist';
+
+const TOKEN = '0x1111111111111111111111111111111111111111';
+const SPENDER = '0x2222222222222222222222222222222222222222';
+const OPERATOR = '0x3333333333333333333333333333333333333333';
+const RECIPIENT = '0x4444444444444444444444444444444444444444';
+
+const ERC20_INTERFACE = new Interface([
+  'function approve(address spender,uint256 amount)',
+]);
+
+const ERC721_INTERFACE = new Interface([
+  'function setApprovalForAll(address operator,bool approved)',
+]);
+
+const ERC1155_INTERFACE = new Interface([
+  'function safeBatchTransferFrom(address from,address to,uint256[] ids,uint256[] amounts,bytes data)',
+]);
+
+describe('getBlacklistTargetsForEvmCall', () => {
+  it('includes the direct target and ERC20 approval spender', () => {
+    const targets = getBlacklistTargetsForEvmCall({
+      data: ERC20_INTERFACE.encodeFunctionData('approve', [SPENDER, 1]),
+      to: TOKEN,
+    });
+
+    expect(targets).toEqual([
+      { address: TOKEN, type: 'target' },
+      { address: SPENDER, method: 'approve', type: 'approval' },
+    ]);
+  });
+
+  it('includes approved NFT operators but ignores revocations', () => {
+    const approvalTargets = getBlacklistTargetsForEvmCall({
+      data: ERC721_INTERFACE.encodeFunctionData('setApprovalForAll', [
+        OPERATOR,
+        true,
+      ]),
+    });
+    expect(approvalTargets).toEqual([
+      { address: OPERATOR, method: 'setApprovalForAll', type: 'approval' },
+    ]);
+
+    const revokeTargets = getBlacklistTargetsForEvmCall({
+      data: ERC721_INTERFACE.encodeFunctionData('setApprovalForAll', [
+        OPERATOR,
+        false,
+      ]),
+    });
+    expect(revokeTargets).toEqual([]);
+  });
+
+  it('extracts ERC1155 batch transfer recipients', () => {
+    const targets = getBlacklistTargetsForEvmCall({
+      data: ERC1155_INTERFACE.encodeFunctionData('safeBatchTransferFrom', [
+        SPENDER,
+        RECIPIENT,
+        [1, 2],
+        [10, 20],
+        '0x',
+      ]),
+      to: TOKEN,
+    });
+
+    expect(targets).toEqual([
+      { address: TOKEN, type: 'target' },
+      {
+        address: RECIPIENT,
+        method: 'safeBatchTransferFrom',
+        type: 'token-recipient',
+      },
+    ]);
+  });
+});

--- a/source/utils/evmCallBlacklist.ts
+++ b/source/utils/evmCallBlacklist.ts
@@ -1,0 +1,188 @@
+import { defaultAbiCoder, getAddress, isAddress } from 'utils/ethersV6Compat';
+
+export type EvmCallBlacklistTargetType =
+  | 'approval'
+  | 'recipient'
+  | 'target'
+  | 'token-recipient';
+
+export interface IEvmCallBlacklistTarget {
+  address: string;
+  method?: string;
+  type: EvmCallBlacklistTargetType;
+}
+
+const normalizeAddress = (address?: string | null): string | null => {
+  if (!address) return null;
+  if (isAddress(address)) return getAddress(address);
+  if (/^0x[0-9a-fA-F]{40}$/.test(address)) {
+    return getAddress(address.toLowerCase());
+  }
+  return null;
+};
+
+const decodeAddressTargets = (data?: string): IEvmCallBlacklistTarget[] => {
+  if (!data || data === '0x' || data.length < 10) return [];
+
+  const selector = data.slice(0, 10).toLowerCase();
+  const calldata = `0x${data.slice(10)}`;
+
+  try {
+    switch (selector) {
+      case '0x095ea7b3': {
+        const [spender] = defaultAbiCoder.decode(
+          ['address', 'uint256'],
+          calldata
+        );
+        return [
+          { address: getAddress(spender), method: 'approve', type: 'approval' },
+        ];
+      }
+      case '0x39509351': {
+        const [spender] = defaultAbiCoder.decode(
+          ['address', 'uint256'],
+          calldata
+        );
+        return [
+          {
+            address: getAddress(spender),
+            method: 'increaseAllowance',
+            type: 'approval',
+          },
+        ];
+      }
+      case '0xa457c2d7': {
+        const [spender] = defaultAbiCoder.decode(
+          ['address', 'uint256'],
+          calldata
+        );
+        return [
+          {
+            address: getAddress(spender),
+            method: 'decreaseAllowance',
+            type: 'approval',
+          },
+        ];
+      }
+      case '0xa22cb465': {
+        const [operator, approved] = defaultAbiCoder.decode(
+          ['address', 'bool'],
+          calldata
+        );
+        return approved
+          ? [
+              {
+                address: getAddress(operator),
+                method: 'setApprovalForAll',
+                type: 'approval',
+              },
+            ]
+          : [];
+      }
+      case '0xa9059cbb': {
+        const [to] = defaultAbiCoder.decode(['address', 'uint256'], calldata);
+        return [
+          {
+            address: getAddress(to),
+            method: 'transfer',
+            type: 'token-recipient',
+          },
+        ];
+      }
+      case '0x23b872dd': {
+        const [, to] = defaultAbiCoder.decode(
+          ['address', 'address', 'uint256'],
+          calldata
+        );
+        return [
+          {
+            address: getAddress(to),
+            method: 'transferFrom',
+            type: 'token-recipient',
+          },
+        ];
+      }
+      case '0x42842e0e': {
+        const [, to] = defaultAbiCoder.decode(
+          ['address', 'address', 'uint256'],
+          calldata
+        );
+        return [
+          {
+            address: getAddress(to),
+            method: 'safeTransferFrom',
+            type: 'token-recipient',
+          },
+        ];
+      }
+      case '0xb88d4fde': {
+        const [, to] = defaultAbiCoder.decode(
+          ['address', 'address', 'uint256', 'bytes'],
+          calldata
+        );
+        return [
+          {
+            address: getAddress(to),
+            method: 'safeTransferFrom',
+            type: 'token-recipient',
+          },
+        ];
+      }
+      case '0xf242432a': {
+        const [, to] = defaultAbiCoder.decode(
+          ['address', 'address', 'uint256', 'uint256', 'bytes'],
+          calldata
+        );
+        return [
+          {
+            address: getAddress(to),
+            method: 'safeTransferFrom',
+            type: 'token-recipient',
+          },
+        ];
+      }
+      case '0x2eb2c2d6': {
+        const [, to] = defaultAbiCoder.decode(
+          ['address', 'address', 'uint256[]', 'uint256[]', 'bytes'],
+          calldata
+        );
+        return [
+          {
+            address: getAddress(to),
+            method: 'safeBatchTransferFrom',
+            type: 'token-recipient',
+          },
+        ];
+      }
+      default:
+        return [];
+    }
+  } catch {
+    return [];
+  }
+};
+
+export const getBlacklistTargetsForEvmCall = ({
+  data,
+  to,
+}: {
+  data?: string;
+  to?: string;
+}): IEvmCallBlacklistTarget[] => {
+  const targets = decodeAddressTargets(data);
+  const normalizedTo = normalizeAddress(to);
+
+  if (normalizedTo) {
+    targets.unshift({ address: normalizedTo, type: 'target' });
+  }
+
+  const seen = new Set<string>();
+  return targets.filter((target) => {
+    const key = `${target.type}:${target.address.toLowerCase()}:${
+      target.method ?? ''
+    }`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+};

--- a/source/utils/evmCallBlacklist.ts
+++ b/source/utils/evmCallBlacklist.ts
@@ -1,4 +1,5 @@
 import { defaultAbiCoder, getAddress, isAddress } from 'utils/ethersV6Compat';
+import { getContractType } from 'utils/validations';
 
 export type EvmCallBlacklistTargetType =
   | 'approval'
@@ -24,7 +25,13 @@ const normalizeAddress = (address?: string | null): string | null => {
 const isZeroIntegerValue = (value: unknown): boolean =>
   value != null && value.toString() === '0';
 
-const decodeAddressTargets = (data?: string): IEvmCallBlacklistTarget[] => {
+export const shouldResolveEvmCallBlacklistContractType = (data?: string) =>
+  data?.slice(0, 10).toLowerCase() === '0x095ea7b3';
+
+const decodeAddressTargets = (
+  data?: string,
+  tokenStandard?: string
+): IEvmCallBlacklistTarget[] => {
   if (!data || data === '0x' || data.length < 10) return [];
 
   const selector = data.slice(0, 10).toLowerCase();
@@ -37,7 +44,9 @@ const decodeAddressTargets = (data?: string): IEvmCallBlacklistTarget[] => {
           ['address', 'uint256'],
           calldata
         );
-        if (isZeroIntegerValue(amount)) return [];
+        if (tokenStandard === 'ERC-20' && isZeroIntegerValue(amount)) {
+          return [];
+        }
         return [
           { address: getAddress(spender), method: 'approve', type: 'approval' },
         ];
@@ -159,12 +168,14 @@ const decodeAddressTargets = (data?: string): IEvmCallBlacklistTarget[] => {
 
 export const getBlacklistTargetsForEvmCall = ({
   data,
+  tokenStandard,
   to,
 }: {
   data?: string;
   to?: string;
+  tokenStandard?: string;
 }): IEvmCallBlacklistTarget[] => {
-  const targets = decodeAddressTargets(data);
+  const targets = decodeAddressTargets(data, tokenStandard);
   const normalizedTo = normalizeAddress(to);
 
   if (normalizedTo) {
@@ -179,5 +190,34 @@ export const getBlacklistTargetsForEvmCall = ({
     if (seen.has(key)) return false;
     seen.add(key);
     return true;
+  });
+};
+
+export const getBlacklistTargetsForEvmCallWithContractType = async ({
+  controller,
+  data,
+  to,
+  web3Provider,
+}: {
+  controller?: any;
+  data?: string;
+  to?: string;
+  web3Provider?: any;
+}): Promise<IEvmCallBlacklistTarget[]> => {
+  let tokenStandard: string | undefined;
+
+  if (to && web3Provider && shouldResolveEvmCallBlacklistContractType(data)) {
+    try {
+      tokenStandard = (await getContractType(to, web3Provider, controller))
+        ?.type;
+    } catch {
+      tokenStandard = undefined;
+    }
+  }
+
+  return getBlacklistTargetsForEvmCall({
+    data,
+    to,
+    tokenStandard,
   });
 };

--- a/source/utils/evmCallBlacklist.ts
+++ b/source/utils/evmCallBlacklist.ts
@@ -21,6 +21,9 @@ const normalizeAddress = (address?: string | null): string | null => {
   return null;
 };
 
+const isZeroIntegerValue = (value: unknown): boolean =>
+  value != null && value.toString() === '0';
+
 const decodeAddressTargets = (data?: string): IEvmCallBlacklistTarget[] => {
   if (!data || data === '0x' || data.length < 10) return [];
 
@@ -30,19 +33,21 @@ const decodeAddressTargets = (data?: string): IEvmCallBlacklistTarget[] => {
   try {
     switch (selector) {
       case '0x095ea7b3': {
-        const [spender] = defaultAbiCoder.decode(
+        const [spender, amount] = defaultAbiCoder.decode(
           ['address', 'uint256'],
           calldata
         );
+        if (isZeroIntegerValue(amount)) return [];
         return [
           { address: getAddress(spender), method: 'approve', type: 'approval' },
         ];
       }
       case '0x39509351': {
-        const [spender] = defaultAbiCoder.decode(
+        const [spender, addedValue] = defaultAbiCoder.decode(
           ['address', 'uint256'],
           calldata
         );
+        if (isZeroIntegerValue(addedValue)) return [];
         return [
           {
             address: getAddress(spender),
@@ -52,17 +57,7 @@ const decodeAddressTargets = (data?: string): IEvmCallBlacklistTarget[] => {
         ];
       }
       case '0xa457c2d7': {
-        const [spender] = defaultAbiCoder.decode(
-          ['address', 'uint256'],
-          calldata
-        );
-        return [
-          {
-            address: getAddress(spender),
-            method: 'decreaseAllowance',
-            type: 'approval',
-          },
-        ];
+        return [];
       }
       case '0xa22cb465': {
         const [operator, approved] = defaultAbiCoder.decode(

--- a/yarn.lock
+++ b/yarn.lock
@@ -3025,10 +3025,10 @@
   resolved "https://registry.yarnpkg.com/@sidhujag/sysweb3-core/-/sysweb3-core-1.0.28.tgz#05daaf0a9411febfe36d96a43f76767a5bcd5d03"
   integrity sha512-YN3qdoPNyFFdseO/iaUmr0gSWpKbVEPA6I9ePd8Sny2BhY11SsXkj1x+acL9RfmtsfZ7kh+tzo3//OOGCw+PLA==
 
-"@sidhujag/sysweb3-keyring@^1.0.608":
-  version "1.0.608"
-  resolved "https://registry.yarnpkg.com/@sidhujag/sysweb3-keyring/-/sysweb3-keyring-1.0.608.tgz#7f658702a841b5830f45fb42b8e291c4c080708c"
-  integrity sha512-vzSe85ataePLvJTF96gggEzJ2B88YnC1SyV/LXCgbBak1A/Yb8ylQvhmMfVEA+jj8VETh2dAxdEGTMaonMfW9A==
+"@sidhujag/sysweb3-keyring@^1.0.609":
+  version "1.0.609"
+  resolved "https://registry.yarnpkg.com/@sidhujag/sysweb3-keyring/-/sysweb3-keyring-1.0.609.tgz#b70f717fb230d3d5d2bc6c545674b04aa97bc6dd"
+  integrity sha512-2abNAhx2GfSRHddg5z7Xg0wTMOmB6gYZgtaIzzqd+3ldpH/rVTRl1/iij+i02JVIhbFmhFzx0upgtLepkOG1kg==
   dependencies:
     "@bitcoinerlab/secp256k1" "^1.2.0"
     "@ledgerhq/hw-app-eth" "^6.47.1"


### PR DESCRIPTION
## Summary
- Add shared EVM calldata blacklist target extraction and apply it to `eth_sendTransaction`, `wallet_sendCalls`, and smart-account execution guards.
- Use RPC custom errors for EIP-5792 57xx codes and preserve bundle status handling.
- Improve smart-account signing compatibility by pruning unused typed-data types before hashing and add curated decoding for known ERC1155 calldata.

## Test plan
- `yarn --ignore-engines test --runTestsByPath source/utils/evmCallBlacklist.spec.ts source/helpers/errors/errors.spec.ts`
- `yarn --ignore-engines type-check`


Made with [Cursor](https://cursor.com)