### PR TITLE
Fix cross-network dapp connection enforcement

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Pali Wallet",
-  "version": "4.0.49",
+  "version": "4.0.50",
   "icons": {
     "16": "assets/all_assets/favicon-16.png",
     "32": "assets/all_assets/favicon-32.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paliwallet",
-  "version": "4.0.49",
+  "version": "4.0.50",
   "description": "A Non-Custodial Crypto Wallet",
   "private": true,
   "repository": {

--- a/source/config/consts.js
+++ b/source/config/consts.js
@@ -80,7 +80,7 @@ const CANARY_EXTENSION_KEY =
 const MV3_OPTIONS = {
   manifest_version: 3,
   name: 'Pali Wallet',
-  version: '4.0.49',
+  version: '4.0.50',
   icons: {
     16: 'assets/all_assets/favicon-16.png',
     32: 'assets/all_assets/favicon-32.png',

--- a/source/pages/SwitchNetwork/NetworkList.tsx
+++ b/source/pages/SwitchNetwork/NetworkList.tsx
@@ -13,10 +13,10 @@ import { dispatchBackgroundEvent } from 'utils/browser';
 import { getChainIdPriority } from 'utils/chainIdPriority';
 
 import { useNetworkInfo } from './NetworkInfo';
-
-type currentNetwork = {
-  current: INetwork;
-};
+import {
+  getInitialNetworkSelection,
+  NetworkSelection,
+} from './networkSelection';
 
 interface INetworkListProps {
   disabledNetworkType?: string;
@@ -43,7 +43,9 @@ export const NetworkList = ({
   const { host, eventName } = queryData;
 
   const [selectCurrentNetwork, setSelectCurrentNetwork] =
-    useState<currentNetwork>();
+    useState<NetworkSelection | null>(() =>
+      getInitialNetworkSelection(activeNetwork, isTypeSwitch)
+    );
   const [selectedNetwork, setSelectedNetwork] = useState<INetworkType>(() => {
     // If this is a type switch, force the target network type
     if (isTypeSwitch && forceNetworkType) {
@@ -55,13 +57,6 @@ export const NetworkList = ({
     return isBitcoinBased ? INetworkType.Syscoin : INetworkType.Ethereum;
   });
   const [isLoading, setIsLoading] = useState(false);
-
-  // Set the initial selected network to the current active network
-  React.useEffect(() => {
-    if (activeNetwork && !selectCurrentNetwork) {
-      setSelectCurrentNetwork({ current: activeNetwork });
-    }
-  }, [activeNetwork, selectCurrentNetwork]);
 
   const {
     networkThatNeedsChanging,

--- a/source/pages/SwitchNetwork/networkSelection.spec.ts
+++ b/source/pages/SwitchNetwork/networkSelection.spec.ts
@@ -1,0 +1,30 @@
+import { INetwork, INetworkType } from 'types/network';
+
+import { getInitialNetworkSelection } from './networkSelection';
+
+const activeNetwork: INetwork = {
+  chainId: 57,
+  currency: 'sys',
+  default: true,
+  explorer: 'https://explorer.example',
+  kind: INetworkType.Syscoin,
+  label: 'Syscoin',
+  slip44: 57,
+  url: 'https://rpc.example',
+};
+
+describe('getInitialNetworkSelection', () => {
+  it('requires an explicit target selection for forced type switches', () => {
+    expect(getInitialNetworkSelection(activeNetwork, true)).toBeNull();
+  });
+
+  it('preselects the active network for regular network navigation', () => {
+    expect(getInitialNetworkSelection(activeNetwork, false)).toEqual({
+      current: activeNetwork,
+    });
+  });
+
+  it('does not create a selection before the active network is available', () => {
+    expect(getInitialNetworkSelection(undefined, false)).toBeNull();
+  });
+});

--- a/source/pages/SwitchNetwork/networkSelection.ts
+++ b/source/pages/SwitchNetwork/networkSelection.ts
@@ -1,0 +1,11 @@
+import { INetwork } from 'types/network';
+
+export type NetworkSelection = {
+  current: INetwork;
+};
+
+export const getInitialNetworkSelection = (
+  activeNetwork: INetwork | undefined,
+  isTypeSwitch?: boolean
+): NetworkSelection | null =>
+  isTypeSwitch || !activeNetwork ? null : { current: activeNetwork };

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -6349,6 +6349,10 @@ class MainController {
     // - network configuration
     // - isBitcoinBased (derived from activeChain)
     store.dispatch(setNetworkChange({ activeNetwork: network }));
+
+    // Invalidate network-dependent provider responses before reconciliation or
+    // notifications can trigger dapp reads against the newly active network.
+    clearProviderCache();
     await this.ensureActiveAccountCompatibleWithNetwork(network);
 
     // Dispatch success immediately to prevent getting stuck in "switching" state

--- a/source/scripts/Background/controllers/message-handler/method-registry.ts
+++ b/source/scripts/Background/controllers/message-handler/method-registry.ts
@@ -203,7 +203,7 @@ export const METHOD_REGISTRY: MethodRegistry = {
     requiresConnection: false,
     allowHardwareWallet: true,
     networkPreference: NetworkPreference.EVM,
-    networkEnforcement: NetworkEnforcement.BeforeConnection,
+    networkEnforcement: NetworkEnforcement.Always,
     hasPopup: true,
     popupRoute: MethodRoute.ChangeAccount,
     popupEventName: 'requestPermissions',
@@ -479,7 +479,7 @@ export const METHOD_REGISTRY: MethodRegistry = {
     requiresConnection: true,
     allowHardwareWallet: true,
     networkPreference: NetworkPreference.EVM,
-    networkEnforcement: NetworkEnforcement.BeforeConnection,
+    networkEnforcement: NetworkEnforcement.Always,
     hasPopup: false, // Let connectionMiddleware handle the popup
     returnsArray: true,
   },
@@ -1168,7 +1168,7 @@ export const METHOD_REGISTRY: MethodRegistry = {
     requiresConnection: true,
     allowHardwareWallet: true,
     networkPreference: NetworkPreference.UTXO,
-    networkEnforcement: NetworkEnforcement.BeforeConnection,
+    networkEnforcement: NetworkEnforcement.Always,
     hasPopup: false, // No popup needed - just returns UTXO address
     returnsArray: true,
   },

--- a/source/scripts/Background/controllers/message-handler/request-pipeline.network-compatibility.spec.ts
+++ b/source/scripts/Background/controllers/message-handler/request-pipeline.network-compatibility.spec.ts
@@ -77,9 +77,9 @@ describe('networkCompatibilityMiddleware connection enforcement', () => {
   it.each(['wallet_requestPermissions', 'eth_requestAccounts'])(
     'forces an EVM type switch for %s despite an existing UTXO connection',
     async (method) => {
-      mockGetState.mockReturnValue({
-        vault: { isBitcoinBased: true },
-      });
+      mockGetState
+        .mockReturnValueOnce({ vault: { isBitcoinBased: true } })
+        .mockReturnValue({ vault: { isBitcoinBased: false } });
       const popupSpy = jest
         .spyOn(requestCoordinator, 'coordinatePopupRequest')
         .mockResolvedValue(null);
@@ -111,9 +111,9 @@ describe('networkCompatibilityMiddleware connection enforcement', () => {
   );
 
   it('forces a UTXO type switch for sys_requestAccounts despite an existing EVM connection', async () => {
-    mockGetState.mockReturnValue({
-      vault: { isBitcoinBased: false },
-    });
+    mockGetState
+      .mockReturnValueOnce({ vault: { isBitcoinBased: false } })
+      .mockReturnValue({ vault: { isBitcoinBased: true } });
     const popupSpy = jest
       .spyOn(requestCoordinator, 'coordinatePopupRequest')
       .mockResolvedValue(null);
@@ -142,6 +142,31 @@ describe('networkCompatibilityMiddleware connection enforcement', () => {
     });
     expect(next).toHaveBeenCalledTimes(1);
   });
+
+  it.each([
+    ['wallet_requestPermissions', true],
+    ['eth_requestAccounts', true],
+    ['sys_requestAccounts', false],
+  ])(
+    'rejects %s when a superseded switch leaves the wallet on the incompatible network type',
+    async (method, isBitcoinBased) => {
+      mockGetState.mockReturnValue({
+        vault: { isBitcoinBased },
+      });
+      jest
+        .spyOn(requestCoordinator, 'coordinatePopupRequest')
+        .mockResolvedValue(null);
+      const next = jest.fn().mockResolvedValue('continued');
+
+      await expect(
+        networkCompatibilityMiddleware(createContext(method as string), next)
+      ).rejects.toMatchObject({
+        message: expect.stringContaining('Network switch did not complete'),
+      });
+
+      expect(next).not.toHaveBeenCalled();
+    }
+  );
 
   it.each([
     ['wallet_requestPermissions', false],

--- a/source/scripts/Background/controllers/message-handler/request-pipeline.network-compatibility.spec.ts
+++ b/source/scripts/Background/controllers/message-handler/request-pipeline.network-compatibility.spec.ts
@@ -26,6 +26,7 @@ jest.mock('./popup-promise', () => ({
 
 import { getController } from 'scripts/Background';
 
+import { clearProviderCache } from './method-handlers';
 import { getMethodConfig } from './method-registry';
 import { popupPromise } from './popup-promise';
 import {
@@ -90,6 +91,7 @@ describe('networkCompatibilityMiddleware connection enforcement', () => {
         'continued'
       );
 
+      expect(clearProviderCache).toHaveBeenCalledTimes(1);
       expect(popupSpy).toHaveBeenCalledWith(
         context,
         expect.any(Function),
@@ -124,6 +126,7 @@ describe('networkCompatibilityMiddleware connection enforcement', () => {
       'continued'
     );
 
+    expect(clearProviderCache).toHaveBeenCalledTimes(1);
     expect(popupSpy).toHaveBeenCalledWith(
       context,
       expect.any(Function),
@@ -164,6 +167,7 @@ describe('networkCompatibilityMiddleware connection enforcement', () => {
         message: expect.stringContaining('Network switch did not complete'),
       });
 
+      expect(clearProviderCache).not.toHaveBeenCalled();
       expect(next).not.toHaveBeenCalled();
     }
   );
@@ -185,6 +189,7 @@ describe('networkCompatibilityMiddleware connection enforcement', () => {
         networkCompatibilityMiddleware(createContext(method as string), next)
       ).resolves.toBe('continued');
 
+      expect(clearProviderCache).not.toHaveBeenCalled();
       expect(popupSpy).not.toHaveBeenCalled();
       expect(next).toHaveBeenCalledTimes(1);
     }

--- a/source/scripts/Background/controllers/message-handler/request-pipeline.network-compatibility.spec.ts
+++ b/source/scripts/Background/controllers/message-handler/request-pipeline.network-compatibility.spec.ts
@@ -1,0 +1,167 @@
+/* eslint-disable camelcase */
+const mockGetState = jest.fn();
+
+jest.mock('state/store', () => ({
+  __esModule: true,
+  default: {
+    getState: () => mockGetState(),
+  },
+}));
+
+jest.mock('scripts/Background', () => ({
+  getController: jest.fn(),
+}));
+
+jest.mock('@sidhujag/sysweb3-keyring', () => ({
+  PsbtUtils: {},
+}));
+
+jest.mock('./method-handlers', () => ({
+  clearProviderCache: jest.fn(),
+}));
+
+jest.mock('./popup-promise', () => ({
+  popupPromise: jest.fn().mockResolvedValue(null),
+}));
+
+import { getController } from 'scripts/Background';
+
+import { getMethodConfig } from './method-registry';
+import { popupPromise } from './popup-promise';
+import {
+  networkCompatibilityMiddleware,
+  requestCoordinator,
+} from './request-pipeline';
+import { MethodRoute, NetworkEnforcement, NetworkPreference } from './types';
+
+const host = 'connected.example';
+
+const createContext = (method: string) =>
+  ({
+    methodConfig: getMethodConfig(method),
+    originalRequest: {
+      host,
+      method,
+      params:
+        method === 'wallet_requestPermissions'
+          ? [{ eth_accounts: {} }]
+          : undefined,
+      sender: {},
+      type: 'METHOD_REQUEST',
+    },
+  } as any);
+
+describe('networkCompatibilityMiddleware connection enforcement', () => {
+  const isConnected = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    isConnected.mockReturnValue(true);
+    (getController as jest.Mock).mockReturnValue({
+      dapp: { isConnected },
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('keeps wallet_requestPermissions from opening a separate connection popup', () => {
+    expect(getMethodConfig('wallet_requestPermissions')).toMatchObject({
+      networkEnforcement: NetworkEnforcement.Always,
+      networkPreference: NetworkPreference.EVM,
+      requiresConnection: false,
+    });
+  });
+
+  it.each(['wallet_requestPermissions', 'eth_requestAccounts'])(
+    'forces an EVM type switch for %s despite an existing UTXO connection',
+    async (method) => {
+      mockGetState.mockReturnValue({
+        vault: { isBitcoinBased: true },
+      });
+      const popupSpy = jest
+        .spyOn(requestCoordinator, 'coordinatePopupRequest')
+        .mockResolvedValue(null);
+      const next = jest.fn().mockResolvedValue('continued');
+      const context = createContext(method);
+
+      await expect(networkCompatibilityMiddleware(context, next)).resolves.toBe(
+        'continued'
+      );
+
+      expect(popupSpy).toHaveBeenCalledWith(
+        context,
+        expect.any(Function),
+        MethodRoute.SwitchNetwork
+      );
+      await popupSpy.mock.calls[0][1]();
+      expect(popupPromise).toHaveBeenCalledWith({
+        data: {
+          disabledNetworkType: 'syscoin',
+          forceNetworkType: 'ethereum',
+          isTypeSwitch: true,
+        },
+        eventName: 'switchNetwork',
+        host,
+        route: MethodRoute.SwitchNetwork,
+      });
+      expect(next).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it('forces a UTXO type switch for sys_requestAccounts despite an existing EVM connection', async () => {
+    mockGetState.mockReturnValue({
+      vault: { isBitcoinBased: false },
+    });
+    const popupSpy = jest
+      .spyOn(requestCoordinator, 'coordinatePopupRequest')
+      .mockResolvedValue(null);
+    const next = jest.fn().mockResolvedValue('continued');
+    const context = createContext('sys_requestAccounts');
+
+    await expect(networkCompatibilityMiddleware(context, next)).resolves.toBe(
+      'continued'
+    );
+
+    expect(popupSpy).toHaveBeenCalledWith(
+      context,
+      expect.any(Function),
+      MethodRoute.SwitchNetwork
+    );
+    await popupSpy.mock.calls[0][1]();
+    expect(popupPromise).toHaveBeenCalledWith({
+      data: {
+        disabledNetworkType: 'ethereum',
+        forceNetworkType: 'syscoin',
+        isTypeSwitch: true,
+      },
+      eventName: 'switchNetwork',
+      host,
+      route: MethodRoute.SwitchNetwork,
+    });
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ['wallet_requestPermissions', false],
+    ['eth_requestAccounts', false],
+    ['sys_requestAccounts', true],
+  ])(
+    'does not open a switch popup for %s on the correct network type',
+    async (method, isBitcoinBased) => {
+      mockGetState.mockReturnValue({
+        vault: { isBitcoinBased },
+      });
+      const popupSpy = jest.spyOn(requestCoordinator, 'coordinatePopupRequest');
+      const next = jest.fn().mockResolvedValue('continued');
+
+      await expect(
+        networkCompatibilityMiddleware(createContext(method as string), next)
+      ).resolves.toBe('continued');
+
+      expect(popupSpy).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+    }
+  );
+});

--- a/source/scripts/Background/controllers/message-handler/request-pipeline.network-compatibility.spec.ts
+++ b/source/scripts/Background/controllers/message-handler/request-pipeline.network-compatibility.spec.ts
@@ -26,7 +26,6 @@ jest.mock('./popup-promise', () => ({
 
 import { getController } from 'scripts/Background';
 
-import { clearProviderCache } from './method-handlers';
 import { getMethodConfig } from './method-registry';
 import { popupPromise } from './popup-promise';
 import {
@@ -91,7 +90,6 @@ describe('networkCompatibilityMiddleware connection enforcement', () => {
         'continued'
       );
 
-      expect(clearProviderCache).toHaveBeenCalledTimes(1);
       expect(popupSpy).toHaveBeenCalledWith(
         context,
         expect.any(Function),
@@ -126,7 +124,6 @@ describe('networkCompatibilityMiddleware connection enforcement', () => {
       'continued'
     );
 
-    expect(clearProviderCache).toHaveBeenCalledTimes(1);
     expect(popupSpy).toHaveBeenCalledWith(
       context,
       expect.any(Function),
@@ -167,7 +164,6 @@ describe('networkCompatibilityMiddleware connection enforcement', () => {
         message: expect.stringContaining('Network switch did not complete'),
       });
 
-      expect(clearProviderCache).not.toHaveBeenCalled();
       expect(next).not.toHaveBeenCalled();
     }
   );
@@ -189,7 +185,6 @@ describe('networkCompatibilityMiddleware connection enforcement', () => {
         networkCompatibilityMiddleware(createContext(method as string), next)
       ).resolves.toBe('continued');
 
-      expect(clearProviderCache).not.toHaveBeenCalled();
       expect(popupSpy).not.toHaveBeenCalled();
       expect(next).toHaveBeenCalledTimes(1);
     }

--- a/source/scripts/Background/controllers/message-handler/request-pipeline.ts
+++ b/source/scripts/Background/controllers/message-handler/request-pipeline.ts
@@ -511,6 +511,10 @@ export const networkCompatibilityMiddleware: Middleware = async (
         )
       );
     }
+
+    // The origin may remain connected across the type switch, so the
+    // connection middleware will not clear network-dependent provider state.
+    clearProviderCache();
   }
 
   return next();

--- a/source/scripts/Background/controllers/message-handler/request-pipeline.ts
+++ b/source/scripts/Background/controllers/message-handler/request-pipeline.ts
@@ -511,10 +511,6 @@ export const networkCompatibilityMiddleware: Middleware = async (
         )
       );
     }
-
-    // The origin may remain connected across the type switch, so the
-    // connection middleware will not clear network-dependent provider state.
-    clearProviderCache();
   }
 
   return next();

--- a/source/scripts/Background/controllers/message-handler/request-pipeline.ts
+++ b/source/scripts/Background/controllers/message-handler/request-pipeline.ts
@@ -491,6 +491,26 @@ export const networkCompatibilityMiddleware: Middleware = async (
         )
       );
     }
+
+    // A competing network switch can supersede this one. setActiveNetwork
+    // reports that cancellation as a fulfilled result so the popup can close,
+    // therefore verify the live network type before allowing the request to
+    // continue.
+    const { isBitcoinBased: isBitcoinBasedAfterSwitch } =
+      store.getState().vault;
+    const switchCompleted = needsEVM
+      ? !isBitcoinBasedAfterSwitch
+      : isBitcoinBasedAfterSwitch;
+
+    if (!switchCompleted) {
+      throw cleanErrorStack(
+        ethErrors.provider.unauthorized(
+          `${originalRequest.method} requires ${
+            needsEVM ? 'an EVM-compatible' : 'a Bitcoin/UTXO'
+          } network. Network switch did not complete.`
+        )
+      );
+    }
   }
 
   return next();

--- a/source/scripts/Background/controllers/message-handler/types.ts
+++ b/source/scripts/Background/controllers/message-handler/types.ts
@@ -22,10 +22,9 @@ export enum NetworkPreference {
 
 // Network enforcement - when to enforce network preference
 export enum NetworkEnforcement {
-  // Enforce when establishing connection
-  Always = 'always', // Never enforce, just a preference
-  BeforeConnection = 'beforeConnection',
-  Never = 'never', // Always enforce before method execution
+  Always = 'always', // Enforce before every method execution
+  BeforeConnection = 'beforeConnection', // Enforce while establishing a new connection
+  Never = 'never', // Never enforce; the network is only a preference
 }
 
 // Popup routes for methods that need UI


### PR DESCRIPTION
## What changed

- force `wallet_requestPermissions` and `eth_requestAccounts` onto an EVM network before execution
- force `sys_requestAccounts` onto a UTXO network before execution
- preserve `wallet_requestPermissions.requiresConnection = false`, so the permissions confirmation remains the connection consent instead of opening a second connect popup
- correct the misleading `NetworkEnforcement` enum comments
- add regression coverage for incompatible existing sessions and already-correct network types

## Root cause

`wallet_requestPermissions` was changed to establish permissions without a separate connection popup, but `BeforeConnection` enforcement was implemented in terms of `requiresConnection`. On UTXO, the permissions request therefore skipped the EVM switch and created a UTXO-scoped dapp session. Later `eth_requestAccounts` calls saw the host as connected, skipped their own pre-connection switch, and returned an incompatible account, causing connector retry loops.

## User impact

Connecting an EVM dapp while Pali is on UTXO now prompts for an EVM network first and then continues through normal permission/account consent. The symmetric EVM-to-UTXO flow is also fixed. Requests on an already-correct network do not gain an extra popup.

## Validation

- 40 Jest suites passed
- 288 tests passed
- full TypeScript check passed
- full ESLint passed with one unrelated pre-existing naming warning
- lint-staged passed on the three changed files
