### PR TITLE
Bump release version to 4.0.47

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Pali Wallet",
-  "version": "4.0.46",
+  "version": "4.0.47",
   "icons": {
     "16": "assets/all_assets/favicon-16.png",
     "32": "assets/all_assets/favicon-32.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paliwallet",
-  "version": "4.0.46",
+  "version": "4.0.47",
   "description": "A Non-Custodial Crypto Wallet",
   "private": true,
   "repository": {

--- a/source/config/consts.js
+++ b/source/config/consts.js
@@ -80,7 +80,7 @@ const CANARY_EXTENSION_KEY =
 const MV3_OPTIONS = {
   manifest_version: 3,
   name: 'Pali Wallet',
-  version: '4.0.46',
+  version: '4.0.47',
   icons: {
     16: 'assets/all_assets/favicon-16.png',
     32: 'assets/all_assets/favicon-32.png',


### PR DESCRIPTION
## Summary

- bump the package version from 4.0.46 to 4.0.47
- align the checked-in extension manifest and generated MV3 manifest options

## Why

Prepare the release containing the merged token-approval confirmation and decoding fixes from PR #822.

## Verification

- production Chrome build completed successfully
- emitted `pali-wallet-production-chrome-4.0.47.zip`
- verified both the unpacked and zipped extension manifests report version 4.0.47
- confirmed the diff is limited to the three established release-version files