### PR TITLE
Fix stuck dapp network switch approvals

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Pali Wallet",
-  "version": "4.0.50",
+  "version": "4.0.51",
   "icons": {
     "16": "assets/all_assets/favicon-16.png",
     "32": "assets/all_assets/favicon-32.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paliwallet",
-  "version": "4.0.50",
+  "version": "4.0.51",
   "description": "A Non-Custodial Crypto Wallet",
   "private": true,
   "repository": {

--- a/source/config/consts.js
+++ b/source/config/consts.js
@@ -80,7 +80,7 @@ const CANARY_EXTENSION_KEY =
 const MV3_OPTIONS = {
   manifest_version: 3,
   name: 'Pali Wallet',
-  version: '4.0.50',
+  version: '4.0.51',
   icons: {
     16: 'assets/all_assets/favicon-16.png',
     32: 'assets/all_assets/favicon-32.png',

--- a/source/hooks/usePageLoadingState.spec.ts
+++ b/source/hooks/usePageLoadingState.spec.ts
@@ -1,0 +1,16 @@
+import { isPageLoadingOverlayExcluded } from './usePageLoadingState';
+
+describe('isPageLoadingOverlayExcluded', () => {
+  it.each([
+    '/external/switch-network',
+    '/external/add-EthChain',
+    '/external/switch-EthChain',
+    '/external/switch-UtxoEvm',
+  ])('keeps the global overlay off dapp switch approval %s', (pathname) => {
+    expect(isPageLoadingOverlayExcluded(pathname)).toBe(true);
+  });
+
+  it('still permits the overlay on ordinary wallet pages', () => {
+    expect(isPageLoadingOverlayExcluded('/home')).toBe(false);
+  });
+});

--- a/source/hooks/usePageLoadingState.tsx
+++ b/source/hooks/usePageLoadingState.tsx
@@ -12,6 +12,20 @@ interface IPageLoadingState {
 
 const TEN_SECONDS = 10000;
 
+const LOADING_OVERLAY_EXCLUDED_PAGES = new Set([
+  '/chain-fail-to-connect',
+  '/settings/networks/custom-rpc',
+  // Dapp approval pages own their pending state. A global overlay would cover
+  // their controls while the background switch is waiting for completion.
+  '/external/switch-network',
+  '/external/add-EthChain',
+  '/external/switch-EthChain',
+  '/external/switch-UtxoEvm',
+]);
+
+export const isPageLoadingOverlayExcluded = (pathname: string): boolean =>
+  LOADING_OVERLAY_EXCLUDED_PAGES.has(pathname);
+
 export const usePageLoadingState = (
   additionalLoadingConditions: boolean[] = []
 ): IPageLoadingState => {
@@ -40,20 +54,12 @@ export const usePageLoadingState = (
   // Only apply timeout logic on pages where users expect quick loading
   const timeoutEnabledPages = ['/home'];
 
-  // Never show loading overlay on these pages - they handle their own loading states
-  const loadingExcludedPages = [
-    '/chain-fail-to-connect',
-    '/settings/networks/custom-rpc',
-  ];
-
   const shouldEnableTimeout = timeoutEnabledPages.some(
     (page) =>
       location.pathname === page || location.pathname.startsWith(`${page}/`)
   );
 
-  const isOnExcludedPage = loadingExcludedPages.some(
-    (page) => location.pathname === page
-  );
+  const isOnExcludedPage = isPageLoadingOverlayExcluded(location.pathname);
 
   // Determine if we're loading
   const isNetworkChanging = networkStatus === 'switching';

--- a/source/pages/Settings/ExternalAddRPC.tsx
+++ b/source/pages/Settings/ExternalAddRPC.tsx
@@ -262,7 +262,11 @@ const CustomRPCExternal = () => {
       setSwitchingNetwork(true);
 
       // Switch to the new network
-      await controllerEmitter(['wallet', 'setActiveNetwork'], [network, true]);
+      await controllerEmitter(
+        ['wallet', 'setActiveNetwork'],
+        // Do not hold the dapp approval open for post-switch balance loading.
+        [network, false]
+      );
 
       const type = data.eventName;
 

--- a/source/pages/Settings/SwitchEthereumChain.tsx
+++ b/source/pages/Settings/SwitchEthereumChain.tsx
@@ -45,7 +45,11 @@ const SwitchChain: React.FC = () => {
     setLoading(true);
     try {
       // Perform the network switch and wait for state update
-      await controllerEmitter(['wallet', 'setActiveNetwork'], [network, true]);
+      await controllerEmitter(
+        ['wallet', 'setActiveNetwork'],
+        // Balance refreshes must not hold a dapp switch approval open.
+        [network, false]
+      );
       try {
         await waitForNetworkSwitch(network.chainId, 5000);
       } catch (_e) {

--- a/source/pages/Settings/SwitchNetworkUtxoEvm.tsx
+++ b/source/pages/Settings/SwitchNetworkUtxoEvm.tsx
@@ -69,7 +69,9 @@ const SwitchNeworkUtxoEvm: React.FC = () => {
       // Perform the network switch and wait for state update
       await controllerEmitter(
         ['wallet', 'setActiveNetwork'],
-        [newNetwork, true]
+        // The network/account state is committed before this resolves. Do not
+        // keep a dapp approval popup open for the subsequent balance refresh.
+        [newNetwork, false]
       );
       try {
         await waitForNetworkSwitch(newNetwork.chainId, 5000);

--- a/source/pages/SwitchNetwork/NetworkList.tsx
+++ b/source/pages/SwitchNetwork/NetworkList.tsx
@@ -84,8 +84,10 @@ export const NetworkList = ({
       // The user can always navigate away or try a different network if it's taking too long
       await controllerEmitter(
         ['wallet', 'setActiveNetwork'],
-        [network, isTypeSwitch]
-      ); // syncUpdates: true
+        // Forced dapp type switches only need the committed network/account
+        // state; balance refreshes continue independently in the background.
+        [network, false]
+      );
 
       // Reset loading state on success
       setIsLoading(false);

--- a/source/scripts/Background/controllers/DAppController.ts
+++ b/source/scripts/Background/controllers/DAppController.ts
@@ -296,7 +296,7 @@ const DAppController = (): IDAppController => {
       : account.address;
   };
 
-  const disconnect = async (host: string) => {
+  const disconnect = async (host: string, persist = true) => {
     try {
       const previousConnectedDapps = getAll();
       const isInActiveSession = Boolean(_dapps[host]);
@@ -305,7 +305,9 @@ const DAppController = (): IDAppController => {
         case true:
           delete _dapps[host];
           store.dispatch(removeDApp(host));
-          await persistDappState('dapp disconnect');
+          if (persist) {
+            await persistDappState('dapp disconnect');
+          }
 
           // Trigger disconnection notification
           notificationManager.notifyDappConnection(host, false);
@@ -342,7 +344,9 @@ const DAppController = (): IDAppController => {
         case false:
           if (previousConnectedDapps[host]) {
             store.dispatch(removeDApp(host));
-            await persistDappState('dapp disconnect');
+            if (persist) {
+              await persistDappState('dapp disconnect');
+            }
 
             // Trigger disconnection notification
             notificationManager.notifyDappConnection(host, false);

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -1818,13 +1818,9 @@ class MainController {
     const activeSlip44 = store.getState().vaultGlobal.activeSlip44;
 
     if (activeSlip44 !== null) {
-      const currentVaultState = store.getState().vault;
-
-      // Save vault state to slip44-specific storage
-      await vaultCache.setSlip44Vault(activeSlip44, currentVaultState);
-
-      // Save main state (global settings)
-      await saveMainState();
+      // Serialize with network-switch and emergency commits. The storage helper
+      // batches vault + changed main state into one Chrome storage operation.
+      await persistCommittedWalletState(true, true);
 
       console.log(
         `[MainController] Wallet state saved successfully for operation: ${operation}`

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -5477,9 +5477,14 @@ class MainController {
               })
             );
 
+            // This flag represents an in-flight request, not network health. If
+            // it survives a rejected request, the app-wide loading overlay can
+            // intercept every click indefinitely. Network health is tracked by
+            // networkStatus/networkQuality instead.
+            if (!isPollingUpdate) {
+              store.dispatch(setIsLoadingBalances(false));
+            }
             reject(error);
-            // Don't clear loading state on error - let it stay until successful update
-            // This keeps the status indicator visible when RPC is failing
           }
         }
       );

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -188,6 +188,7 @@ class MainController {
   private assetsManager: IAssetsManager;
   private transactionsManager: ITransactionsManager;
   private balancesManager: IBalancesManager;
+  private balanceLoadingRequestId = 0;
   private smartAccount: SmartAccountController;
   private cancellablePromises: CancellablePromises;
   private currentPromise: {
@@ -5345,6 +5346,19 @@ class MainController {
     isBitcoinBased: boolean;
     isPolling?: boolean;
   }) {
+    // Polling requests never own the blocking loading state. Each non-polling
+    // request receives a generation so a superseded executor cannot clear the
+    // flag after a newer foreground balance request has started.
+    const loadingRequestId = isPolling ? null : ++this.balanceLoadingRequestId;
+    const clearBalanceLoadingIfOwned = () => {
+      if (
+        loadingRequestId !== null &&
+        loadingRequestId === this.balanceLoadingRequestId
+      ) {
+        store.dispatch(setIsLoadingBalances(false));
+      }
+    };
+
     // Set loading state immediately for non-polling updates
     // This prevents skeleton flashing by ensuring loading state is set before any async operations
     if (!isPolling) {
@@ -5360,7 +5374,7 @@ class MainController {
           '[MainController] Wallet is locked, skipping non-polling balance updates'
         );
         // Clear loading state and return
-        store.dispatch(setIsLoadingBalances(false));
+        clearBalanceLoadingIfOwned();
         return Promise.resolve();
       }
     }
@@ -5373,12 +5387,9 @@ class MainController {
       console.warn(
         '[updateBalancesFromCurrentAccount] Active account not found'
       );
-      store.dispatch(setIsLoadingBalances(false));
+      clearBalanceLoadingIfOwned();
       return Promise.resolve();
     }
-
-    // Capture isPolling for use in the inner async function
-    const isPollingUpdate = isPolling;
 
     // No need to create a new provider - let the BalancesManager use its own provider
     // The BalancesManager already handles EVM vs UTXO networks correctly
@@ -5406,6 +5417,7 @@ class MainController {
               console.log(
                 '[MainController] Skipping stale balance update after network change'
               );
+              clearBalanceLoadingIfOwned();
               resolve();
               return;
             }
@@ -5462,9 +5474,7 @@ class MainController {
             }
 
             // Clear loading state on success only if we set it
-            if (!isPollingUpdate) {
-              store.dispatch(setIsLoadingBalances(false));
-            }
+            clearBalanceLoadingIfOwned();
             resolve();
           } catch (error) {
             // Mark network quality as slow/poor on error
@@ -5481,9 +5491,7 @@ class MainController {
             // it survives a rejected request, the app-wide loading overlay can
             // intercept every click indefinitely. Network health is tracked by
             // networkStatus/networkQuality instead.
-            if (!isPollingUpdate) {
-              store.dispatch(setIsLoadingBalances(false));
-            }
+            clearBalanceLoadingIfOwned();
             reject(error);
           }
         }

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -193,6 +193,7 @@ class MainController {
   private transactionsManager: ITransactionsManager;
   private balancesManager: IBalancesManager;
   private balanceLoadingRequestId = 0;
+  private isNetworkSwitchMainStateDirty = false;
   private smartAccount: SmartAccountController;
   private cancellablePromises: CancellablePromises;
   private currentPromise: {
@@ -289,9 +290,7 @@ class MainController {
     if (this.cancellablePromises.assetsPromise) {
       this.cancellablePromises.assetsPromise.cancel();
     }
-    if (this.cancellablePromises.balancePromise) {
-      this.cancellablePromises.balancePromise.cancel();
-    }
+    this.cancelActiveBalanceUpdate();
     if (this.cancellablePromises.nftsPromise) {
       this.cancellablePromises.nftsPromise.cancel();
     }
@@ -308,6 +307,7 @@ class MainController {
     this.isStartingUp = false;
     this.isAccountSwitching = false;
     this.isNetworkSwitching = false;
+    this.isNetworkSwitchMainStateDirty = false;
 
     // Clear vault cache
     vaultCache.clearCache();
@@ -3024,9 +3024,7 @@ class MainController {
         if (this.cancellablePromises.assetsPromise) {
           this.cancellablePromises.assetsPromise.cancel();
         }
-        if (this.cancellablePromises.balancePromise) {
-          this.cancellablePromises.balancePromise.cancel();
-        }
+        this.cancelActiveBalanceUpdate();
         if (this.cancellablePromises.nftsPromise) {
           this.cancellablePromises.nftsPromise.cancel();
         }
@@ -3251,9 +3249,7 @@ class MainController {
     if (this.cancellablePromises.assetsPromise) {
       this.cancellablePromises.assetsPromise.cancel();
     }
-    if (this.cancellablePromises.balancePromise) {
-      this.cancellablePromises.balancePromise.cancel();
-    }
+    this.cancelActiveBalanceUpdate();
     if (this.cancellablePromises.nftsPromise) {
       this.cancellablePromises.nftsPromise.cancel();
     }
@@ -5527,6 +5523,19 @@ class MainController {
     return balancePromise;
   }
 
+  private cancelActiveBalanceUpdate(): void {
+    // Cancellation only rejects the wrapper; the underlying RPC can still
+    // settle later. Advance ownership first so that stale executor can no
+    // longer clear a newer request's loading state.
+    this.balanceLoadingRequestId += 1;
+    this.cancellablePromises.balancePromise?.cancel();
+    this.cancellablePromises.balancePromise = null;
+
+    if (store.getState().vaultGlobal.loadingStates.isLoadingBalances) {
+      store.dispatch(setIsLoadingBalances(false));
+    }
+  }
+
   public async refreshActiveAccountBalances({
     includeAssets = false,
     isPolling = false,
@@ -6404,16 +6413,19 @@ class MainController {
         clearTimeout(this.saveTimeout);
         this.saveTimeout = null;
       }
+      this.isNetworkSwitchMainStateDirty =
+        this.isNetworkSwitchMainStateDirty ||
+        previousSlip44 !== activeSlip44 ||
+        dappStateChanged ||
+        hadPendingWalletSave;
       try {
-        await persistCommittedWalletState(
-          previousSlip44 !== activeSlip44 ||
-            dappStateChanged ||
-            hadPendingWalletSave
-        );
+        await persistCommittedWalletState(this.isNetworkSwitchMainStateDirty);
+        this.isNetworkSwitchMainStateDirty = false;
       } catch (error) {
-        // The approval will reject, but keep a background retry so a transient
-        // storage failure does not also discard the already-committed state.
-        this.saveWalletState('network-switch-persistence-retry');
+        // Keep the main state dirty across retries. This is necessary when an
+        // earlier attempt removed incompatible dapps in memory but failed to
+        // persist them; a later retry must still include the main state.
+        this.isNetworkSwitchMainStateDirty = true;
         throw error;
       }
     }

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -6399,9 +6399,23 @@ class MainController {
     // wallet save. Commit the active vault and only include global state when
     // activeSlip44 or dapp connections changed, using one storage operation.
     if (!syncUpdates) {
-      await persistCommittedWalletState(
-        previousSlip44 !== activeSlip44 || dappStateChanged
-      );
+      const hadPendingWalletSave = Boolean(this.saveTimeout);
+      if (this.saveTimeout) {
+        clearTimeout(this.saveTimeout);
+        this.saveTimeout = null;
+      }
+      try {
+        await persistCommittedWalletState(
+          previousSlip44 !== activeSlip44 ||
+            dappStateChanged ||
+            hadPendingWalletSave
+        );
+      } catch (error) {
+        // The approval will reject, but keep a background retry so a transient
+        // storage failure does not also discard the already-committed state.
+        this.saveWalletState('network-switch-persistence-retry');
+        throw error;
+      }
     }
 
     // Notify about network change (notification manager handles validation)

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -32,7 +32,11 @@ import PaliLogo from 'assets/all_assets/favicon-32.png';
 import { ASSET_PRICE_API } from 'constants/index';
 import { setPrices } from 'state/price';
 import store from 'state/store';
-import { loadAndActivateSlip44Vault, saveMainState } from 'state/store';
+import {
+  loadAndActivateSlip44Vault,
+  persistCommittedWalletState,
+  saveMainState,
+} from 'state/store';
 import {
   createAccount,
   initializeCleanVaultForSlip44,
@@ -3160,7 +3164,9 @@ class MainController {
     return null;
   }
 
-  private async ensureActiveAccountCompatibleWithNetwork(network: INetwork) {
+  private async ensureActiveAccountCompatibleWithNetwork(
+    network: INetwork
+  ): Promise<boolean> {
     const { accounts, activeAccount } = store.getState().vault;
     const currentAccount = accounts[activeAccount.type]?.[activeAccount.id];
     let fallbackAccount = this.isAccountCompatibleWithNetwork(
@@ -3199,6 +3205,7 @@ class MainController {
 
     const { dapps } = store.getState().dapp;
     const controller = getController();
+    const incompatibleHosts: string[] = [];
     for (const [host, dapp] of Object.entries(dapps)) {
       const dappAccount = accounts[dapp.accountType]?.[dapp.accountId];
       if (
@@ -3211,14 +3218,23 @@ class MainController {
         continue;
       }
 
-      await controller.dapp.disconnect(host);
+      incompatibleHosts.push(host);
     }
+
+    // Remove all incompatible sessions in memory first. The caller includes
+    // the resulting dapp state in the same durable network-switch commit,
+    // avoiding one full main-state write per disconnected site.
+    await Promise.all(
+      incompatibleHosts.map((host) => controller.dapp.disconnect(host, false))
+    );
+    return incompatibleHosts.length > 0;
   }
 
   public async setActiveNetwork(
     network: INetwork,
     syncUpdates = false
   ): Promise<{ chainId: string; networkVersion: number }> {
+    const previousSlip44 = store.getState().vaultGlobal.activeSlip44;
     // Cancel the current promise if it exists
     if (this.currentPromise) {
       this.currentPromise.cancel();
@@ -3263,7 +3279,11 @@ class MainController {
     // Return the promise chain with error handling attached
     return promiseWrapper.promise
       .then(async () => {
-        await this.handleNetworkChangeSuccess(completeNetwork, syncUpdates);
+        await this.handleNetworkChangeSuccess(
+          completeNetwork,
+          syncUpdates,
+          previousSlip44
+        );
 
         // Return the success result
         const isBitcoinBased = completeNetwork.kind === INetworkType.Syscoin;
@@ -6337,7 +6357,8 @@ class MainController {
   };
   private async handleNetworkChangeSuccess(
     network: INetwork,
-    syncUpdates = false
+    syncUpdates = false,
+    previousSlip44: number | null = null
   ) {
     const isBitcoinBased = network.kind === INetworkType.Syscoin;
 
@@ -6361,15 +6382,28 @@ class MainController {
     // - all accounts
     // - network configuration
     // - isBitcoinBased (derived from activeChain)
-    store.dispatch(setNetworkChange({ activeNetwork: network }));
+    if (store.getState().vault.activeNetwork !== network) {
+      store.dispatch(setNetworkChange({ activeNetwork: network }));
+    }
 
     // Invalidate network-dependent provider responses before reconciliation or
     // notifications can trigger dapp reads against the newly active network.
     clearProviderCache();
-    await this.ensureActiveAccountCompatibleWithNetwork(network);
+    const dappStateChanged =
+      await this.ensureActiveAccountCompatibleWithNetwork(network);
 
     // Dispatch success immediately to prevent getting stuck in "switching" state
     store.dispatch(switchNetworkSuccess());
+
+    // External approvals need a persistence barrier, but not a full sequential
+    // wallet save. Commit the active vault and only include global state when
+    // activeSlip44 or dapp connections changed, using one storage operation.
+    if (!syncUpdates) {
+      await persistCommittedWalletState(
+        previousSlip44 !== activeSlip44 || dappStateChanged
+      );
+    }
+
     // Notify about network change (notification manager handles validation)
     notificationManager.notifyNetworkChange(network);
 

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -1794,23 +1794,17 @@ class MainController {
     slip44: number;
     vaultState: any;
   }) {
-    // Use setTimeout to defer the save, but handle async errors properly
-    setTimeout(async () => {
-      try {
-        await vaultCache.setSlip44Vault(
-          deferredSaveData.slip44,
-          deferredSaveData.vaultState
-        );
-      } catch (error) {
+    // Enqueue immediately so a later switch back to this slip44 cannot commit
+    // first and then be overwritten by this older snapshot. The promise remains
+    // non-blocking, while VaultCache serializes the actual storage operation.
+    void vaultCache
+      .setSlip44Vault(deferredSaveData.slip44, deferredSaveData.vaultState)
+      .catch((error) => {
         console.error(
           `[MainController] Deferred save failed for slip44 ${deferredSaveData.slip44}:`,
           error
         );
-        // Since we're in an async context, we can't re-throw to the caller
-        // Instead, we should handle the error appropriately here
-        // For now, logging is sufficient as this is a background save
-      }
-    }, 10);
+      });
   }
 
   // Internal method to perform the actual save

--- a/source/state/paliStorage.ts
+++ b/source/state/paliStorage.ts
@@ -20,6 +20,22 @@ export const saveSlip44State = async (slip44: number, vaultState: any) => {
   }
 };
 
+export const saveCommittedWalletState = async (
+  slip44: number,
+  vaultState: any,
+  mainState?: any
+) => {
+  const items: Record<string, any> = {
+    [`state-vault-${slip44}`]: vaultState,
+  };
+
+  if (mainState) {
+    items.state = mainState;
+  }
+
+  await chromeStorage.setItems(items);
+};
+
 export const savePasskeyCredentialProfileState = async (
   slip44: number,
   passkeyCredentialProfile: any

--- a/source/state/store.ts
+++ b/source/state/store.ts
@@ -10,6 +10,7 @@ import { thunk, ThunkMiddleware } from 'redux-thunk';
 
 import { INetwork } from 'types/network';
 import { ISpamFilterState } from 'types/security';
+import { walletPersistenceMutex } from 'utils/asyncMutex';
 
 import dapp from './dapp';
 import { IDAppState } from './dapp/types';
@@ -86,6 +87,14 @@ const getMainStateForStorage = (state: ReturnType<typeof store.getState>) => ({
   vaultGlobal: state.vaultGlobal,
 });
 
+const isMainStateUnchanged = (state: ReturnType<typeof store.getState>) =>
+  Boolean(
+    lastPersistedState &&
+      isEqual(lastPersistedState.dapp, state.dapp) &&
+      isEqual(lastPersistedState.price, state.price) &&
+      isEqual(lastPersistedState.vaultGlobal, state.vaultGlobal)
+  );
+
 // Initialize cache once on startup.
 (async () => {
   try {
@@ -96,19 +105,14 @@ const getMainStateForStorage = (state: ReturnType<typeof store.getState>) => ({
   }
 })();
 
-// Manual state persistence for important operations
-export async function saveMainState() {
+// Internal variant for callers that already hold walletPersistenceMutex.
+export async function saveMainStateWithinPersistenceLock() {
   try {
     const state = store.getState();
 
     // Fast in-memory comparison first. This avoids hitting chrome.storage
     // for the common case where nothing relevant has changed.
-    if (
-      lastPersistedState &&
-      isEqual(lastPersistedState.dapp, state.dapp) &&
-      isEqual(lastPersistedState.price, state.price) &&
-      isEqual(lastPersistedState.vaultGlobal, state.vaultGlobal)
-    ) {
+    if (isMainStateUnchanged(state)) {
       return false;
     }
     // Create main state with only global data (dapp, price, vaultGlobal)
@@ -123,31 +127,44 @@ export async function saveMainState() {
   }
 }
 
+// Manual state persistence for important operations
+export async function saveMainState() {
+  return walletPersistenceMutex.runExclusive(() =>
+    saveMainStateWithinPersistenceLock()
+  );
+}
+
 /**
  * Durably commit the active vault and, when necessary, the global state in one
  * Chrome storage call. This is the minimal persistence barrier needed before
  * an externally approved network switch reports success.
  */
 export async function persistCommittedWalletState(
-  includeMainState: boolean
+  includeMainState: boolean,
+  skipUnchangedMainState = false
 ): Promise<void> {
-  const state = store.getState();
-  const activeSlip44 = state.vaultGlobal.activeSlip44;
+  return walletPersistenceMutex.runExclusive(async () => {
+    const state = store.getState();
+    const activeSlip44 = state.vaultGlobal.activeSlip44;
 
-  if (activeSlip44 === null) {
-    throw new Error('Cannot persist network switch without an active slip44');
-  }
+    if (activeSlip44 === null) {
+      throw new Error('Cannot persist wallet state without an active slip44');
+    }
 
-  const vaultState = vaultCache.prepareSlip44Vault(activeSlip44, state.vault);
-  const mainState = includeMainState
-    ? getMainStateForStorage(state)
-    : undefined;
+    const vaultState = vaultCache.prepareSlip44Vault(activeSlip44, state.vault);
+    const shouldIncludeMainState =
+      includeMainState &&
+      (!skipUnchangedMainState || !isMainStateUnchanged(state));
+    const mainState = shouldIncludeMainState
+      ? getMainStateForStorage(state)
+      : undefined;
 
-  await saveCommittedWalletState(activeSlip44, vaultState, mainState);
+    await saveCommittedWalletState(activeSlip44, vaultState, mainState);
 
-  if (mainState) {
-    lastPersistedState = mainState;
-  }
+    if (mainState) {
+      lastPersistedState = mainState;
+    }
+  });
 }
 
 // New centralized function to load and activate a slip44 vault

--- a/source/state/store.ts
+++ b/source/state/store.ts
@@ -16,6 +16,7 @@ import { IDAppState } from './dapp/types';
 import {
   loadPasskeyCredentialProfileState,
   loadState,
+  saveCommittedWalletState,
   saveState,
   savePasskeyCredentialProfileState,
 } from './paliStorage';
@@ -79,6 +80,12 @@ const store: Store<{
 
 let lastPersistedState: any | null = null;
 
+const getMainStateForStorage = (state: ReturnType<typeof store.getState>) => ({
+  dapp: state.dapp,
+  price: state.price,
+  vaultGlobal: state.vaultGlobal,
+});
+
 // Initialize cache once on startup.
 (async () => {
   try {
@@ -105,11 +112,7 @@ export async function saveMainState() {
       return false;
     }
     // Create main state with only global data (dapp, price, vaultGlobal)
-    const mainState = {
-      dapp: state.dapp,
-      price: state.price,
-      vaultGlobal: state.vaultGlobal,
-    };
+    const mainState = getMainStateForStorage(state);
 
     await saveState(mainState);
     lastPersistedState = state;
@@ -117,6 +120,33 @@ export async function saveMainState() {
   } catch (error) {
     console.error('saveMainState() failed', error);
     return false;
+  }
+}
+
+/**
+ * Durably commit the active vault and, when necessary, the global state in one
+ * Chrome storage call. This is the minimal persistence barrier needed before
+ * an externally approved network switch reports success.
+ */
+export async function persistCommittedWalletState(
+  includeMainState: boolean
+): Promise<void> {
+  const state = store.getState();
+  const activeSlip44 = state.vaultGlobal.activeSlip44;
+
+  if (activeSlip44 === null) {
+    throw new Error('Cannot persist network switch without an active slip44');
+  }
+
+  const vaultState = vaultCache.prepareSlip44Vault(activeSlip44, state.vault);
+  const mainState = includeMainState
+    ? getMainStateForStorage(state)
+    : undefined;
+
+  await saveCommittedWalletState(activeSlip44, vaultState, mainState);
+
+  if (mainState) {
+    lastPersistedState = mainState;
   }
 }
 

--- a/source/state/vaultCache.spec.ts
+++ b/source/state/vaultCache.spec.ts
@@ -1,0 +1,36 @@
+import { INetworkType } from 'types/network';
+
+import { loadSlip44State, saveSlip44State } from './paliStorage';
+import type { ISlip44State } from './vault/types';
+import vaultCache from './vaultCache';
+
+jest.mock('./paliStorage', () => ({
+  ...jest.requireActual('./paliStorage'),
+  loadSlip44State: jest.fn(),
+  saveSlip44State: jest.fn(),
+}));
+
+describe('VaultCache', () => {
+  beforeEach(() => {
+    vaultCache.clearCache();
+    jest.mocked(loadSlip44State).mockReset().mockResolvedValue(null);
+    jest.mocked(saveSlip44State).mockReset().mockResolvedValue(undefined);
+  });
+
+  it('publishes a queued vault snapshot to the cache synchronously', async () => {
+    const vaultState = {
+      activeNetwork: {
+        kind: INetworkType.Ethereum,
+        slip44: 60,
+      },
+    } as ISlip44State;
+
+    const savePromise = vaultCache.setSlip44Vault(60, vaultState);
+
+    await expect(vaultCache.getSlip44Vault(60)).resolves.toEqual(vaultState);
+    expect(loadSlip44State).not.toHaveBeenCalled();
+
+    await savePromise;
+    expect(saveSlip44State).toHaveBeenCalledWith(60, vaultState);
+  });
+});

--- a/source/state/vaultCache.ts
+++ b/source/state/vaultCache.ts
@@ -1,8 +1,8 @@
 import { INetwork, INetworkType } from 'types/network';
-import { emergencySaveMutex } from 'utils/asyncMutex';
+import { walletPersistenceMutex } from 'utils/asyncMutex';
 
 import { loadSlip44State, saveSlip44State } from './paliStorage';
-import store, { saveMainState } from './store';
+import store, { saveMainStateWithinPersistenceLock } from './store';
 import { ISlip44State } from './vault/types';
 
 // Slip44 constants
@@ -157,14 +157,14 @@ class VaultCache {
     console.log('[VaultCache] 🚨 Emergency save triggered');
 
     // Use mutex to ensure only one emergency save runs at a time
-    return emergencySaveMutex.runExclusive(async () => {
+    return walletPersistenceMutex.runExclusive(async () => {
       const globalState = store.getState().vaultGlobal;
       const activeSlip44 = globalState.activeSlip44;
       const liveVaultState = store.getState().vault;
 
       try {
         // Always save main state (vaultGlobal, dapp, price) - settings could have changed
-        await saveMainState();
+        await saveMainStateWithinPersistenceLock();
 
         if (activeSlip44 !== null && liveVaultState) {
           // During emergency save, we need to handle potential slip44 mismatches carefully

--- a/source/state/vaultCache.ts
+++ b/source/state/vaultCache.ts
@@ -93,10 +93,12 @@ class VaultCache {
     slip44: number,
     slip44State: ISlip44State
   ): Promise<void> {
-    const vaultState = this.prepareSlip44Vault(slip44, slip44State);
+    return walletPersistenceMutex.runExclusive(async () => {
+      const vaultState = this.prepareSlip44Vault(slip44, slip44State);
 
-    // Save to storage immediately
-    await saveSlip44State(slip44, vaultState);
+      // Save to storage immediately
+      await saveSlip44State(slip44, vaultState);
+    });
   }
 
   /**

--- a/source/state/vaultCache.ts
+++ b/source/state/vaultCache.ts
@@ -93,9 +93,12 @@ class VaultCache {
     slip44: number,
     slip44State: ISlip44State
   ): Promise<void> {
-    return walletPersistenceMutex.runExclusive(async () => {
-      const vaultState = this.prepareSlip44Vault(slip44, slip44State);
+    // Refresh the cache synchronously when the write is enqueued. A switch back
+    // to this slip44 may read the cache while an older persistence operation is
+    // still holding the mutex, and must observe this newest snapshot.
+    const vaultState = this.prepareSlip44Vault(slip44, slip44State);
 
+    return walletPersistenceMutex.runExclusive(async () => {
       // Save to storage immediately
       await saveSlip44State(slip44, vaultState);
     });

--- a/source/state/vaultCache.ts
+++ b/source/state/vaultCache.ts
@@ -93,6 +93,17 @@ class VaultCache {
     slip44: number,
     slip44State: ISlip44State
   ): Promise<void> {
+    const vaultState = this.prepareSlip44Vault(slip44, slip44State);
+
+    // Save to storage immediately
+    await saveSlip44State(slip44, vaultState);
+  }
+
+  /**
+   * Validate and cache a vault snapshot for a caller that persists multiple
+   * storage keys in one Chrome storage operation.
+   */
+  prepareSlip44Vault(slip44: number, slip44State: ISlip44State): ISlip44State {
     // 🛡️ SAFEGUARD: Validate slip44 matches before saving
     if (!validateVaultSlip44(slip44State, slip44)) {
       throw new Error(
@@ -103,9 +114,7 @@ class VaultCache {
 
     // Update cache
     this.slip44Cache.set(slip44, vaultState);
-
-    // Save to storage immediately
-    await saveSlip44State(slip44, vaultState);
+    return vaultState;
   }
 
   // activeSlip44 tracking removed - now handled by Redux global state

--- a/source/types/controllers.ts
+++ b/source/types/controllers.ts
@@ -25,7 +25,7 @@ export interface IDAppController {
    * Removes a connection with a DApp
    * @emits disconnect
    */
-  disconnect: (host: string) => Promise<void>;
+  disconnect: (host: string, persist?: boolean) => Promise<void>;
   /**
    * Retrieves a DApp
    */

--- a/source/utils/asyncMutex.ts
+++ b/source/utils/asyncMutex.ts
@@ -49,5 +49,5 @@ export const fiatPriceMutex = new AsyncMutex();
 export const networkSwitchMutex = new AsyncMutex();
 export const fiatAlarmMutex = new AsyncMutex();
 export const pollingMutex = new AsyncMutex();
-export const emergencySaveMutex = new AsyncMutex();
+export const walletPersistenceMutex = new AsyncMutex();
 export const accountSwitchMutex = new AsyncMutex();

--- a/source/utils/storageAPI.ts
+++ b/source/utils/storageAPI.ts
@@ -21,6 +21,16 @@ export const chromeStorage = {
         }
       });
     }),
+  setItems: (items: Record<string, any>): Promise<void> =>
+    new Promise((resolve, reject) => {
+      chrome.storage.local.set(items, function () {
+        if (chrome.runtime.lastError) {
+          reject(chrome.runtime.lastError);
+        } else {
+          resolve();
+        }
+      });
+    }),
   removeItem: (key: string): Promise<void> =>
     new Promise((resolve, reject) => {
       // Use Chrome Storage API


### PR DESCRIPTION
## Summary

- stop dapp network approvals from waiting on post-switch balance refreshes
- keep the app-wide loading overlay off external approval pages that manage their own pending state
- clear the transient balance-loading flag when a non-polling balance request fails

## Root cause

External chain-switch pages called `setActiveNetwork` with synchronous updates enabled. That kept the approval open while Pali refreshed fiat and native balances. A rejected balance request intentionally left `isLoadingBalances` set, and the global loading overlay then intercepted the entire popup indefinitely.

The network switch itself already commits the keyring/network state, reconciles connected accounts, invalidates provider caches, and emits network/account notifications before resolving. Balance and price refreshes do not need to be in the approval's critical path.

## User impact

Dapp-requested EVM, UTXO, family, and add-chain approvals close once the network switch is committed. Slow or failed balance refreshes continue independently and can no longer leave the approval popup permanently blurred and unclickable.

## Validation

- 52 Jest suites / 490 tests passed
- TypeScript passed
- ESLint passed with one unrelated pre-existing naming warning
- i18n consistency passed
- Prettier and `git diff --check` passed
- Syscoin Testnet Blockbook endpoint verified healthy during diagnosis
