### PR TITLE
Fix external EVM nonce selection

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Pali Wallet",
-  "version": "4.0.41",
+  "version": "4.0.42",
   "icons": {
     "16": "assets/all_assets/favicon-16.png",
     "32": "assets/all_assets/favicon-32.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paliwallet",
-  "version": "4.0.41",
+  "version": "4.0.42",
   "description": "A Non-Custodial Crypto Wallet",
   "private": true,
   "repository": {

--- a/source/config/consts.js
+++ b/source/config/consts.js
@@ -80,7 +80,7 @@ const CANARY_EXTENSION_KEY =
 const MV3_OPTIONS = {
   manifest_version: 3,
   name: 'Pali Wallet',
-  version: '4.0.41',
+  version: '4.0.42',
   icons: {
     16: 'assets/all_assets/favicon-16.png',
     32: 'assets/all_assets/favicon-32.png',

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -107,6 +107,10 @@ import { Contract } from 'utils/ethersV6Compat';
 import { isHexString } from 'utils/ethersV6Compat';
 import { decodeTransactionData } from 'utils/ethUtil';
 import { getBlacklistTargetsForEvmCallWithContractType } from 'utils/evmCallBlacklist';
+import {
+  getEoaNonceFromHistoryTransaction,
+  needsEoaNonceHistoryVerification,
+} from 'utils/evmNonce';
 import { logError } from 'utils/logger';
 import { getNetworkChain } from 'utils/network';
 import { blacklistService } from 'utils/security/blacklistService';
@@ -5018,7 +5022,10 @@ class MainController {
         }
       }
 
-      let localConfirmedNextNonce = 0;
+      const localConfirmedTransactions: Array<{
+        nonce: number;
+        transaction: any;
+      }> = [];
       const localPendingNonces = new Set<number>();
       const localTransactions =
         accountType !== undefined && accountId !== undefined
@@ -5030,29 +5037,55 @@ class MainController {
       // Match MetaMask's nonce model: start from canonical/latest chain state
       // plus local confirmed history, then skip nonces Pali has locally pending.
       for (const tx of localTransactions as any[]) {
-        if (tx.from && tx.from.toLowerCase() !== normalizedAddress) {
-          continue;
-        }
-        if (tx.nonce === undefined || tx.nonce === null) {
+        const nonce = getEoaNonceFromHistoryTransaction(tx, normalizedAddress);
+        if (nonce === undefined) {
           continue;
         }
 
-        const nonce =
-          typeof tx.nonce === 'string'
-            ? tx.nonce.startsWith('0x')
-              ? parseInt(tx.nonce, 16)
-              : Number(tx.nonce)
-            : Number(tx.nonce);
-        if (Number.isFinite(nonce)) {
-          if (isTransactionInBlock(tx)) {
-            localConfirmedNextNonce = Math.max(
-              localConfirmedNextNonce,
-              nonce + 1
+        if (isTransactionInBlock(tx)) {
+          localConfirmedTransactions.push({ nonce, transaction: tx });
+        } else {
+          localPendingNonces.add(nonce);
+        }
+      }
+
+      // Highest confirmed nonce is the only one that can affect the result.
+      // Verify incomplete explorer/history rows lazily so priority operations
+      // and old token-event records cannot masquerade as EOA transactions.
+      localConfirmedTransactions.sort((a, b) => b.nonce - a.nonce);
+      let localConfirmedNextNonce = 0;
+      for (const candidate of localConfirmedTransactions) {
+        if (candidate.nonce < latestNonce) {
+          break;
+        }
+
+        if (needsEoaNonceHistoryVerification(candidate.transaction)) {
+          const hash = candidate.transaction?.hash;
+          if (!hash) {
+            continue;
+          }
+
+          try {
+            const providerTransaction = await provider.send(
+              'eth_getTransactionByHash',
+              [hash]
             );
-          } else {
-            localPendingNonces.add(nonce);
+            if (
+              !providerTransaction ||
+              getEoaNonceFromHistoryTransaction(
+                providerTransaction as any,
+                normalizedAddress
+              ) !== candidate.nonce
+            ) {
+              continue;
+            }
+          } catch {
+            continue;
           }
         }
+
+        localConfirmedNextNonce = candidate.nonce + 1;
+        break;
       }
 
       let nextNonce = Math.max(latestNonce, localConfirmedNextNonce);

--- a/source/scripts/Background/controllers/transactions/evm.ts
+++ b/source/scripts/Background/controllers/transactions/evm.ts
@@ -4,6 +4,11 @@ import { INetworkType, retryableFetch } from '@sidhujag/sysweb3-network';
 import store from 'state/store';
 import { setActiveAccountProperty } from 'state/vault';
 import { hasPositiveBalance } from 'utils/balance';
+import {
+  EVM_TRANSACTION_HISTORY_SOURCE,
+  parseEvmInteger,
+  type EvmTransactionHistorySource,
+} from 'utils/evmNonce';
 
 import { fetchSmartAccountUserOpTransactions } from './smartAccountHistory';
 import { IEvmTransactionsController, IEvmTransactionResponse } from './types';
@@ -140,7 +145,8 @@ const EvmTransactionsController = (): IEvmTransactionsController => {
     const mapApiTx = (
       item: any,
       chainIdForMap: number,
-      overrideTo?: string
+      overrideTo?: string,
+      historySource: EvmTransactionHistorySource = EVM_TRANSACTION_HISTORY_SOURCE.ExplorerTransaction
     ) => {
       // Validate timestamp into a sane range
       let timestamp = parseInt(item.timeStamp, 10);
@@ -181,6 +187,11 @@ const EvmTransactionsController = (): IEvmTransactionsController => {
         gasPrice: item.gasPrice,
         gas: item.gas || item.gasLimit,
         nonce: nonceParsed,
+        type: parseEvmInteger(item.type),
+        r: item.r,
+        s: item.s,
+        v: parseEvmInteger(item.v),
+        historySource,
         // eslint-disable-next-line camelcase
         txreceipt_status: item.txreceipt_status || item.isError || null,
         isError: item.isError || null,
@@ -312,7 +323,12 @@ const EvmTransactionsController = (): IEvmTransactionsController => {
           const token20Data = await token20Response.json();
           if (Array.isArray(token20Data?.result)) {
             for (const ev of token20Data.result) {
-              const base = mapApiTx(ev, chainId, ev.contractAddress);
+              const base = mapApiTx(
+                ev,
+                chainId,
+                ev.contractAddress,
+                EVM_TRANSACTION_HISTORY_SOURCE.ExplorerTokenTransfer
+              );
               tokenOnly.push({ ...base, tokenRecipient: ev.to } as any);
             }
           }
@@ -412,6 +428,11 @@ const EvmTransactionsController = (): IEvmTransactionsController => {
               tx.nonce !== undefined && tx.nonce !== null
                 ? parseInt(tx.nonce)
                 : undefined,
+            type: parseEvmInteger(tx.type),
+            r: tx.r,
+            s: tx.s,
+            v: parseEvmInteger(tx.v),
+            historySource: EVM_TRANSACTION_HISTORY_SOURCE.ExplorerPending,
             // Add any other fields your UI expects as null/default
             contractAddress: tx.contractAddress || null,
             cumulativeGasUsed: tx.cumulativeGasUsed || null,
@@ -440,7 +461,12 @@ const EvmTransactionsController = (): IEvmTransactionsController => {
     } catch {}
 
     const tokenTransactions = tokenEventResults.map((ev: any) => {
-      const base = mapApiTx(ev, chainId, ev.contractAddress);
+      const base = mapApiTx(
+        ev,
+        chainId,
+        ev.contractAddress,
+        EVM_TRANSACTION_HISTORY_SOURCE.ExplorerTokenTransfer
+      );
       return { ...base, tokenRecipient: ev.to } as any;
     });
 
@@ -551,7 +577,12 @@ const EvmTransactionsController = (): IEvmTransactionsController => {
             if (Array.isArray(token20Data?.result))
               tokenEvents.push(...token20Data.result);
             const tokenTxs = tokenEvents.map((ev: any) => {
-              const base = mapApiTx(ev, chainId, ev.contractAddress);
+              const base = mapApiTx(
+                ev,
+                chainId,
+                ev.contractAddress,
+                EVM_TRANSACTION_HISTORY_SOURCE.ExplorerTokenTransfer
+              );
               return { ...base, tokenRecipient: ev.to } as any;
             });
             return { transactions: tokenTxs };
@@ -573,11 +604,12 @@ const EvmTransactionsController = (): IEvmTransactionsController => {
       ]);
 
       // Shared mapper for API items (txlist or tokentx) to internal shape
-      const mapApiTx = (
+      function mapApiTx(
         item: any,
         chainIdForMap: number,
-        overrideTo?: string
-      ) => {
+        overrideTo?: string,
+        historySource: EvmTransactionHistorySource = EVM_TRANSACTION_HISTORY_SOURCE.ExplorerTransaction
+      ) {
         let timestamp = parseInt(item.timeStamp, 10);
         const now = Math.floor(Date.now() / 1000);
         const oneYearFromNow = now + 365 * 24 * 60 * 60;
@@ -616,11 +648,16 @@ const EvmTransactionsController = (): IEvmTransactionsController => {
           gasPrice: item.gasPrice,
           gas: item.gas || item.gasLimit,
           nonce: nonceParsed,
+          type: parseEvmInteger(item.type),
+          r: item.r,
+          s: item.s,
+          v: parseEvmInteger(item.v),
+          historySource,
           // eslint-disable-next-line camelcase
           txreceipt_status: item.txreceipt_status || item.isError || null,
           isError: item.isError || null,
         } as any;
-      };
+      }
 
       let baseTxs: IEvmTransactionResponse[] = [];
       let baseCount = 0;

--- a/source/scripts/Background/controllers/transactions/utils.ts
+++ b/source/scripts/Background/controllers/transactions/utils.ts
@@ -303,12 +303,24 @@ export const treatAndSortTransactions = (
 
       txMap.set(id, mergedTx);
     } else if (existing) {
-      // The existing tx has same or more confirmations, but check if new tx has earlier timestamps
+      // The existing tx has same or more confirmations, but enrich it with
+      // authoritative explorer metadata and earlier timestamps. Older vault
+      // rows may predate the source/type fields used for EOA nonce filtering.
       const TSTAMP_PROP = 'timestamp' as keyof UnifiedTransaction;
       const BLOCKTIME_PROP = 'blockTime' as keyof UnifiedTransaction;
 
       let updated = false;
       const mergedTx = { ...existing };
+
+      for (const metadataProperty of ['historySource', 'type', 'r', 's', 'v']) {
+        if (
+          (tx as any)[metadataProperty] !== undefined &&
+          (tx as any)[metadataProperty] !== (existing as any)[metadataProperty]
+        ) {
+          (mergedTx as any)[metadataProperty] = (tx as any)[metadataProperty];
+          updated = true;
+        }
+      }
 
       if (
         tx[TSTAMP_PROP] &&

--- a/source/utils/evmNonce.spec.ts
+++ b/source/utils/evmNonce.spec.ts
@@ -1,0 +1,107 @@
+import {
+  EVM_TRANSACTION_HISTORY_SOURCE,
+  getEoaNonceFromHistoryTransaction,
+  needsEoaNonceHistoryVerification,
+  parseEvmInteger,
+} from './evmNonce';
+
+const ADDRESS = '0x6781dd2b72002f1fb37E7415479cBF5ffE828BfB';
+
+describe('EOA nonce history filtering', () => {
+  it('accepts a standard outgoing EOA transaction', () => {
+    expect(
+      getEoaNonceFromHistoryTransaction(
+        { from: ADDRESS.toLowerCase(), nonce: '0x2', type: '0x2' },
+        ADDRESS
+      )
+    ).toBe(2);
+  });
+
+  it('rejects rows without the exact EOA sender', () => {
+    expect(getEoaNonceFromHistoryTransaction({ nonce: 9 }, ADDRESS)).toBe(
+      undefined
+    );
+    expect(
+      getEoaNonceFromHistoryTransaction(
+        { from: '0x0000000000000000000000000000000000000001', nonce: 9 },
+        ADDRESS
+      )
+    ).toBe(undefined);
+  });
+
+  it('rejects explorer token-transfer event placeholders', () => {
+    expect(
+      getEoaNonceFromHistoryTransaction(
+        {
+          from: ADDRESS,
+          historySource: EVM_TRANSACTION_HISTORY_SOURCE.ExplorerTokenTransfer,
+          nonce: 847,
+        },
+        ADDRESS
+      )
+    ).toBe(undefined);
+  });
+
+  it('rejects zkSYS L1-to-L2 priority operations', () => {
+    expect(
+      getEoaNonceFromHistoryTransaction(
+        { from: ADDRESS, nonce: 133, type: '0x7f' },
+        ADDRESS
+      )
+    ).toBe(undefined);
+    expect(
+      getEoaNonceFromHistoryTransaction(
+        {
+          from: ADDRESS,
+          nonce: 133,
+          r: `0x${'0'.repeat(64)}`,
+          s: `0x${'0'.repeat(64)}`,
+          v: '0x0',
+        },
+        ADDRESS
+      )
+    ).toBe(undefined);
+  });
+
+  it('rejects synthetic smart-account display transactions', () => {
+    expect(
+      getEoaNonceFromHistoryTransaction(
+        {
+          from: ADDRESS,
+          nonce: 14,
+          smartAccountExecutionFrom: ADDRESS,
+          type: 2,
+        },
+        ADDRESS
+      )
+    ).toBe(undefined);
+  });
+
+  it('recognizes legacy persisted rows that require verification', () => {
+    expect(
+      needsEoaNonceHistoryVerification({ from: ADDRESS, nonce: 133 })
+    ).toBe(true);
+    expect(
+      needsEoaNonceHistoryVerification({
+        from: ADDRESS,
+        historySource: EVM_TRANSACTION_HISTORY_SOURCE.ExplorerTransaction,
+        nonce: 133,
+      })
+    ).toBe(true);
+    expect(
+      needsEoaNonceHistoryVerification({
+        from: ADDRESS,
+        historySource: EVM_TRANSACTION_HISTORY_SOURCE.ExplorerTransaction,
+        nonce: 1,
+        type: 2,
+      })
+    ).toBe(false);
+  });
+
+  it('parses decimal and hexadecimal EVM quantities safely', () => {
+    expect(parseEvmInteger('0x7f')).toBe(127);
+    expect(parseEvmInteger('133')).toBe(133);
+    expect(parseEvmInteger(-1)).toBe(undefined);
+    expect(parseEvmInteger('not-a-number')).toBe(undefined);
+  });
+});

--- a/source/utils/evmNonce.ts
+++ b/source/utils/evmNonce.ts
@@ -1,0 +1,90 @@
+export const EVM_TRANSACTION_HISTORY_SOURCE = {
+  ExplorerPending: 'explorer-pendingtxlist',
+  ExplorerTokenTransfer: 'explorer-tokentx',
+  ExplorerTransaction: 'explorer-txlist',
+} as const;
+
+export type EvmTransactionHistorySource =
+  (typeof EVM_TRANSACTION_HISTORY_SOURCE)[keyof typeof EVM_TRANSACTION_HISTORY_SOURCE];
+
+interface IEvmNonceHistoryTransaction {
+  from?: unknown;
+  historySource?: EvmTransactionHistorySource | string;
+  nonce?: unknown;
+  r?: unknown;
+  s?: unknown;
+  smartAccountExecutionFrom?: unknown;
+  type?: unknown;
+  v?: unknown;
+}
+
+export const parseEvmInteger = (value: unknown): number | undefined => {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+
+  const parsed =
+    typeof value === 'string' && value.toLowerCase().startsWith('0x')
+      ? parseInt(value, 16)
+      : Number(value);
+
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : undefined;
+};
+
+const isZeroEvmValue = (value: unknown): boolean => {
+  if (typeof value === 'number') {
+    return value === 0;
+  }
+  if (typeof value !== 'string') {
+    return false;
+  }
+
+  const normalized = value.toLowerCase().replace(/^0x/, '').replace(/^0+/, '');
+  return normalized.length === 0;
+};
+
+const hasZeroSignature = (tx: IEvmNonceHistoryTransaction): boolean =>
+  tx.r !== undefined &&
+  tx.s !== undefined &&
+  tx.v !== undefined &&
+  isZeroEvmValue(tx.r) &&
+  isZeroEvmValue(tx.s) &&
+  isZeroEvmValue(tx.v);
+
+/**
+ * Returns the nonce only when the history row represents an EOA transaction
+ * sent by the requested address. Explorer token-event placeholders, ERC-4337
+ * display rows, and unsigned L1-to-L2 priority operations do not consume the
+ * EOA's sequential nonce.
+ */
+export const getEoaNonceFromHistoryTransaction = (
+  tx: IEvmNonceHistoryTransaction,
+  address: string
+): number | undefined => {
+  if (
+    typeof tx.from !== 'string' ||
+    tx.from.toLowerCase() !== address.toLowerCase() ||
+    tx.historySource === EVM_TRANSACTION_HISTORY_SOURCE.ExplorerTokenTransfer ||
+    Boolean(tx.smartAccountExecutionFrom)
+  ) {
+    return undefined;
+  }
+
+  const transactionType = parseEvmInteger(tx.type);
+  if (transactionType === 0x7f || hasZeroSignature(tx)) {
+    return undefined;
+  }
+
+  return parseEvmInteger(tx.nonce);
+};
+
+/**
+ * Explorer APIs may omit type/signature metadata, and old persisted rows also
+ * predate it. Such rows need a transaction-by-hash check before they can
+ * advance an EOA nonce beyond the provider's canonical latest value.
+ */
+export const needsEoaNonceHistoryVerification = (
+  tx: IEvmNonceHistoryTransaction
+): boolean =>
+  parseEvmInteger(tx.type) === undefined &&
+  (tx.r === undefined || tx.s === undefined || tx.v === undefined);


### PR DESCRIPTION
## Summary

- preserve the existing canonical/latest plus local confirmed and pending-gap nonce strategy used by external dapp sends
- restrict local nonce inputs to real EOA transactions from the requested sender
- tag explorer transaction sources and retain type/signature metadata
- exclude zkSYS L1-to-L2 priority operations, token-event placeholders, sender-less rows, and synthetic smart-account display rows
- verify incomplete persisted explorer rows by transaction hash before they can advance the EOA nonce
- add focused nonce filtering coverage
- bump Pali and MV3 manifest versions to 4.0.42

## Root cause

The external signing popup consumed the shared EVM transaction history as if every row represented an EOA transaction. zkTanenbaum explorer `txlist` rows for type `0x7f` priority operations omitted `type`, `r`, `s`, and `v`, so priority IDs such as 130 and 133 were interpreted as the account's sequential nonce. Explorer `tokentx` placeholders could also pair an ERC-20 event sender with the enclosing transaction sender's nonce, producing the same class of incorrect recommendation on mainnet dapps.

## Impact

External `eth_sendTransaction` and `wallet_sendCalls` popups now recommend the next EOA nonce without discarding the local-history gap handling needed for stale provider state. Internal wallet sends remain on their existing path.

## Validation

- `npm run type-check`
- `npm test -- --runInBand source/utils/evmNonce.spec.ts` — 7 tests passed
- repository ESLint/lint-staged pre-commit hook
- repository TypeScript pre-push hook
- Canary Chrome production-mode Webpack build
- Production Chrome Webpack build
- live zkTanenbaum verification: account latest nonce `0`; explorer priority rows `130/133`; raw RPC type `0x7f` with zero signature
