### PR TITLE
Fix zkSYS smart-account fee-cap gas estimation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Pali Wallet",
-  "version": "4.0.44",
+  "version": "4.0.45",
   "icons": {
     "16": "assets/all_assets/favicon-16.png",
     "32": "assets/all_assets/favicon-32.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paliwallet",
-  "version": "4.0.44",
+  "version": "4.0.45",
   "description": "A Non-Custodial Crypto Wallet",
   "private": true,
   "repository": {

--- a/source/config/consts.js
+++ b/source/config/consts.js
@@ -80,7 +80,7 @@ const CANARY_EXTENSION_KEY =
 const MV3_OPTIONS = {
   manifest_version: 3,
   name: 'Pali Wallet',
-  version: '4.0.44',
+  version: '4.0.45',
   icons: {
     16: 'assets/all_assets/favicon-16.png',
     32: 'assets/all_assets/favicon-32.png',

--- a/source/scripts/Background/controllers/smartAccount/hydration.spec.ts
+++ b/source/scripts/Background/controllers/smartAccount/hydration.spec.ts
@@ -152,11 +152,15 @@ describe('SmartAccountController smart account execution fees', () => {
   };
 
   const buildController = () => {
+    const estimateGas = jest.fn().mockResolvedValue('143280');
     const sendAndSaveEthTransaction = jest.fn().mockResolvedValue({
       hash: '0xabc',
       wait: jest.fn(),
     });
     const controller: any = new SmartAccountController({
+      getEthereumTransaction: () => ({
+        web3Provider: { estimateGas },
+      }),
       sendAndSaveEthTransaction,
     } as any);
     controller.getActiveSmartAccount = jest.fn(() => ({
@@ -170,7 +174,7 @@ describe('SmartAccountController smart account execution fees', () => {
     controller.getLocalNativeExecutionRecipients = jest.fn(() => []);
     controller.invalidateHydratedMetadata = jest.fn();
 
-    return { controller, sendAndSaveEthTransaction };
+    return { controller, estimateGas, sendAndSaveEthTransaction };
   };
 
   const buildUserOperation = () =>
@@ -213,7 +217,8 @@ describe('SmartAccountController smart account execution fees', () => {
   });
 
   it('preserves explicit zero priority fee overrides for the outer transaction', async () => {
-    const { controller, sendAndSaveEthTransaction } = buildController();
+    const { controller, estimateGas, sendAndSaveEthTransaction } =
+      buildController();
 
     await controller.submitSmartAccountExecution({
       executions: [],
@@ -226,6 +231,7 @@ describe('SmartAccountController smart account execution fees', () => {
 
     expect(sendAndSaveEthTransaction).toHaveBeenCalledWith(
       expect.objectContaining({
+        gasLimit: '143280',
         maxFeePerGas: '1000000000',
         maxPriorityFeePerGas: '0',
       }),
@@ -233,6 +239,17 @@ describe('SmartAccountController smart account execution fees', () => {
       { id: gasPayer.id, type: gasPayer.type },
       expect.any(Object),
       expect.any(Object)
+    );
+    expect(estimateGas).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: gasPayer.address,
+      })
+    );
+    expect(estimateGas).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        maxFeePerGas: expect.anything(),
+        maxPriorityFeePerGas: expect.anything(),
+      })
     );
   });
 });

--- a/source/scripts/Background/controllers/smartAccount/hydration.spec.ts
+++ b/source/scripts/Background/controllers/smartAccount/hydration.spec.ts
@@ -18,6 +18,7 @@ jest.mock('utils/security/blacklistService', () => ({
 }));
 
 import { KeyringAccountType } from 'types/network';
+import { BigNumber } from 'utils/ethersV6Compat';
 import {
   buildSmartAccountUserOperation,
   encodeSmartAccountGasFees,
@@ -250,6 +251,47 @@ describe('SmartAccountController smart account execution fees', () => {
         maxFeePerGas: expect.anything(),
         maxPriorityFeePerGas: expect.anything(),
       })
+    );
+  });
+
+  it('reuses the gas-tank credit estimate for the outer transaction', async () => {
+    const { controller, estimateGas, sendAndSaveEthTransaction } =
+      buildController();
+    controller.getActiveSmartAccount.mockReturnValue({
+      account: { address: ACCOUNT_ADDRESS, id: 9 },
+      metadata: {
+        chainId: 57057,
+        deploymentGasPayer: gasPayer,
+      },
+    });
+    controller.assertZkSysGasTankCoversTransaction = jest
+      .fn()
+      .mockResolvedValue(BigNumber.from('143280'));
+    const userOperation = buildUserOperation();
+    userOperation.gasFees = encodeSmartAccountGasFees({
+      maxFeePerGas: 0,
+      maxPriorityFeePerGas: 0,
+    });
+
+    await controller.submitSmartAccountExecution({
+      executions: [],
+      gasPayer,
+      maxFeePerGas: '1000000000',
+      maxPriorityFeePerGas: '0',
+      signature: '0x1234',
+      userOperation,
+    });
+
+    expect(
+      controller.assertZkSysGasTankCoversTransaction
+    ).toHaveBeenCalledTimes(1);
+    expect(estimateGas).not.toHaveBeenCalled();
+    expect(sendAndSaveEthTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({ gasLimit: '143280' }),
+      false,
+      { id: gasPayer.id, type: gasPayer.type },
+      expect.any(Object),
+      expect.any(Object)
     );
   });
 });

--- a/source/scripts/Background/controllers/smartAccount/index.ts
+++ b/source/scripts/Background/controllers/smartAccount/index.ts
@@ -1275,8 +1275,9 @@ class SmartAccountController {
       const usesZkSysGasTank =
         Boolean(getZkSysGasTankAddress(active.metadata.chainId)) &&
         signedUserOperation.gasFees === SMART_ACCOUNT_ZERO_GAS_FEES;
+      let outerGasLimit: BigNumber | undefined;
       if (usesZkSysGasTank) {
-        await this.assertZkSysGasTankCoversTransaction({
+        outerGasLimit = await this.assertZkSysGasTankCoversTransaction({
           chainId: active.metadata.chainId,
           gasPayerAddress: gasPayer.address,
           maxFeePerGas: params.maxFeePerGas,
@@ -1308,19 +1309,22 @@ class SmartAccountController {
       // LackOfFundForMaxFee failure whenever maxFeePerGas exceeds baseFee.
       // Estimate the outer handleOps call without fee fields, then provide the
       // resolved limit alongside the selected caps so the signing path does
-      // not estimate it a second time.
-      const provider = this.ethereumTransaction?.web3Provider;
-      if (!provider) {
-        throw new Error('Web3 provider not available');
+      // not estimate it a second time. Tank mode already made this exact
+      // estimate while checking credit, so reuse it instead of calling twice.
+      if (!outerGasLimit) {
+        const provider = this.ethereumTransaction?.web3Provider;
+        if (!provider) {
+          throw new Error('Web3 provider not available');
+        }
+        outerGasLimit = toCompatBigNumber(
+          await provider.estimateGas({
+            data: callData,
+            from: gasPayer.address,
+            to: entryPointAddress,
+            value: '0x0',
+          })
+        );
       }
-      const outerGasLimit = toCompatBigNumber(
-        await provider.estimateGas({
-          data: callData,
-          from: gasPayer.address,
-          to: entryPointAddress,
-          value: '0x0',
-        })
-      );
       const response = await this.deps.sendAndSaveEthTransaction(
         {
           data: callData,
@@ -1415,7 +1419,7 @@ class SmartAccountController {
     gasPayerAddress: string;
     maxFeePerGas?: string;
     transaction: { data?: string; to: string; value?: string };
-  }): Promise<void> {
+  }): Promise<BigNumber> {
     const provider = this.ethereumTransaction?.web3Provider;
     const tankAddress = getZkSysGasTankAddress(chainId);
     if (!provider || !tankAddress) {
@@ -1434,15 +1438,17 @@ class SmartAccountController {
       maxFeePerGas ? Promise.resolve(null) : provider.getFeeData(),
     ]);
     const credit = toCompatBigNumber(rawCredit);
+    const estimatedGasLimit = toCompatBigNumber(gasLimit);
     const resolvedMaxFeePerGas = BigNumber.from(
       maxFeePerGas || feeData?.maxFeePerGas || feeData?.gasPrice || 0
     );
-    const requiredCredit = gasLimit
+    const requiredCredit = estimatedGasLimit
       .add(SMART_ACCOUNT_GAS_TANK_OUTER_GAS_BUFFER)
       .mul(resolvedMaxFeePerGas);
     if (credit.lt(requiredCredit)) {
       throw new Error('PALI_ZKSYS_GAS_TANK_REQUIRED');
     }
+    return estimatedGasLimit;
   }
 
   /**

--- a/source/scripts/Background/controllers/smartAccount/index.ts
+++ b/source/scripts/Background/controllers/smartAccount/index.ts
@@ -1302,9 +1302,29 @@ class SmartAccountController {
           gasPayer
         );
       }
+      // zkSYS derives an omitted estimateGas ceiling from balance / baseFee,
+      // then validates that ceiling against maxFeePerGas. Supplying EIP-1559
+      // caps during estimation therefore creates a self-scaling
+      // LackOfFundForMaxFee failure whenever maxFeePerGas exceeds baseFee.
+      // Estimate the outer handleOps call without fee fields, then provide the
+      // resolved limit alongside the selected caps so the signing path does
+      // not estimate it a second time.
+      const provider = this.ethereumTransaction?.web3Provider;
+      if (!provider) {
+        throw new Error('Web3 provider not available');
+      }
+      const outerGasLimit = toCompatBigNumber(
+        await provider.estimateGas({
+          data: callData,
+          from: gasPayer.address,
+          to: entryPointAddress,
+          value: '0x0',
+        })
+      );
       const response = await this.deps.sendAndSaveEthTransaction(
         {
           data: callData,
+          gasLimit: outerGasLimit.toString(),
           ...(params.maxFeePerGas && params.maxPriorityFeePerGas
             ? {
                 maxFeePerGas: params.maxFeePerGas,


### PR DESCRIPTION
## What changed

- Estimate the final EntryPoint `handleOps` transaction without EIP-1559 fee fields.
- Pass the resolved `gasLimit` together with Pali's selected fee overrides to the signing/submission path.
- Reuse the gas-tank credit check's identical estimate instead of issuing a second RPC call.
- Add regressions for explicit zero-priority fee overrides, fee-free estimation, and gas-tank estimate reuse.
- Bump the release version to 4.0.45.

## Why

zkSYS currently derives an omitted `eth_estimateGas` ceiling from `balance / baseFee`, then validates that ceiling at `maxFeePerGas`. When the selected maximum fee exceeds the base fee, this creates a self-scaling `LackOfFundForMaxFee` failure even though the actual `handleOps` execution costs only a small fraction of the payer's balance.

The wallet workaround preserves the fee caps selected in Pali on the final explorer-visible outer transaction while avoiding fee-cap-dependent estimation. The protocol-side correction is tracked in syscoin/zksync-os-server#296.

## Validation

- TypeScript type-check passed.
- Full unit suite passed: 37 suites, 268 tests.
- Targeted ESLint passed with no errors; four pre-existing `eqeqeq` warnings remain and will be handled separately.
- `git diff --check` passed.
