### PR TITLE
show SLH-DSA signing progress and bump release to 4.0.49

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Pali Wallet",
-  "version": "4.0.48",
+  "version": "4.0.49",
   "icons": {
     "16": "assets/all_assets/favicon-16.png",
     "32": "assets/all_assets/favicon-32.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paliwallet",
-  "version": "4.0.48",
+  "version": "4.0.49",
   "description": "A Non-Custodial Crypto Wallet",
   "private": true,
   "repository": {

--- a/source/config/consts.js
+++ b/source/config/consts.js
@@ -80,7 +80,7 @@ const CANARY_EXTENSION_KEY =
 const MV3_OPTIONS = {
   manifest_version: 3,
   name: 'Pali Wallet',
-  version: '4.0.48',
+  version: '4.0.49',
   icons: {
     16: 'assets/all_assets/favicon-16.png',
     32: 'assets/all_assets/favicon-32.png',

--- a/source/pages/Send/SendCalls.tsx
+++ b/source/pages/Send/SendCalls.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import { v4 as uuidv4 } from 'uuid';
 
 import { Button, Icon, Tooltip } from 'components/index';
-import { LoadingComponent } from 'components/Loading';
+import { LoadingComponent, PqSigningOverlay } from 'components/Loading';
 import { useQueryData, useUtils } from 'hooks/index';
 import { useController } from 'hooks/useController';
 import { RootState } from 'state/store';
@@ -181,6 +181,7 @@ export const SendCalls = () => {
 
   const [confirmed, setConfirmed] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(false);
+  const [isPqSigning, setIsPqSigning] = useState<boolean>(false);
   const [initialLoading, setInitialLoading] = useState<boolean>(true);
   const [selectedCalls, setSelectedCalls] = useState<boolean[]>([]);
   const [processingIndex, setProcessingIndex] = useState<number>(-1);
@@ -372,6 +373,7 @@ export const SendCalls = () => {
 
   const handleApprove = async () => {
     try {
+      setIsPqSigning(false);
       setLoading(true);
       setConfirmed(false); // Reset confirmed state for each attempt
 
@@ -515,6 +517,16 @@ export const SendCalls = () => {
                 });
               });
             },
+            onAuthenticatorSigningResolved: (authenticator) => {
+              if (authenticator === 'slh-dsa') {
+                setIsPqSigning(false);
+              }
+            },
+            onAuthenticatorSigningStarted: (authenticator) => {
+              if (authenticator === 'slh-dsa') {
+                setIsPqSigning(true);
+              }
+            },
             smartAccount: activeAccount.smartAccount,
           })) as any;
           const txHash = response.hash || response;
@@ -550,6 +562,8 @@ export const SendCalls = () => {
           setProcessingIndex(-1);
           alert.error(errorMessage);
           return;
+        } finally {
+          setIsPqSigning(false);
         }
       }
 
@@ -761,6 +775,7 @@ export const SendCalls = () => {
       }
     } catch (error) {
       console.error('Failed to process batch calls', error);
+      setIsPqSigning(false);
       setLoading(false);
       setConfirmed(false);
       setProcessingIndex(-1);
@@ -1057,6 +1072,13 @@ export const SendCalls = () => {
 
       {/* Action buttons */}
       <div className="fixed bottom-0 left-0 right-0 bg-bkg-3 border-t border-brand-gray300 px-4 py-3 shadow-lg z-50">
+        <PqSigningOverlay
+          expectedSeconds={90}
+          show={isPqSigning}
+          subtitle={t('settings.slhDsaSigningOverlayDescription')}
+          title={t('settings.slhDsaSigningInProgress')}
+          warningSeconds={180}
+        />
         {/* Progress indicator */}
         {loading && transactionStatuses && (
           <div className="mb-3 px-4">

--- a/source/pages/Send/SendTransaction.tsx
+++ b/source/pages/Send/SendTransaction.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 
 import { Button, DeviceWaitingBanner, WarningModal } from 'components/index';
-import { LoadingComponent } from 'components/Loading';
+import { LoadingComponent, PqSigningOverlay } from 'components/Loading';
 import { useQueryData, useUtils } from 'hooks/index';
 import { useController } from 'hooks/useController';
 import { RootState } from 'state/store';
@@ -150,6 +150,7 @@ export const SendTransaction = () => {
 
   const [confirmed, setConfirmed] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(false);
+  const [isPqSigning, setIsPqSigning] = useState<boolean>(false);
   const [initialLoading, setInitialLoading] = useState<boolean>(true);
   const [tx, setTx] = useState<ITxState>();
   const [fee, setFee] = useState<IFeeState>();
@@ -436,6 +437,7 @@ export const SendTransaction = () => {
       return;
     }
 
+    setIsPqSigning(false);
     setLoading(true);
 
     let balance = Number(activeAccount?.balances?.ethereum || 0);
@@ -582,6 +584,16 @@ export const SendTransaction = () => {
               },
             ],
             feeOverrides: getSmartAccountFeeOverrides(),
+            onAuthenticatorSigningResolved: (authenticator) => {
+              if (authenticator === 'slh-dsa') {
+                setIsPqSigning(false);
+              }
+            },
+            onAuthenticatorSigningStarted: (authenticator) => {
+              if (authenticator === 'slh-dsa') {
+                setIsPqSigning(true);
+              }
+            },
             smartAccount: activeAccount.smartAccount,
           });
         } else if (isLegacyTransaction) {
@@ -742,6 +754,8 @@ export const SendTransaction = () => {
           setLoading(false);
         }
         return error;
+      } finally {
+        setIsPqSigning(false);
       }
     } else {
       setLoading(false);
@@ -1331,6 +1345,13 @@ export const SendTransaction = () => {
           {/* Fixed button container at bottom */}
           <div className="fixed bottom-0 left-0 right-0 bg-bkg-3 border-t border-brand-gray300 px-4 py-3 shadow-lg z-50">
             <DeviceWaitingBanner account={activeAccount} show={loading} />
+            <PqSigningOverlay
+              expectedSeconds={90}
+              show={isPqSigning}
+              subtitle={t('settings.slhDsaSigningOverlayDescription')}
+              title={t('settings.slhDsaSigningInProgress')}
+              warningSeconds={180}
+            />
             {hasTxDataError && (
               <p className="text-center text-warning-error text-xs mb-2">
                 {t('send.contractEstimateError')}


### PR DESCRIPTION
## What changed

- show the existing SLH-DSA signing overlay while dapp-initiated `eth_sendTransaction` requests are being signed
- show the same overlay for atomic smart-account `wallet_sendCalls` batches
- retain the normal spinner/status behavior for passkey and ECDSA authenticators
- clear the overlay on both success and failure
- bump the extension release version from `4.0.48` to `4.0.49`

## Root cause

The dapp transaction screens called `signAndSubmitSmartAccountExecutions` without wiring its authenticator signing lifecycle callbacks. Wallet-originated sends and message signing already used those callbacks, so SLH-DSA execution was working but the dapp UI exposed only a generic spinner during the long local signing phase.

## Validation

- TypeScript type-check
- ESLint on both changed screens and release constants
- Prettier check for changed formatted sources
- release-version alignment across `package.json`, `manifest.json`, and `source/config/consts.js`
- i18n analyzer: 926 aligned keys, no missing/extra/empty/unused keys
- 39 test suites / 281 tests passed