### PR TITLE
Replace loose equality checks

### DIFF
--- a/source/pages/Send/Confirm.tsx
+++ b/source/pages/Send/Confirm.tsx
@@ -479,7 +479,8 @@ export const SendConfirm = () => {
             : fee.maxFeePerGas;
 
         if (
-          maxPriorityFeePerGas == null ||
+          maxPriorityFeePerGas === null ||
+          maxPriorityFeePerGas === undefined ||
           maxPriorityFeePerGas < 0 ||
           !maxFeePerGas ||
           maxFeePerGas <= 0

--- a/source/pages/Send/EditPriority.tsx
+++ b/source/pages/Send/EditPriority.tsx
@@ -102,7 +102,8 @@ export const EditPriorityModal = (props: IEditPriorityModalProps) => {
       const gasPriceFloor = estimatedFeeFloor?.gasPrice;
 
       if (
-        gasPriceFloor != null &&
+        gasPriceFloor !== null &&
+        gasPriceFloor !== undefined &&
         currentGasPrice > 0 &&
         currentGasPrice < gasPriceFloor
       ) {
@@ -120,7 +121,8 @@ export const EditPriorityModal = (props: IEditPriorityModalProps) => {
     const maxFeeFloor = estimatedFeeFloor?.maxFeePerGas;
 
     if (
-      maxFeeFloor != null &&
+      maxFeeFloor !== null &&
+      maxFeeFloor !== undefined &&
       currentMaxFee > 0 &&
       currentMaxFee < maxFeeFloor
     ) {
@@ -135,7 +137,8 @@ export const EditPriorityModal = (props: IEditPriorityModalProps) => {
     const priorityFeeFloor = estimatedFeeFloor?.maxPriorityFeePerGas;
 
     if (
-      priorityFeeFloor != null &&
+      priorityFeeFloor !== null &&
+      priorityFeeFloor !== undefined &&
       currentPriorityFee >= 0 &&
       currentPriorityFee < priorityFeeFloor
     ) {

--- a/source/pages/Send/SendTransaction.tsx
+++ b/source/pages/Send/SendTransaction.tsx
@@ -246,7 +246,8 @@ export const SendTransaction = () => {
 
     if (isLegacyTransaction) {
       return Boolean(
-        fee.gasPrice != null &&
+        fee.gasPrice !== null &&
+          fee.gasPrice !== undefined &&
           customFee.gasPrice &&
           customFee.gasPrice > 0 &&
           customFee.gasPrice < fee.gasPrice
@@ -501,7 +502,8 @@ export const SendTransaction = () => {
               : fee.maxFeePerGas;
 
           if (
-            maxPriorityFeePerGas == null ||
+            maxPriorityFeePerGas === null ||
+            maxPriorityFeePerGas === undefined ||
             maxPriorityFeePerGas < 0 ||
             !maxFeePerGas ||
             maxFeePerGas <= 0
@@ -630,7 +632,8 @@ export const SendTransaction = () => {
               customFee.isCustom && customFee.maxPriorityFeePerGas >= 0
             )
               ? parseUnits(safeToFixed(customFee.maxPriorityFeePerGas), 9)
-              : tx.maxPriorityFeePerGas != null
+              : tx.maxPriorityFeePerGas !== null &&
+                tx.maxPriorityFeePerGas !== undefined
               ? safeBigNumber(
                   tx.maxPriorityFeePerGas,
                   parseUnits(safeToFixed(fee.maxPriorityFeePerGas), 9),
@@ -641,7 +644,7 @@ export const SendTransaction = () => {
               customFee.isCustom && customFee.maxFeePerGas > 0
             )
               ? parseUnits(safeToFixed(customFee.maxFeePerGas), 9)
-              : tx.maxFeePerGas != null
+              : tx.maxFeePerGas !== null && tx.maxFeePerGas !== undefined
               ? safeBigNumber(
                   tx.maxFeePerGas,
                   parseUnits(safeToFixed(fee.maxFeePerGas), 9),
@@ -652,7 +655,7 @@ export const SendTransaction = () => {
               customFee.isCustom && customFee.gasLimit && customFee.gasLimit > 0
             )
               ? BigNumber.from(customFee.gasLimit)
-              : tx.gasLimit != null
+              : tx.gasLimit !== null && tx.gasLimit !== undefined
               ? safeBigNumber(
                   tx.gasLimit,
                   BigNumber.from(fee.gasLimit || 42000),

--- a/source/scripts/Background/controllers/smartAccount/index.ts
+++ b/source/scripts/Background/controllers/smartAccount/index.ts
@@ -1073,9 +1073,14 @@ class SmartAccountController {
       validatorKind: validatorProfile.validatorKind,
     });
     const hasOuterEip1559FeeParams =
-      (options.feeOverrides?.maxFeePerGas != null &&
-        options.feeOverrides?.maxPriorityFeePerGas != null) ||
-      (feeData.maxFeePerGas != null && feeData.maxPriorityFeePerGas != null);
+      (options.feeOverrides?.maxFeePerGas !== null &&
+        options.feeOverrides?.maxFeePerGas !== undefined &&
+        options.feeOverrides?.maxPriorityFeePerGas !== null &&
+        options.feeOverrides?.maxPriorityFeePerGas !== undefined) ||
+      (feeData.maxFeePerGas !== null &&
+        feeData.maxFeePerGas !== undefined &&
+        feeData.maxPriorityFeePerGas !== null &&
+        feeData.maxPriorityFeePerGas !== undefined);
     const maxFeePerGas = BigNumber.from(
       options.feeOverrides?.maxFeePerGas ??
         feeData.maxFeePerGas ??

--- a/source/utils/ethersV6Compat.ts
+++ b/source/utils/ethersV6Compat.ts
@@ -101,7 +101,7 @@ export type BigNumberish =
     };
 
 const toBigIntValue = (value: BigNumberish | null | undefined): bigint => {
-  if (value == null) return BigInt(0);
+  if (value === null || value === undefined) return BigInt(0);
   if (value instanceof BigNumberCompat) return value.value;
   if (typeof value === 'bigint') return value;
   if (typeof value === 'number') return BigInt(Math.trunc(value));

--- a/source/utils/evmCallBlacklist.ts
+++ b/source/utils/evmCallBlacklist.ts
@@ -23,7 +23,7 @@ const normalizeAddress = (address?: string | null): string | null => {
 };
 
 const isZeroIntegerValue = (value: unknown): boolean =>
-  value != null && value.toString() === '0';
+  value !== null && value !== undefined && value.toString() === '0';
 
 export const shouldResolveEvmCallBlacklistContractType = (data?: string) =>
   data?.slice(0, 10).toLowerCase() === '0x095ea7b3';

--- a/source/utils/transactions.ts
+++ b/source/utils/transactions.ts
@@ -63,7 +63,7 @@ export const getTransactionDisplayInfo = async (
     // Get token ID for NFTs
     const tokenId = isErc1155Tx ? getERC1155TokenId(tx) : getERC721TokenId(tx);
 
-    if (tokenValue != null && tokenAddress) {
+    if (tokenValue !== null && tokenValue !== undefined && tokenAddress) {
       // Try to get token info from user's assets or fetch from controller
       try {
         const { accounts, activeAccount, accountAssets } =
@@ -188,7 +188,10 @@ export const getTransactionDisplayInfo = async (
         // ERC-1155 safeTransferFrom has an unambiguous selector
         if (isErc1155Tx) {
           const erc1155Value = getERC1155TransferValue(tx);
-          const nftAmount = erc1155Value == null ? 1 : Number(erc1155Value);
+          const nftAmount =
+            erc1155Value === null || erc1155Value === undefined
+              ? 1
+              : Number(erc1155Value);
           const inferredTokenId = getERC1155TokenId(tx) || undefined;
           return {
             displayValue: nftAmount,


### PR DESCRIPTION
## Summary

- replace all 17 loose `==` / `!=` TypeScript checks with strict equality
- preserve each nullish check's existing `null`-or-`undefined` semantics explicitly
- leave unrelated behavior unchanged

## Why

The existing `eqeqeq` warnings made it easier for a genuine accidental coercive comparison to be overlooked. Removing the backlog makes future loose-equality use visible immediately.

## Validation

- repository-wide ESLint with `eqeqeq` promoted to an error: zero equality violations
- TypeScript type-check passed
- Prettier check passed for all changed files
- full unit suite passed: 37 suites, 268 tests
- `git diff --check` passed

One unrelated pre-existing interface naming warning remains in `source/utils/smartAccount/execution.ts`.
