### PR TITLE
Bump Pali release version to 4.0.46

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Pali Wallet",
-  "version": "4.0.45",
+  "version": "4.0.46",
   "icons": {
     "16": "assets/all_assets/favicon-16.png",
     "32": "assets/all_assets/favicon-32.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paliwallet",
-  "version": "4.0.45",
+  "version": "4.0.46",
   "description": "A Non-Custodial Crypto Wallet",
   "private": true,
   "repository": {

--- a/source/config/consts.js
+++ b/source/config/consts.js
@@ -80,7 +80,7 @@ const CANARY_EXTENSION_KEY =
 const MV3_OPTIONS = {
   manifest_version: 3,
   name: 'Pali Wallet',
-  version: '4.0.45',
+  version: '4.0.46',
   icons: {
     16: 'assets/all_assets/favicon-16.png',
     32: 'assets/all_assets/favicon-32.png',


### PR DESCRIPTION
## Summary

- bump Pali from 4.0.45 to 4.0.46
- synchronize `package.json`, `manifest.json`, and the MV3 manifest source in `source/config/consts.js`
- base the release on merged strict-equality cleanup PR #820

## Validation

- all three canonical version sources resolve to 4.0.46
- JSON version files parse successfully
- `git diff --check` passed

The full test, visual, and release-build workflows run in CI for this ready-for-review PR.
