### PR TITLE
Harden extension message and provider boundaries

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -3,11 +3,7 @@
   "moduleFileExtensions": ["js", "mjs", "ts", "json", "jsx", "tsx"],
   "moduleDirectories": ["source", "node_modules"],
   "modulePathIgnorePatterns": ["node_modules"],
-  "testPathIgnorePatterns": [
-    "<rootDir>/tests/account/",
-    "<rootDir>/e2e/",
-    "<rootDir>/source/scripts/Background/handlers/handleListeners.spec.ts"
-  ],
+  "testPathIgnorePatterns": ["<rootDir>/tests/account/", "<rootDir>/e2e/"],
   "transform": {
     "^.+\\.(js|jsx|mjs|cjs|ts|tsx)$": [
       "ts-jest",

--- a/source/scripts/Background/controllers/message-handler/method-handlers.security.spec.ts
+++ b/source/scripts/Background/controllers/message-handler/method-handlers.security.spec.ts
@@ -1,0 +1,254 @@
+const getControllerMock = jest.fn();
+const getStateMock = jest.fn();
+
+jest.mock('scripts/Background', () => ({
+  getController: () => getControllerMock(),
+}));
+
+jest.mock('state/store', () => ({
+  __esModule: true,
+  default: {
+    getState: () => getStateMock(),
+  },
+}));
+
+jest.mock('scripts/Provider/EthProvider', () => ({
+  EthProvider: jest.fn(),
+}));
+
+jest.mock('scripts/Provider/SysProvider', () => ({
+  SysProvider: jest.fn(),
+}));
+
+jest.mock('./popup-promise', () => ({
+  popupPromise: jest.fn(),
+}));
+
+jest.mock('./request-pipeline', () => ({
+  requestCoordinator: {
+    coordinatePopupRequest: jest.fn(),
+  },
+}));
+
+jest.mock('./sendCallsBundles', () => ({
+  generateWalletBundleId: jest.fn(),
+  isValidAppProvidedBundleId: jest.fn(),
+  releaseSendCallsBundleReservation: jest.fn(),
+  reserveSendCallsBundle: jest.fn(),
+  resolveCallsStatus: jest.fn(),
+}));
+
+import {
+  clearProviderCache,
+  EthMethodHandler,
+  WalletMethodHandler,
+} from './method-handlers';
+import {
+  IEnhancedRequestContext,
+  MethodHandlerType,
+  NetworkEnforcement,
+  NetworkPreference,
+} from './types';
+
+const ACTIVE_ADDRESS = '0x1111111111111111111111111111111111111111';
+const CONNECTED_ADDRESS = '0x2222222222222222222222222222222222222222';
+
+const activeAccount = {
+  address: ACTIVE_ADDRESS,
+  id: 0,
+  type: 'HDAccount',
+  xpub: 'active-xpub',
+};
+
+const connectedAccount = {
+  address: CONNECTED_ADDRESS,
+  id: 1,
+  type: 'HDAccount',
+  xpub: 'connected-xpub',
+};
+
+const activeTokens = [{ balance: '100', token: 'active-token' }];
+const connectedTokens = [{ balance: '200', token: 'connected-token' }];
+
+const makeContext = (
+  method: string,
+  host: string,
+  handlerType: MethodHandlerType,
+  cacheKey?: string
+): IEnhancedRequestContext => ({
+  methodConfig: {
+    allowHardwareWallet: true,
+    cacheKey,
+    cacheTTL: cacheKey ? 10_000 : undefined,
+    handlerType,
+    hasPopup: false,
+    name: method,
+    networkEnforcement: NetworkEnforcement.Never,
+    networkPreference: NetworkPreference.Any,
+    requiresAuth: false,
+    requiresConnection: false,
+    requiresTabId: true,
+  },
+  originalRequest: {
+    host,
+    method,
+    sender: { tab: { id: 1 } } as chrome.runtime.MessageSender,
+    type: 'METHOD_REQUEST',
+  },
+});
+
+describe('origin-scoped provider data', () => {
+  const getAccount = jest.fn();
+  const getDapp = jest.fn();
+  const isUnlocked = jest.fn(() => true);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearProviderCache();
+
+    getControllerMock.mockReturnValue({
+      dapp: {
+        get: getDapp,
+        getAccount,
+      },
+      wallet: {
+        isUnlocked,
+      },
+    });
+
+    getStateMock.mockReturnValue({
+      vault: {
+        accountAssets: {
+          HDAccount: {
+            0: activeTokens,
+            1: connectedTokens,
+          },
+        },
+        accounts: {
+          HDAccount: {
+            0: activeAccount,
+            1: connectedAccount,
+          },
+        },
+        activeAccount: { id: 0, type: 'HDAccount' },
+        activeNetwork: {
+          chainId: 1,
+          url: 'https://rpc.example',
+        },
+        isBitcoinBased: false,
+      },
+      vaultGlobal: {
+        networks: { ethereum: {} },
+      },
+    });
+  });
+
+  it('does not expose the active account during provider initialization for an unconnected origin', async () => {
+    getAccount.mockReturnValue(null);
+    getDapp.mockReturnValue(null);
+
+    const result = await new WalletMethodHandler().handle(
+      makeContext(
+        'wallet_getProviderState',
+        'unconnected.example',
+        MethodHandlerType.Wallet,
+        'providerState'
+      )
+    );
+
+    expect(result.accounts).toEqual([]);
+  });
+
+  it('does not expose the active UTXO account during provider initialization for an unconnected origin', async () => {
+    const state = getStateMock();
+    state.vault.isBitcoinBased = true;
+    getStateMock.mockReturnValue(state);
+    getAccount.mockReturnValue(null);
+    getDapp.mockReturnValue(null);
+
+    const result = await new WalletMethodHandler().handle(
+      makeContext(
+        'wallet_getSysProviderState',
+        'unconnected.example',
+        MethodHandlerType.Wallet,
+        'sysProviderState'
+      )
+    );
+
+    expect(result.accounts).toEqual([]);
+    expect(result.xpub).toBeNull();
+  });
+
+  it('returns assets for the origin-connected account, not the globally active account', async () => {
+    getAccount.mockReturnValue(connectedAccount);
+    getDapp.mockReturnValue({ accountId: 1, accountType: 'HDAccount' });
+
+    const result = await new WalletMethodHandler().handle(
+      makeContext(
+        'wallet_getTokens',
+        'connected.example',
+        MethodHandlerType.Wallet
+      )
+    );
+
+    expect(result).toEqual(connectedTokens);
+  });
+
+  it('returns no assets to an unconnected origin', async () => {
+    getAccount.mockReturnValue(null);
+    getDapp.mockReturnValue(null);
+
+    const result = await new WalletMethodHandler().handle(
+      makeContext(
+        'wallet_getTokens',
+        'unconnected.example',
+        MethodHandlerType.Wallet
+      )
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns no assets while the wallet is locked without prompting', async () => {
+    isUnlocked.mockReturnValueOnce(false);
+    getAccount.mockReturnValue(connectedAccount);
+    getDapp.mockReturnValue({ accountId: 1, accountType: 'HDAccount' });
+
+    const result = await new WalletMethodHandler().handle(
+      makeContext(
+        'wallet_getTokens',
+        'connected.example',
+        MethodHandlerType.Wallet
+      )
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it('does not reuse a connected origin eth_accounts cache entry for another origin', async () => {
+    getAccount.mockImplementation((host: string) =>
+      host === 'connected.example' ? connectedAccount : null
+    );
+
+    const handler = new EthMethodHandler();
+    const connectedResult = await handler.handle(
+      makeContext(
+        'eth_accounts',
+        'connected.example',
+        MethodHandlerType.Eth,
+        'accounts'
+      )
+    );
+    const unconnectedResult = await handler.handle(
+      makeContext(
+        'eth_accounts',
+        'unconnected.example',
+        MethodHandlerType.Eth,
+        'accounts'
+      )
+    );
+
+    expect(connectedResult).toEqual([CONNECTED_ADDRESS.toLowerCase()]);
+    expect(unconnectedResult).toEqual([]);
+  });
+});

--- a/source/scripts/Background/controllers/message-handler/method-handlers.security.spec.ts
+++ b/source/scripts/Background/controllers/message-handler/method-handlers.security.spec.ts
@@ -41,6 +41,7 @@ jest.mock('./sendCallsBundles', () => ({
 import {
   clearProviderCache,
   EthMethodHandler,
+  MAX_PROVIDER_CACHE_ENTRIES,
   WalletMethodHandler,
 } from './method-handlers';
 import {
@@ -250,5 +251,28 @@ describe('origin-scoped provider data', () => {
 
     expect(connectedResult).toEqual([CONNECTED_ADDRESS.toLowerCase()]);
     expect(unconnectedResult).toEqual([]);
+  });
+
+  it('bounds the host-scoped provider cache and evicts the least recently used entry', async () => {
+    getAccount.mockReturnValue(connectedAccount);
+    const handler = new EthMethodHandler();
+    const requestAccounts = (host: string) =>
+      handler.handle(
+        makeContext('eth_accounts', host, MethodHandlerType.Eth, 'accounts')
+      );
+
+    for (let index = 0; index < MAX_PROVIDER_CACHE_ENTRIES; index += 1) {
+      await requestAccounts(`host-${index}.example`);
+    }
+    expect(getAccount).toHaveBeenCalledTimes(MAX_PROVIDER_CACHE_ENTRIES);
+
+    // Refresh host 0, then insert one more host. Host 1 is now the LRU entry.
+    await requestAccounts('host-0.example');
+    await requestAccounts('host-overflow.example');
+    await requestAccounts('host-0.example');
+    expect(getAccount).toHaveBeenCalledTimes(MAX_PROVIDER_CACHE_ENTRIES + 1);
+
+    await requestAccounts('host-1.example');
+    expect(getAccount).toHaveBeenCalledTimes(MAX_PROVIDER_CACHE_ENTRIES + 2);
   });
 });

--- a/source/scripts/Background/controllers/message-handler/method-handlers.ts
+++ b/source/scripts/Background/controllers/message-handler/method-handlers.ts
@@ -19,18 +19,29 @@ import {
 } from './sendCallsBundles';
 import { IEnhancedRequestContext, MethodHandlerType } from './types';
 
-// Cache for provider state methods
-interface IProviderStateCache {
-  [key: string]: { timestamp: number; value: any };
+// Cache for provider state methods. Host scoping prevents data crossing site
+// boundaries; the size cap prevents hostile sites from growing it without
+// bound by issuing requests from many subdomains.
+export const MAX_PROVIDER_CACHE_ENTRIES = 100;
+
+interface IProviderStateCacheEntry {
+  expiresAt: number;
+  value: any;
 }
 
-const providerStateCache: IProviderStateCache = {};
+const providerStateCache = new Map<string, IProviderStateCacheEntry>();
+
+const pruneProviderCache = (now: number) => {
+  for (const [key, cached] of providerStateCache) {
+    if (cached.expiresAt <= now) {
+      providerStateCache.delete(key);
+    }
+  }
+};
 
 // Clear cache function
 export function clearProviderCache() {
-  Object.keys(providerStateCache).forEach((key) => {
-    delete providerStateCache[key];
-  });
+  providerStateCache.clear();
 }
 
 // Base interface for method handlers
@@ -49,6 +60,7 @@ async function executeMethodWithCache(
   // Check if method has caching enabled
   if (methodConfig.cacheKey && methodConfig.cacheTTL) {
     const now = Date.now();
+    pruneProviderCache(now);
     // Provider responses can contain origin-specific account data. Keep every
     // cache entry scoped to the requesting host so a connected site's result
     // can never be reused for another site.
@@ -56,18 +68,28 @@ async function executeMethodWithCache(
       methodConfig.cacheKey,
       context.originalRequest.host,
     ]);
-    const cached = providerStateCache[originCacheKey];
+    const cached = providerStateCache.get(originCacheKey);
 
-    if (cached && now - cached.timestamp < methodConfig.cacheTTL) {
+    if (cached) {
+      // Refresh insertion order so the Map also acts as an LRU queue.
+      providerStateCache.delete(originCacheKey);
+      providerStateCache.set(originCacheKey, cached);
       return cached.value;
     }
 
     // Execute and cache the result
     const result = await executor();
-    providerStateCache[originCacheKey] = {
+    const completedAt = Date.now();
+    pruneProviderCache(completedAt);
+    while (providerStateCache.size >= MAX_PROVIDER_CACHE_ENTRIES) {
+      const oldestKey = providerStateCache.keys().next().value;
+      if (oldestKey === undefined) break;
+      providerStateCache.delete(oldestKey);
+    }
+    providerStateCache.set(originCacheKey, {
+      expiresAt: completedAt + methodConfig.cacheTTL,
       value: result,
-      timestamp: now,
-    };
+    });
     return result;
   }
 

--- a/source/scripts/Background/controllers/message-handler/method-handlers.ts
+++ b/source/scripts/Background/controllers/message-handler/method-handlers.ts
@@ -49,7 +49,14 @@ async function executeMethodWithCache(
   // Check if method has caching enabled
   if (methodConfig.cacheKey && methodConfig.cacheTTL) {
     const now = Date.now();
-    const cached = providerStateCache[methodConfig.cacheKey];
+    // Provider responses can contain origin-specific account data. Keep every
+    // cache entry scoped to the requesting host so a connected site's result
+    // can never be reused for another site.
+    const originCacheKey = JSON.stringify([
+      methodConfig.cacheKey,
+      context.originalRequest.host,
+    ]);
+    const cached = providerStateCache[originCacheKey];
 
     if (cached && now - cached.timestamp < methodConfig.cacheTTL) {
       return cached.value;
@@ -57,7 +64,7 @@ async function executeMethodWithCache(
 
     // Execute and cache the result
     const result = await executor();
-    providerStateCache[methodConfig.cacheKey] = {
+    providerStateCache[originCacheKey] = {
       value: result,
       timestamp: now,
     };
@@ -109,10 +116,10 @@ export class WalletMethodHandler implements IMethodHandler {
 
     const { vault, vaultGlobal } = state;
     // Don't destructure these variables if vault is not initialized
-    let activeAccount, activeNetwork, isBitcoinBased, accountAssets, networks;
+    let activeNetwork, isBitcoinBased, accountAssets, networks;
 
     if (vault) {
-      ({ activeAccount, activeNetwork, isBitcoinBased, accountAssets } = vault);
+      ({ activeNetwork, isBitcoinBased, accountAssets } = vault);
     }
 
     if (vaultGlobal) {
@@ -313,11 +320,22 @@ export class WalletMethodHandler implements IMethodHandler {
         case 'getAddress':
           return account.address;
 
-        case 'getTokens':
-          if (!activeAccount || !accountAssets) {
+        case 'getTokens': {
+          const connectedDapp = dapp.get(host);
+          if (
+            !wallet.isUnlocked() ||
+            !account ||
+            !connectedDapp ||
+            !accountAssets
+          ) {
             return [];
           }
-          return accountAssets[activeAccount.type]?.[activeAccount.id] || [];
+          return (
+            accountAssets[connectedDapp.accountType]?.[
+              connectedDapp.accountId
+            ] || []
+          );
+        }
 
         case 'estimateFee':
           return wallet.getRecommendedFee();
@@ -397,22 +415,8 @@ export class WalletMethodHandler implements IMethodHandler {
           // Return accounts if wallet is unlocked, similar to eth_accounts
           providerAccounts = [];
           if (wallet.isUnlocked() && !isBitcoinBased) {
-            // First check if dapp is already connected
             if (account) {
               providerAccounts = [account.address];
-            } else {
-              // If not connected but wallet is unlocked, return the active account
-              const vaultAccounts = store.getState().vault?.accounts;
-              const vaultActiveAccount = store.getState().vault?.activeAccount;
-              if (vaultAccounts && vaultActiveAccount) {
-                const activeAccountData =
-                  vaultAccounts[vaultActiveAccount.type]?.[
-                    vaultActiveAccount.id
-                  ];
-                if (activeAccountData?.address) {
-                  providerAccounts = [activeAccountData.address];
-                }
-              }
             }
           }
 
@@ -440,22 +444,8 @@ export class WalletMethodHandler implements IMethodHandler {
           // Return accounts if wallet is unlocked, similar to eth_accounts
           providerAccounts = [];
           if (wallet.isUnlocked() && isBitcoinBased) {
-            // First check if dapp is already connected
             if (account) {
               providerAccounts = [account.address];
-            } else {
-              // If not connected but wallet is unlocked, return the active account
-              const vaultAccounts = store.getState().vault?.accounts;
-              const vaultActiveAccount = store.getState().vault?.activeAccount;
-              if (vaultAccounts && vaultActiveAccount) {
-                const activeAccountData =
-                  vaultAccounts[vaultActiveAccount.type]?.[
-                    vaultActiveAccount.id
-                  ];
-                if (activeAccountData?.address) {
-                  providerAccounts = [activeAccountData.address];
-                }
-              }
             }
           }
           return {

--- a/source/scripts/Background/controllers/message-handler/method-registry.ts
+++ b/source/scripts/Background/controllers/message-handler/method-registry.ts
@@ -160,6 +160,8 @@ export const METHOD_REGISTRY: MethodRegistry = {
     handlerType: MethodHandlerType.Wallet,
     requiresTabId: true,
     requiresAuth: false, // Read-only - just token metadata
+    // Passive read: do not trigger a connect popup. The handler returns an
+    // empty list unless this origin already has a connected account.
     requiresConnection: false,
     allowHardwareWallet: true,
     networkPreference: NetworkPreference.Any,

--- a/source/scripts/Background/handlers/handleListeners.spec.ts
+++ b/source/scripts/Background/handlers/handleListeners.spec.ts
@@ -16,6 +16,8 @@ const chrome = {
     getAll: jest.fn(),
   },
   runtime: {
+    getURL: jest.fn((path = '') => `chrome-extension://pali-extension/${path}`),
+    id: 'pali-extension',
     onMessage: {
       addListener: jest.fn(),
       removeListener: jest.fn(),
@@ -122,6 +124,9 @@ jest.mock('@sidhujag/sysweb3-keyring', () => ({
 
 // Mock dependencies
 jest.mock('scripts/Background/handlers/handleLogout');
+jest.mock('scripts/Background/controllers/message-handler', () => ({
+  onMessage: jest.fn(),
+}));
 jest.mock('state/store', () => ({
   getState: jest.fn(() => ({
     vault: {
@@ -160,7 +165,7 @@ const mockMasterController: jest.Mocked<IMasterController> = {
   // Mock wallet methods used in handleListeners
   wallet: {
     setActiveNetwork: jest.fn(),
-    setFiat: jest.fn(),
+    setFiat: jest.fn().mockResolvedValue(undefined),
   } as any, // Use 'as any' for brevity, ideally mock all methods
 };
 
@@ -243,7 +248,15 @@ describe('Background: handleListeners', () => {
   });
 
   describe('onMessage Listener', () => {
-    const sender = {} as chrome.runtime.MessageSender;
+    const sender = {
+      id: 'pali-extension',
+      url: 'chrome-extension://pali-extension/app.html',
+    } as chrome.runtime.MessageSender;
+    const contentScriptSender = {
+      id: 'pali-extension',
+      tab: { id: 1 },
+      url: 'https://malicious.example/',
+    } as chrome.runtime.MessageSender;
     const sendResponse = jest.fn();
 
     beforeEach(() => {
@@ -272,6 +285,25 @@ describe('Background: handleListeners', () => {
       messageListener(message, sender, sendResponse);
       expect(handleLogout).toHaveBeenCalledWith(mockMasterController);
       expect(sendResponse).not.toHaveBeenCalled();
+    });
+
+    it('should reject lock_wallet from a content script', () => {
+      const messageListener =
+        chrome.runtime.onMessage.addListener.mock.calls[0][0];
+
+      messageListener(
+        { type: 'lock_wallet' },
+        contentScriptSender,
+        sendResponse
+      );
+
+      expect(handleLogout).not.toHaveBeenCalled();
+      expect(sendResponse).toHaveBeenCalledWith({
+        error: {
+          code: 4100,
+          message: 'Unauthorized internal message source',
+        },
+      });
     });
 
     it('should call wallet.setActiveNetwork for changeNetwork message (Bitcoin-based)', () => {
@@ -306,6 +338,27 @@ describe('Background: handleListeners', () => {
         message.data.network
       );
       expect(sendResponse).not.toHaveBeenCalled();
+    });
+
+    it('should reject changeNetwork from a content script', () => {
+      const messageListener =
+        chrome.runtime.onMessage.addListener.mock.calls[0][0];
+      const message = {
+        type: 'changeNetwork',
+        data: { network: { chainId: 1 } },
+      };
+
+      messageListener(message, contentScriptSender, sendResponse);
+
+      expect(
+        mockMasterController.wallet.setActiveNetwork
+      ).not.toHaveBeenCalled();
+      expect(sendResponse).toHaveBeenCalledWith({
+        error: {
+          code: 4100,
+          message: 'Unauthorized internal message source',
+        },
+      });
     });
   });
 });

--- a/source/scripts/Background/handlers/handleListeners.ts
+++ b/source/scripts/Background/handlers/handleListeners.ts
@@ -6,6 +6,10 @@ import store from 'state/store';
 import vaultCache from 'state/vaultCache';
 
 import { checkForUpdates } from './handlePaliUpdates';
+import {
+  isPrivilegedInternalMessage,
+  isTrustedExtensionPageSender,
+} from './internalMessageAuthorization';
 
 // Flag to prevent duplicate listener registration
 let listenersInitialized = false;
@@ -149,6 +153,22 @@ export const handleListeners = (masterController: IMasterController) => {
     // EMERGENCY FIX: Drop all messages without types to prevent loops
     if (!type) {
       return false; // Silently drop malformed messages
+    }
+
+    // Raw internal commands intentionally bypass the dapp request pipeline,
+    // so they must only be callable by the extension's own UI/offscreen pages.
+    // A content script has the same extension id but retains the webpage URL.
+    if (
+      isPrivilegedInternalMessage(type) &&
+      !isTrustedExtensionPageSender(sender)
+    ) {
+      sendResponse({
+        error: {
+          code: 4100,
+          message: 'Unauthorized internal message source',
+        },
+      });
+      return false;
     }
 
     const { hasEthProperty } = store.getState().vaultGlobal;

--- a/source/scripts/Background/handlers/handleMasterControllerResponses.security.spec.ts
+++ b/source/scripts/Background/handlers/handleMasterControllerResponses.security.spec.ts
@@ -1,0 +1,66 @@
+import { handleMasterControllerResponses } from './handleMasterControllerResponses';
+
+describe('controller action sender authorization', () => {
+  const addListener = chrome.runtime.onMessage.addListener as jest.Mock;
+  const lock = jest.fn().mockResolvedValue('locked');
+  const sendResponse = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.assign(chrome.runtime, {
+      getURL: jest.fn(
+        (path = '') => `chrome-extension://pali-extension/${path}`
+      ),
+      id: 'pali-extension',
+    });
+
+    handleMasterControllerResponses({ wallet: { lock } } as any);
+  });
+
+  const getListener = () => addListener.mock.calls[0][0];
+
+  it('rejects controller actions relayed from a file page', () => {
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    const result = getListener()(
+      {
+        data: { methods: ['wallet', 'lock'], params: [] },
+        type: 'CONTROLLER_ACTION',
+      },
+      {
+        id: 'pali-extension',
+        tab: { id: 1 },
+        url: 'file:///tmp/malicious.html',
+      },
+      sendResponse
+    );
+
+    expect(result).toBe(false);
+    expect(lock).not.toHaveBeenCalled();
+    expect(sendResponse).toHaveBeenCalledWith({
+      error: 'Controller actions are not available from connected sites',
+      success: false,
+    });
+    consoleError.mockRestore();
+  });
+
+  it('preserves controller actions from extension pages', async () => {
+    const result = getListener()(
+      {
+        data: { methods: ['wallet', 'lock'], params: [] },
+        type: 'CONTROLLER_ACTION',
+      },
+      {
+        id: 'pali-extension',
+        url: 'chrome-extension://pali-extension/app.html',
+      },
+      sendResponse
+    );
+
+    expect(result).toBe(true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(lock).toHaveBeenCalledTimes(1);
+    expect(sendResponse).toHaveBeenCalledWith('locked');
+  });
+});

--- a/source/scripts/Background/handlers/handleMasterControllerResponses.ts
+++ b/source/scripts/Background/handlers/handleMasterControllerResponses.ts
@@ -1,6 +1,8 @@
 import { IMasterController } from 'scripts/Background/controllers';
 import { extractErrorMessage } from 'utils/index';
 
+import { isTrustedExtensionPageSender } from './internalMessageAuthorization';
+
 const AA21_PREFUND_REASON_HEX =
   '41413231206469646e2774207061792070726566756e64';
 const NATIVE_GAS_REQUIRED_ERROR = 'PALI_NATIVE_GAS_REQUIRED';
@@ -95,8 +97,6 @@ const normalizeControllerErrorMessage = (error: unknown): string => {
 export const handleMasterControllerResponses = (
   MasterControllerInstance: IMasterController
 ) => {
-  const extensionOrigin = new URL(chrome.runtime.getURL('')).origin;
-
   chrome.runtime.onMessage.addListener((message: any, sender, sendResponse) => {
     const { type, data } = message;
 
@@ -107,13 +107,13 @@ export const handleMasterControllerResponses = (
         return false;
       }
 
-      const { methods, params } = data;
-      const senderOrigin = sender.url ? new URL(sender.url).origin : '';
-      if (sender.tab && senderOrigin !== extensionOrigin) {
+      if (!isTrustedExtensionPageSender(sender)) {
         throw new Error(
           'Controller actions are not available from connected sites'
         );
       }
+
+      const { methods, params } = data;
 
       let targetMethod = MasterControllerInstance;
 

--- a/source/scripts/Background/handlers/internalMessageAuthorization.spec.ts
+++ b/source/scripts/Background/handlers/internalMessageAuthorization.spec.ts
@@ -1,0 +1,62 @@
+import {
+  isPrivilegedInternalMessage,
+  isTrustedExtensionPageSender,
+} from './internalMessageAuthorization';
+
+const runtime = {
+  getURL: (path = '') => `chrome-extension://pali-extension/${path}`,
+  id: 'pali-extension',
+} as Pick<typeof chrome.runtime, 'getURL' | 'id'>;
+
+describe('internal message authorization', () => {
+  it('trusts messages sent by an extension page', () => {
+    expect(
+      isTrustedExtensionPageSender(
+        {
+          id: runtime.id,
+          url: runtime.getURL('external.html'),
+        },
+        runtime
+      )
+    ).toBe(true);
+  });
+
+  it('rejects content-script messages even though they share the extension id', () => {
+    expect(
+      isTrustedExtensionPageSender(
+        {
+          id: runtime.id,
+          tab: { id: 1 } as chrome.tabs.Tab,
+          url: 'https://malicious.example/',
+        },
+        runtime
+      )
+    ).toBe(false);
+  });
+
+  it('rejects extension-origin URLs from a different extension id', () => {
+    expect(
+      isTrustedExtensionPageSender(
+        {
+          id: 'different-extension',
+          url: runtime.getURL('app.html'),
+        },
+        runtime
+      )
+    ).toBe(false);
+  });
+
+  it.each([
+    'PALI_SLH_DSA_SETUP_PROGRESS',
+    'changeNetwork',
+    'getCurrentState',
+    'lock_wallet',
+    'startPolling',
+  ])('marks %s as privileged', (type) => {
+    expect(isPrivilegedInternalMessage(type)).toBe(true);
+  });
+
+  it('does not classify public provider requests as privileged', () => {
+    expect(isPrivilegedInternalMessage('METHOD_REQUEST')).toBe(false);
+  });
+});

--- a/source/scripts/Background/handlers/internalMessageAuthorization.ts
+++ b/source/scripts/Background/handlers/internalMessageAuthorization.ts
@@ -1,0 +1,37 @@
+const PRIVILEGED_INTERNAL_MESSAGE_TYPES = new Set([
+  'PALI_SLH_DSA_SETUP_PROGRESS',
+  'changeNetwork',
+  'getCurrentState',
+  'lock_wallet',
+  'startPolling',
+]);
+
+type RuntimeIdentity = Pick<typeof chrome.runtime, 'getURL' | 'id'>;
+
+export const isPrivilegedInternalMessage = (type: string) =>
+  PRIVILEGED_INTERNAL_MESSAGE_TYPES.has(type);
+
+/**
+ * Content scripts share the extension id, so sender.id alone does not prove
+ * that a message came from an extension UI page. Require the sender URL to be
+ * on this extension's own origin as well.
+ */
+export const isTrustedExtensionPageSender = (
+  sender: chrome.runtime.MessageSender,
+  runtime: RuntimeIdentity = chrome.runtime
+): boolean => {
+  if (!sender?.url || sender.id !== runtime.id) {
+    return false;
+  }
+
+  try {
+    const extensionUrl = new URL(runtime.getURL(''));
+    const senderUrl = new URL(sender.url);
+    return (
+      senderUrl.protocol === extensionUrl.protocol &&
+      senderUrl.host === extensionUrl.host
+    );
+  } catch {
+    return false;
+  }
+};

--- a/source/scripts/ContentScript/index.ts
+++ b/source/scripts/ContentScript/index.ts
@@ -5,6 +5,8 @@ import {
   PaliSyscoinEvents,
 } from 'scripts/Background/controllers/message-handler/types';
 
+import { isAllowedPageProviderMessageType } from './pageMessageAuthorization';
+
 const emitter = new EventEmitter();
 
 // Simple error logging rate limiting
@@ -147,6 +149,7 @@ const start = () => {
       const { id, type, data } = event.data;
 
       if (!id || !type) return;
+      if (!isAllowedPageProviderMessageType(type)) return;
 
       // listen for the response
       checkForPaliRegisterEvent(id);

--- a/source/scripts/ContentScript/pageMessageAuthorization.spec.ts
+++ b/source/scripts/ContentScript/pageMessageAuthorization.spec.ts
@@ -1,0 +1,23 @@
+import { isAllowedPageProviderMessageType } from './pageMessageAuthorization';
+
+describe('page-to-extension message authorization', () => {
+  it.each(['DISABLE', 'ENABLE', 'IS_UNLOCKED', 'METHOD_REQUEST'])(
+    'allows the public provider message %s',
+    (type) => {
+      expect(isAllowedPageProviderMessageType(type)).toBe(true);
+    }
+  );
+
+  it.each([
+    'CONTROLLER_ACTION',
+    'CONTROLLER_STATE_CHANGE',
+    'PALI_SLH_DSA_SETUP_PROGRESS',
+    'changeNetwork',
+    'getCurrentState',
+    'lock_wallet',
+    'logout',
+    'startPolling',
+  ])('rejects the internal message %s', (type) => {
+    expect(isAllowedPageProviderMessageType(type)).toBe(false);
+  });
+});

--- a/source/scripts/ContentScript/pageMessageAuthorization.ts
+++ b/source/scripts/ContentScript/pageMessageAuthorization.ts
@@ -1,0 +1,10 @@
+const PUBLIC_PROVIDER_MESSAGE_TYPES = new Set([
+  'DISABLE',
+  'ENABLE',
+  'IS_UNLOCKED',
+  'METHOD_REQUEST',
+]);
+
+/** Only provider protocol messages may cross from page JavaScript. */
+export const isAllowedPageProviderMessageType = (type: string): boolean =>
+  PUBLIC_PROVIDER_MESSAGE_TYPES.has(type);


### PR DESCRIPTION
## Summary

- allowlist page-to-content-script provider message types and reject raw internal commands
- require extension ID plus extension protocol/host for privileged background messages and controller actions
- scope provider caches to the requesting host
- return account and token data only for the account connected to that host
- keep passive provider initialization reads non-interactive for unconnected sites
- add regression coverage and re-enable the listener suite in normal Jest runs

## Root cause

The page bridge forwarded arbitrary message types, while several raw background commands bypassed the normal dapp request pipeline. Provider initialization and token handlers also fell back to globally active wallet data, and the provider cache was shared across hosts. The controller-action guard additionally compared `URL.origin`, which can serialize both `chrome-extension://` and `file://` URLs as `null`.

## Security impact

Untrusted pages can no longer invoke privileged internal actions, spoof internal extension broadcasts through the page bridge, receive an unconnected wallet address or portfolio, or reuse another site's cached `eth_accounts` response. Legitimate extension pages retain internal access, and normal connect/switch approval flows are unchanged.

## Validation

- TypeScript: `tsc --noEmit`
- ESLint on all changed TypeScript files
- Jest: 44 suites, 442 tests passed
- production Chrome build: `4.0.42` completed successfully
