### PR TITLE
Bump production release to 4.0.43

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Pali Wallet",
-  "version": "4.0.42",
+  "version": "4.0.43",
   "icons": {
     "16": "assets/all_assets/favicon-16.png",
     "32": "assets/all_assets/favicon-32.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paliwallet",
-  "version": "4.0.42",
+  "version": "4.0.43",
   "description": "A Non-Custodial Crypto Wallet",
   "private": true,
   "repository": {

--- a/source/config/consts.js
+++ b/source/config/consts.js
@@ -80,7 +80,7 @@ const CANARY_EXTENSION_KEY =
 const MV3_OPTIONS = {
   manifest_version: 3,
   name: 'Pali Wallet',
-  version: '4.0.42',
+  version: '4.0.43',
   icons: {
     16: 'assets/all_assets/favicon-16.png',
     32: 'assets/all_assets/favicon-32.png',


### PR DESCRIPTION
## Summary

- bump the package release version from `4.0.42` to `4.0.43`
- keep `package.json`, the checked-in Chrome manifest, and `MV3_OPTIONS` synchronized

## Why

PR #816 was merged without a package version change. The release workflow explicitly skips publishing when `package.json` matches the previous commit, so the security hardening would not produce new production and canary release artifacts without this follow-up bump.

## Impact

Merging this PR into `master` allows the release workflow to create the `v4.0.43` draft release and build both Chrome variants. The production extension keeps its store identity; the canary build keeps its separate stable manifest key.

## Validation

- production Chrome build succeeded: `pali-wallet-production-chrome-4.0.43.zip`
- canary Chrome build succeeded: `pali-wallet-canary-chrome-4.0.43.zip`
- archive manifests verified as version `4.0.43`
- production archive name: `Pali Wallet`
- canary archive name: `Pali Wallet Canary`, with the configured stable canary key
- ESLint passed for `source/config/consts.js`
- `lint-staged` passed
- `git diff --check` passed