### PR TITLE
Restore lazy connection balances with per-network caching

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Pali Wallet",
-  "version": "4.0.51",
+  "version": "4.0.52",
   "icons": {
     "16": "assets/all_assets/favicon-16.png",
     "32": "assets/all_assets/favicon-32.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paliwallet",
-  "version": "4.0.51",
+  "version": "4.0.52",
   "description": "A Non-Custodial Crypto Wallet",
   "private": true,
   "repository": {

--- a/source/components/AccountBalance/LazyAccountBalance.tsx
+++ b/source/components/AccountBalance/LazyAccountBalance.tsx
@@ -49,13 +49,20 @@ export const LazyAccountBalance: React.FC<ILazyAccountBalanceProps> = ({
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const mountedRef = useRef(true);
+  const loadRequestIdRef = useRef(0);
   const fetchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   // Generate unique key for request deduplication
   const getCacheKey = useCallback(() => {
-    const networkKey = isBitcoinBased ? 'sys' : `evm-${activeNetwork.chainId}`;
-    return `${accountType}-${account.id}-${networkKey}`;
-  }, [account.id, accountType, isBitcoinBased, activeNetwork.chainId]);
+    const networkKey = `${activeNetwork.kind}-${activeNetwork.chainId}`;
+    return `${accountType}-${account.id}-${account.address}-${networkKey}`;
+  }, [
+    account.address,
+    account.id,
+    accountType,
+    activeNetwork.chainId,
+    activeNetwork.kind,
+  ]);
 
   // Check if we can make a request based on rate limiting
   const canMakeRequest = useCallback(() => {
@@ -70,9 +77,6 @@ export const LazyAccountBalance: React.FC<ILazyAccountBalanceProps> = ({
     return validTimestamps.length < MAX_REQUESTS_PER_WINDOW;
   }, []);
 
-  // Abort controller for cancelling requests
-  const abortControllerRef = useRef<AbortController | null>(null);
-
   // Fetch balance from backend
   const fetchBalance = useCallback(async (): Promise<string> => {
     const cacheKey = getCacheKey();
@@ -84,47 +88,38 @@ export const LazyAccountBalance: React.FC<ILazyAccountBalanceProps> = ({
 
     // Create the fetch promise
     const fetchPromise = (async () => {
-      try {
-        // Add timestamp for rate limiting
-        requestTimestamps.push(Date.now());
+      // Add timestamp for rate limiting
+      requestTimestamps.push(Date.now());
 
-        // Add randomized delay to prevent thundering herd when multiple accounts fetch simultaneously
-        const randomDelay =
-          Math.floor(Math.random() * (MAX_BATCH_DELAY - MIN_BATCH_DELAY)) +
-          MIN_BATCH_DELAY;
-        await new Promise((resolve) => setTimeout(resolve, randomDelay));
+      // Add randomized delay to prevent thundering herd when multiple accounts fetch simultaneously
+      const randomDelay =
+        Math.floor(Math.random() * (MAX_BATCH_DELAY - MIN_BATCH_DELAY)) +
+        MIN_BATCH_DELAY;
+      await new Promise((resolve) => setTimeout(resolve, randomDelay));
 
-        // Call the background controller to fetch balance
-        try {
-          const result = await controllerEmitter(
-            ['wallet', 'getBalanceForAccount'],
-            [account, isBitcoinBased, activeNetwork.url]
-          );
-          const balanceValue = result as string;
-
-          // Clear pending request
-          pendingRequests.delete(cacheKey);
-
-          return balanceValue;
-        } catch (fetchError) {
-          throw fetchError;
-        }
-      } catch (err) {
-        // Clear pending request on error
+      // Call the background controller to fetch balance
+      return (await controllerEmitter(
+        ['wallet', 'getBalanceForAccount'],
+        [account, accountType, activeNetwork]
+      )) as string;
+    })().finally(() => {
+      // Keep the request shared across fast popup remounts until it settles.
+      // The promise owns its registry entry, not any individual component.
+      if (pendingRequests.get(cacheKey) === fetchPromise) {
         pendingRequests.delete(cacheKey);
-        throw err;
       }
-    })();
+    });
 
     // Store the pending request
     pendingRequests.set(cacheKey, fetchPromise);
 
     return fetchPromise;
-  }, [account, isBitcoinBased, activeNetwork, getCacheKey]);
+  }, [account, accountType, activeNetwork, getCacheKey]);
 
   // Load balance with rate limiting
   const loadBalance = useCallback(async () => {
     if (!mountedRef.current) return;
+    const requestId = ++loadRequestIdRef.current;
 
     // Check if balance is already available in the account object
     const existingBalance = isBitcoinBased
@@ -172,7 +167,8 @@ export const LazyAccountBalance: React.FC<ILazyAccountBalanceProps> = ({
     try {
       const balanceValue = await fetchBalance();
 
-      // Always update state since components remount quickly on external screens
+      if (!mountedRef.current || requestId !== loadRequestIdRef.current) return;
+
       setBalance(balanceValue);
       setIsLoading(false);
 
@@ -180,6 +176,8 @@ export const LazyAccountBalance: React.FC<ILazyAccountBalanceProps> = ({
         onBalanceLoad(balanceValue);
       }
     } catch (err) {
+      if (!mountedRef.current || requestId !== loadRequestIdRef.current) return;
+
       setError('Failed to load balance');
       setIsLoading(false);
       setBalance('0'); // Default to 0 on error
@@ -194,15 +192,22 @@ export const LazyAccountBalance: React.FC<ILazyAccountBalanceProps> = ({
     onBalanceLoad,
   ]);
 
-  // Load balance on mount or when dependencies change
+  // Track the actual component lifetime separately from balance refreshes.
   useEffect(() => {
-    loadBalance();
+    mountedRef.current = true;
+
     return () => {
       mountedRef.current = false;
+      loadRequestIdRef.current += 1;
       if (fetchTimeoutRef.current) {
         clearTimeout(fetchTimeoutRef.current);
       }
     };
+  }, []);
+
+  // Load on mount and re-read live Redux balances when account data changes.
+  useEffect(() => {
+    void loadBalance();
   }, [loadBalance]);
 
   // Format balance for display
@@ -216,24 +221,6 @@ export const LazyAccountBalance: React.FC<ILazyAccountBalanceProps> = ({
   // Calculate fiat value
   const fiatValue =
     showFiat && nativeBalance > 0 ? getFiatAmount(nativeBalance, 4) : '$0.00';
-
-  // Cleanup effect - cancel any pending requests on unmount
-  useEffect(
-    () => () => {
-      // Cancel any pending request
-      if (abortControllerRef.current) {
-        abortControllerRef.current.abort();
-        abortControllerRef.current = null;
-      }
-
-      // Clear from pending requests map
-      const cacheKey = getCacheKey();
-      if (pendingRequests.has(cacheKey)) {
-        pendingRequests.delete(cacheKey);
-      }
-    },
-    [getCacheKey]
-  );
 
   // Show skeleton if loading OR if we don't have a balance yet (and existing balance is -1)
   const shouldShowSkeleton =

--- a/source/components/AccountBalance/LazyAccountBalance.tsx
+++ b/source/components/AccountBalance/LazyAccountBalance.tsx
@@ -7,6 +7,7 @@ import { usePrice } from 'hooks/usePrice';
 import { RootState } from 'state/store';
 import { IKeyringAccountState } from 'types/network';
 import { formatNumber } from 'utils/index';
+import { getFreshNativeBalance } from 'utils/nativeBalanceCache';
 
 // Rate limiting configuration
 const RATE_LIMIT_WINDOW = 1000; // 1 second window
@@ -40,9 +41,7 @@ export const LazyAccountBalance: React.FC<ILazyAccountBalanceProps> = ({
   onBalanceLoad,
 }) => {
   const { controllerEmitter } = useController();
-  const { isBitcoinBased, activeNetwork } = useSelector(
-    (state: RootState) => state.vault
-  );
+  const { activeNetwork } = useSelector((state: RootState) => state.vault);
   const { getFiatAmount } = usePrice();
 
   const [balance, setBalance] = useState<string | null>(null);
@@ -121,10 +120,12 @@ export const LazyAccountBalance: React.FC<ILazyAccountBalanceProps> = ({
     if (!mountedRef.current) return;
     const requestId = ++loadRequestIdRef.current;
 
-    // Check if balance is already available in the account object
-    const existingBalance = isBitcoinBased
-      ? account.balances?.syscoin
-      : account.balances?.ethereum;
+    // The legacy balances field has no timestamp, so only short-circuit with
+    // the matching network cache entry while it is still fresh.
+    const existingBalance = getFreshNativeBalance(
+      account,
+      activeNetwork
+    )?.balance;
 
     // If balance exists and is not -1 (which means "no data"), use it directly
     if (
@@ -152,6 +153,12 @@ export const LazyAccountBalance: React.FC<ILazyAccountBalanceProps> = ({
       return;
     }
 
+    // Do not keep rendering a stale value while this request is rate-limited
+    // or in flight.
+    setBalance(null);
+    setIsLoading(true);
+    setError(null);
+
     // Check rate limiting
     if (!canMakeRequest()) {
       // Schedule a retry after the rate limit window
@@ -165,9 +172,6 @@ export const LazyAccountBalance: React.FC<ILazyAccountBalanceProps> = ({
 
       return;
     }
-
-    setIsLoading(true);
-    setError(null);
 
     try {
       const balanceValue = await fetchBalance();
@@ -188,8 +192,8 @@ export const LazyAccountBalance: React.FC<ILazyAccountBalanceProps> = ({
       setBalance('0'); // Default to 0 on error
     }
   }, [
-    account.balances,
-    isBitcoinBased,
+    account,
+    activeNetwork,
     fetchOnMissingBalance,
     getCacheKey,
     canMakeRequest,
@@ -227,18 +231,15 @@ export const LazyAccountBalance: React.FC<ILazyAccountBalanceProps> = ({
   const fiatValue =
     showFiat && nativeBalance > 0 ? getFiatAmount(nativeBalance, 4) : '$0.00';
 
-  // Show skeleton if loading OR if we don't have a balance yet (and existing balance is -1)
-  const shouldShowSkeleton =
-    fetchOnMissingBalance &&
-    showSkeleton &&
-    (isLoading ||
-      (balance === null &&
-        (account.balances?.ethereum === -1 ||
-          account.balances?.syscoin === -1)));
+  const hasFreshBalance = Boolean(
+    getFreshNativeBalance(account, activeNetwork)
+  );
 
-  const hasMissingBalance =
-    balance === null &&
-    (account.balances?.ethereum === -1 || account.balances?.syscoin === -1);
+  const hasMissingBalance = balance === null && !hasFreshBalance;
+
+  // Show a skeleton while a missing or expired value is being fetched.
+  const shouldShowSkeleton =
+    fetchOnMissingBalance && showSkeleton && (isLoading || hasMissingBalance);
 
   if (shouldShowSkeleton) {
     return (

--- a/source/components/AccountBalance/LazyAccountBalance.tsx
+++ b/source/components/AccountBalance/LazyAccountBalance.tsx
@@ -7,7 +7,10 @@ import { usePrice } from 'hooks/usePrice';
 import { RootState } from 'state/store';
 import { IKeyringAccountState } from 'types/network';
 import { formatNumber } from 'utils/index';
-import { getFreshNativeBalance } from 'utils/nativeBalanceCache';
+import {
+  getFreshNativeBalance,
+  NATIVE_BALANCE_CACHE_TTL_MS,
+} from 'utils/nativeBalanceCache';
 
 // Rate limiting configuration
 const RATE_LIMIT_WINDOW = 1000; // 1 second window
@@ -50,6 +53,8 @@ export const LazyAccountBalance: React.FC<ILazyAccountBalanceProps> = ({
   const mountedRef = useRef(true);
   const loadRequestIdRef = useRef(0);
   const fetchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const freshBalanceEntry = getFreshNativeBalance(account, activeNetwork);
+  const freshBalanceUpdatedAt = freshBalanceEntry?.updatedAt;
 
   // Generate unique key for request deduplication
   const getCacheKey = useCallback(() => {
@@ -219,6 +224,30 @@ export const LazyAccountBalance: React.FC<ILazyAccountBalanceProps> = ({
     void loadBalance();
   }, [loadBalance]);
 
+  // Refresh a mounted card when its current cache entry reaches the TTL.
+  // This is a single sleeping timeout, not polling, and unmounting the card
+  // cancels it before any request can be made.
+  useEffect(() => {
+    if (freshBalanceUpdatedAt === undefined) return undefined;
+
+    const expiresAt = freshBalanceUpdatedAt + NATIVE_BALANCE_CACHE_TTL_MS;
+    let expiryTimeout: ReturnType<typeof setTimeout>;
+
+    const refreshWhenExpired = () => {
+      const remaining = expiresAt - Date.now();
+      if (remaining > 0) {
+        expiryTimeout = setTimeout(refreshWhenExpired, remaining + 1);
+        return;
+      }
+
+      void loadBalance();
+    };
+
+    refreshWhenExpired();
+
+    return () => clearTimeout(expiryTimeout);
+  }, [freshBalanceUpdatedAt, loadBalance]);
+
   // Format balance for display
   const formattedBalance = balance
     ? formatNumber(parseFloat(balance), precision)
@@ -231,9 +260,7 @@ export const LazyAccountBalance: React.FC<ILazyAccountBalanceProps> = ({
   const fiatValue =
     showFiat && nativeBalance > 0 ? getFiatAmount(nativeBalance, 4) : '$0.00';
 
-  const hasFreshBalance = Boolean(
-    getFreshNativeBalance(account, activeNetwork)
-  );
+  const hasFreshBalance = Boolean(freshBalanceEntry);
 
   const hasMissingBalance = balance === null && !hasFreshBalance;
 

--- a/source/components/AccountBalance/LazyAccountBalance.tsx
+++ b/source/components/AccountBalance/LazyAccountBalance.tsx
@@ -134,6 +134,11 @@ export const LazyAccountBalance: React.FC<ILazyAccountBalanceProps> = ({
     ) {
       const balanceStr = String(existingBalance);
       setBalance(balanceStr);
+      // A targeted Redux update may deliver this value before an in-flight
+      // controller request resolves. This branch owns the newest request id,
+      // so it must also finish the loading state for the superseded request.
+      setIsLoading(false);
+      setError(null);
       if (onBalanceLoad) {
         onBalanceLoad(balanceStr);
       }

--- a/source/config/consts.js
+++ b/source/config/consts.js
@@ -80,7 +80,7 @@ const CANARY_EXTENSION_KEY =
 const MV3_OPTIONS = {
   manifest_version: 3,
   name: 'Pali Wallet',
-  version: '4.0.51',
+  version: '4.0.52',
   icons: {
     16: 'assets/all_assets/favicon-16.png',
     32: 'assets/all_assets/favicon-32.png',

--- a/source/pages/Connections/ChangeAccount.tsx
+++ b/source/pages/Connections/ChangeAccount.tsx
@@ -499,7 +499,6 @@ export const ChangeAccount = () => {
                                   <LazyAccountBalance
                                     account={acc}
                                     accountType={keyringType}
-                                    fetchOnMissingBalance={false}
                                     showFiat={true}
                                     showSkeleton={true}
                                     precision={8}

--- a/source/pages/Connections/ChangeConnectedAccount.tsx
+++ b/source/pages/Connections/ChangeConnectedAccount.tsx
@@ -245,7 +245,6 @@ export const ChangeConnectedAccount = () => {
                     <LazyAccountBalance
                       account={connectedAccount}
                       accountType={accountType}
-                      fetchOnMissingBalance={false}
                       showFiat={true}
                       showSkeleton={true}
                       precision={8}
@@ -307,7 +306,6 @@ export const ChangeConnectedAccount = () => {
                     <LazyAccountBalance
                       account={activeAccount}
                       accountType={activeAccountRef.type}
-                      fetchOnMissingBalance={false}
                       showFiat={true}
                       showSkeleton={true}
                       precision={8}

--- a/source/pages/Connections/ConnectWallet.tsx
+++ b/source/pages/Connections/ConnectWallet.tsx
@@ -470,7 +470,6 @@ export const ConnectWallet = () => {
                                     <LazyAccountBalance
                                       account={acc}
                                       accountType={keyringType}
-                                      fetchOnMissingBalance={false}
                                       showFiat={true}
                                       showSkeleton={true}
                                       precision={8}

--- a/source/routers/useRouterLogic.ts
+++ b/source/routers/useRouterLogic.ts
@@ -11,7 +11,7 @@ import store, { RootState } from 'state/store';
 import {
   setAccounts,
   setActiveAccount,
-  setAccountPropertyByIdAndType,
+  setAccountBalanceSnapshot,
   setNetworkChange,
 } from 'state/vault';
 import { setNetworkRuntimeState, setNetworkStatus } from 'state/vaultGlobal';
@@ -202,11 +202,11 @@ export const useRouterLogic = () => {
         message.data
       ) {
         store.dispatch(
-          setAccountPropertyByIdAndType({
+          setAccountBalanceSnapshot({
+            balances: message.data.balances,
             id: message.data.id,
+            nativeBalanceCache: message.data.nativeBalanceCache,
             type: message.data.type,
-            property: 'balances',
-            value: message.data.balances,
           })
         );
         return true;

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -43,6 +43,7 @@ import {
   forgetWallet,
   removeAccount,
   setAccountLabel,
+  setAccountBalanceForNetwork,
   setAccountPropertyByIdAndType,
   setActiveAccount,
   setTransactionStatusToReplaced,
@@ -100,7 +101,6 @@ import {
   networkSwitchMutex,
   accountSwitchMutex,
 } from 'utils/asyncMutex';
-import { areBalancesDifferent } from 'utils/balance';
 import {
   SYSCOIN_UTXO_MAINNET_NETWORK,
   PALI_NETWORKS_STATE,
@@ -116,6 +116,10 @@ import {
   needsEoaNonceHistoryVerification,
 } from 'utils/evmNonce';
 import { logError } from 'utils/logger';
+import {
+  getFreshNativeBalance,
+  isSameBalanceNetwork,
+} from 'utils/nativeBalanceCache';
 import { getNetworkChain } from 'utils/network';
 import { blacklistService } from 'utils/security/blacklistService';
 import {
@@ -1830,7 +1834,8 @@ class MainController {
   private async saveWalletState(
     operation: string,
     isUserActivity = false,
-    sync = false
+    sync = false,
+    debounceMs = 100
   ): Promise<void> {
     try {
       // Only reset auto-lock timer for explicit user activities, not automatic saves
@@ -1863,7 +1868,8 @@ class MainController {
         clearTimeout(this.saveTimeout);
       }
 
-      // Debounce the actual save by 100ms to prevent rapid consecutive saves
+      // Debounce the actual save to prevent rapid consecutive storage writes.
+      // High-volume background caches can opt into a longer coalescing window.
       this.saveTimeout = setTimeout(async () => {
         try {
           await this.performSave(operation);
@@ -1876,7 +1882,7 @@ class MainController {
         } finally {
           this.saveTimeout = null;
         }
-      }, 100); // 100ms debounce delay
+      }, debounceMs);
     } catch (error) {
       console.error(
         `[MainController] Error in saveWalletState for operation ${operation}:`,
@@ -5455,29 +5461,16 @@ class MainController {
               );
             }
 
-            const actualUserBalance = isBitcoinBased
-              ? currentAccount.balances[INetworkType.Syscoin]
-              : currentAccount.balances[INetworkType.Ethereum];
-            const validateIfCanDispatch = areBalancesDifferent(
-              actualUserBalance,
-              updatedBalance
+            // Record successful reads even when the numeric value did not
+            // change, so the per-network cache freshness reflects this RPC.
+            store.dispatch(
+              setAccountBalanceForNetwork({
+                balance: updatedBalance,
+                id: activeAccount.id,
+                network: activeNetwork,
+                type: activeAccount.type,
+              })
             );
-
-            if (validateIfCanDispatch) {
-              store.dispatch(
-                setAccountPropertyByIdAndType({
-                  id: activeAccount.id,
-                  type: activeAccount.type,
-                  property: 'balances',
-                  value: {
-                    ...currentAccount.balances,
-                    [isBitcoinBased
-                      ? INetworkType.Syscoin
-                      : INetworkType.Ethereum]: updatedBalance,
-                  },
-                })
-              );
-            }
 
             // Clear loading state on success only if we set it
             clearBalanceLoadingIfOwned();
@@ -7499,22 +7492,88 @@ class MainController {
 
   public async getBalanceForAccount(
     account: IKeyringAccountState,
-    isBitcoinBased: boolean,
-    networkUrl: string
+    accountType: KeyringAccountType | string,
+    requestedNetwork: INetwork
   ): Promise<string> {
-    try {
-      const balance =
-        await this.balancesManager.utils.getBalanceUpdatedForAccount(
-          account,
-          isBitcoinBased,
-          networkUrl
-        );
-
-      return balance;
-    } catch (error) {
-      // Return 0 on error to allow UI to continue functioning
-      return '0';
+    const { accounts, activeAccount, activeNetwork } = store.getState().vault;
+    if (!isSameBalanceNetwork(activeNetwork, requestedNetwork)) {
+      throw new Error('Network changed before balance request started');
     }
+
+    const requestedAccountType = Object.values(KeyringAccountType).includes(
+      accountType as KeyringAccountType
+    )
+      ? (accountType as KeyringAccountType)
+      : activeAccount.id === account.id
+      ? activeAccount.type
+      : null;
+    const resolvedType = requestedAccountType;
+    const storedAccount = resolvedType
+      ? accounts[resolvedType]?.[account.id]
+      : null;
+
+    const isSameAccount =
+      storedAccount && account.xpub && storedAccount.xpub
+        ? storedAccount.xpub === account.xpub
+        : storedAccount?.address?.toLowerCase() ===
+          account.address?.toLowerCase();
+    if (!resolvedType || !storedAccount || !isSameAccount) {
+      throw new Error('Balance account is no longer available');
+    }
+
+    const cachedBalance = getFreshNativeBalance(storedAccount, activeNetwork);
+    if (cachedBalance) {
+      if (
+        String(storedAccount.balances?.[activeNetwork.kind]) !==
+        String(cachedBalance.balance)
+      ) {
+        store.dispatch(
+          setAccountBalanceForNetwork({
+            balance: cachedBalance.balance,
+            id: storedAccount.id,
+            network: activeNetwork,
+            type: resolvedType,
+            updatedAt: cachedBalance.updatedAt,
+          })
+        );
+      }
+      return String(cachedBalance.balance);
+    }
+
+    const balance =
+      await this.balancesManager.utils.getBalanceUpdatedForAccount(
+        storedAccount,
+        activeNetwork.kind === INetworkType.Syscoin,
+        activeNetwork.url
+      );
+
+    const latestState = store.getState().vault;
+    if (!isSameBalanceNetwork(latestState.activeNetwork, requestedNetwork)) {
+      throw new Error('Network changed while balance request was in flight');
+    }
+    const latestAccount = latestState.accounts[resolvedType]?.[account.id];
+    if (
+      !latestAccount ||
+      (account.xpub && latestAccount.xpub
+        ? latestAccount.xpub !== account.xpub
+        : latestAccount.address?.toLowerCase() !==
+          account.address?.toLowerCase())
+    ) {
+      throw new Error('Balance account changed while request was in flight');
+    }
+
+    store.dispatch(
+      setAccountBalanceForNetwork({
+        balance,
+        id: latestAccount.id,
+        network: latestState.activeNetwork,
+        type: resolvedType,
+      })
+    );
+    // Persist bursts as one delayed wallet write; this never blocks the popup.
+    void this.saveWalletState('native-balance-cache', false, false, 2000);
+
+    return balance;
   }
 
   // Chain info methods for frontend access

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -5493,6 +5493,7 @@ class MainController {
                 type: activeAccount.type,
               })
             );
+            this.scheduleNativeBalanceCacheSave();
 
             // Clear loading state on success only if we set it
             clearBalanceLoadingIfOwned();

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -180,6 +180,7 @@ import {
   ITransactionsManager,
 } from './transactions/types';
 import { clearFetchBackendAccountCache } from './utils/fetchBackendAccountWrapper';
+import { NativeBalanceCacheSaveScheduler } from './utils/nativeBalanceCacheSaveScheduler';
 
 // Default slip44 values for fallback cases
 
@@ -217,6 +218,8 @@ class MainController {
 
   // Centralized wallet state saving
   private saveTimeout: NodeJS.Timeout | null = null;
+  private nativeBalanceCacheSaveScheduler =
+    new NativeBalanceCacheSaveScheduler();
 
   // Track active rapid polls to avoid duplicates
   private activeRapidPolls = new Map<string, NodeJS.Timeout>();
@@ -1129,6 +1132,7 @@ class MainController {
       clearTimeout(this.saveTimeout);
       this.saveTimeout = null;
     }
+    this.clearNativeBalanceCacheSaveTimeout();
 
     // Clear auto-lock reset timeout
     if (this.autoLockResetTimeout) {
@@ -1746,6 +1750,7 @@ class MainController {
       clearTimeout(this.saveTimeout);
       this.saveTimeout = null;
     }
+    this.clearNativeBalanceCacheSaveTimeout();
 
     console.log('[MainController] Auto-lock timer stopped');
   }
@@ -1830,12 +1835,26 @@ class MainController {
     }
   }
 
+  private clearNativeBalanceCacheSaveTimeout(): void {
+    this.nativeBalanceCacheSaveScheduler.cancel();
+  }
+
+  private scheduleNativeBalanceCacheSave(): void {
+    this.nativeBalanceCacheSaveScheduler.schedule(() => {
+      void this.performSave('native-balance-cache').catch((error) => {
+        console.error(
+          '[MainController] Failed to save native balance cache:',
+          error
+        );
+      });
+    });
+  }
+
   // Centralized wallet state saving with debouncing - auto-lock timer reset only for user operations
   private async saveWalletState(
     operation: string,
     isUserActivity = false,
-    sync = false,
-    debounceMs = 100
+    sync = false
   ): Promise<void> {
     try {
       // Only reset auto-lock timer for explicit user activities, not automatic saves
@@ -1850,6 +1869,7 @@ class MainController {
           clearTimeout(this.saveTimeout);
           this.saveTimeout = null;
         }
+        this.clearNativeBalanceCacheSaveTimeout();
 
         try {
           await this.performSave(operation);
@@ -1869,8 +1889,10 @@ class MainController {
       }
 
       // Debounce the actual save to prevent rapid consecutive storage writes.
-      // High-volume background caches can opt into a longer coalescing window.
       this.saveTimeout = setTimeout(async () => {
+        // This save includes the latest balance cache, so an older pending
+        // cache-only write would only duplicate the storage operation.
+        this.clearNativeBalanceCacheSaveTimeout();
         try {
           await this.performSave(operation);
         } catch (error) {
@@ -1882,7 +1904,7 @@ class MainController {
         } finally {
           this.saveTimeout = null;
         }
-      }, debounceMs);
+      }, 100);
     } catch (error) {
       console.error(
         `[MainController] Error in saveWalletState for operation ${operation}:`,
@@ -6396,6 +6418,7 @@ class MainController {
         clearTimeout(this.saveTimeout);
         this.saveTimeout = null;
       }
+      this.clearNativeBalanceCacheSaveTimeout();
       this.isNetworkSwitchMainStateDirty =
         this.isNetworkSwitchMainStateDirty ||
         previousSlip44 !== activeSlip44 ||
@@ -7570,8 +7593,9 @@ class MainController {
         type: resolvedType,
       })
     );
-    // Persist bursts as one delayed wallet write; this never blocks the popup.
-    void this.saveWalletState('native-balance-cache', false, false, 2000);
+    // Persist bursts independently from user-state saves so cache coalescing
+    // can never postpone a label, token, or settings write.
+    this.scheduleNativeBalanceCacheSave();
 
     return balance;
   }

--- a/source/scripts/Background/controllers/utils/nativeBalanceCacheSaveScheduler.spec.ts
+++ b/source/scripts/Background/controllers/utils/nativeBalanceCacheSaveScheduler.spec.ts
@@ -1,0 +1,37 @@
+import { NativeBalanceCacheSaveScheduler } from './nativeBalanceCacheSaveScheduler';
+
+describe('NativeBalanceCacheSaveScheduler', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('coalesces cache-save bursts without sharing another debounce timer', () => {
+    const scheduler = new NativeBalanceCacheSaveScheduler(2000);
+    const save = jest.fn();
+
+    scheduler.schedule(save);
+    jest.advanceTimersByTime(1000);
+    scheduler.schedule(save);
+    jest.advanceTimersByTime(1999);
+
+    expect(save).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(save).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels a redundant cache save absorbed by a wallet save', () => {
+    const scheduler = new NativeBalanceCacheSaveScheduler(2000);
+    const save = jest.fn();
+
+    scheduler.schedule(save);
+    scheduler.cancel();
+    jest.advanceTimersByTime(2000);
+
+    expect(save).not.toHaveBeenCalled();
+  });
+});

--- a/source/scripts/Background/controllers/utils/nativeBalanceCacheSaveScheduler.ts
+++ b/source/scripts/Background/controllers/utils/nativeBalanceCacheSaveScheduler.ts
@@ -1,0 +1,29 @@
+const DEFAULT_CACHE_SAVE_DELAY_MS = 2000;
+
+export class NativeBalanceCacheSaveScheduler {
+  private timeout: ReturnType<typeof setTimeout> | null = null;
+
+  public constructor(private readonly delayMs = DEFAULT_CACHE_SAVE_DELAY_MS) {}
+
+  public cancel(): void {
+    if (!this.timeout) return;
+
+    clearTimeout(this.timeout);
+    this.timeout = null;
+  }
+
+  public schedule(task: () => void): void {
+    this.cancel();
+
+    const timeout = setTimeout(() => {
+      if (this.timeout !== timeout) return;
+
+      // Release the slot before the task runs so an update arriving during
+      // persistence can schedule the next write instead of being dropped.
+      this.timeout = null;
+      task();
+    }, this.delayMs);
+
+    this.timeout = timeout;
+  }
+}

--- a/source/scripts/Background/handlers/handleStateChanges.ts
+++ b/source/scripts/Background/handlers/handleStateChanges.ts
@@ -1,5 +1,4 @@
 import store from 'state/store';
-import { INetworkType } from 'types/network';
 
 let currentState = store.getState();
 let pendingState: typeof currentState | null = null;
@@ -85,23 +84,13 @@ const shallowEqualExcept = (
   return true;
 };
 
-const isOnlyActiveAccountBalanceChange = (
+const getOnlyAccountBalanceChange = (
   previousState: typeof currentState,
-  nextState: typeof currentState,
-  networkType: INetworkType
+  nextState: typeof currentState
 ) => {
-  const activeAccount = nextState.vault.activeAccount;
   const previousAccounts = previousState.vault.accounts;
   const nextAccounts = nextState.vault.accounts;
-  const previousTypeAccounts = previousAccounts[activeAccount.type] || {};
-  const nextTypeAccounts = nextAccounts[activeAccount.type] || {};
-  const activeAccountKey = String(activeAccount.id);
-  const previousAccount = previousTypeAccounts[activeAccount.id];
-  const nextAccount = nextTypeAccounts[activeAccount.id];
-
-  if (!previousAccount || !nextAccount) {
-    return false;
-  }
+  let balanceChange: any = null;
 
   const accountTypes = new Set([
     ...Object.keys(previousAccounts),
@@ -109,12 +98,8 @@ const isOnlyActiveAccountBalanceChange = (
   ]);
 
   for (const accountType of accountTypes) {
-    if (accountType !== activeAccount.type) {
-      if (previousAccounts[accountType] !== nextAccounts[accountType]) {
-        return false;
-      }
-      continue;
-    }
+    const previousTypeAccounts = previousAccounts[accountType] || {};
+    const nextTypeAccounts = nextAccounts[accountType] || {};
 
     const accountIds = new Set([
       ...Object.keys(previousTypeAccounts),
@@ -122,22 +107,33 @@ const isOnlyActiveAccountBalanceChange = (
     ]);
 
     for (const accountId of accountIds) {
-      if (accountId !== activeAccountKey) {
-        if (previousTypeAccounts[accountId] !== nextTypeAccounts[accountId]) {
-          return false;
-        }
+      const previousAccount = previousTypeAccounts[accountId];
+      const nextAccount = nextTypeAccounts[accountId];
+      if (previousAccount === nextAccount) {
+        continue;
       }
+      if (
+        !previousAccount ||
+        !nextAccount ||
+        !shallowEqualExcept(previousAccount, nextAccount, [
+          'balances',
+          'nativeBalanceCache',
+        ]) ||
+        balanceChange
+      ) {
+        return null;
+      }
+
+      balanceChange = {
+        balances: nextAccount.balances,
+        id: Number(accountId),
+        nativeBalanceCache: nextAccount.nativeBalanceCache,
+        type: accountType,
+      };
     }
   }
 
-  if (!shallowEqualExcept(previousAccount, nextAccount, ['balances'])) {
-    return false;
-  }
-
-  return (
-    previousAccount.balances?.[networkType] !==
-    nextAccount.balances?.[networkType]
-  );
+  return balanceChange;
 };
 
 const sendFastStatePatches = (
@@ -174,13 +170,14 @@ const sendFastStatePatches = (
 
   const previousActiveAccount = previousState.vault.activeAccount;
   const nextActiveAccount = nextState.vault.activeAccount;
-  const networkType = nextState.vault.isBitcoinBased
-    ? INetworkType.Syscoin
-    : INetworkType.Ethereum;
+  const accountBalanceChange =
+    previousState.vault.accounts !== nextState.vault.accounts
+      ? getOnlyAccountBalanceChange(previousState, nextState)
+      : null;
 
   if (
     previousState.vault.accounts !== nextState.vault.accounts &&
-    !isOnlyActiveAccountBalanceChange(previousState, nextState, networkType)
+    !accountBalanceChange
   ) {
     sendRuntimeMessage({
       type: 'CONTROLLER_ACCOUNTS_CHANGE',
@@ -229,24 +226,10 @@ const sendFastStatePatches = (
     sentPatch = true;
   }
 
-  const previousAccount =
-    previousState.vault.accounts[nextActiveAccount.type]?.[
-      nextActiveAccount.id
-    ];
-  const nextAccount =
-    nextState.vault.accounts[nextActiveAccount.type]?.[nextActiveAccount.id];
-
-  const previousBalance = previousAccount?.balances?.[networkType];
-  const nextBalance = nextAccount?.balances?.[networkType];
-
-  if (previousBalance !== nextBalance && nextAccount?.balances) {
+  if (accountBalanceChange) {
     sendRuntimeMessage({
       type: 'CONTROLLER_ACCOUNT_BALANCE_CHANGE',
-      data: {
-        id: nextActiveAccount.id,
-        type: nextActiveAccount.type,
-        balances: nextAccount.balances,
-      },
+      data: accountBalanceChange,
     });
     sentPatch = true;
   }

--- a/source/state/vault/index.ts
+++ b/source/state/vault/index.ts
@@ -15,6 +15,11 @@ import {
   initialActiveHdAccountState,
 } from 'types/network';
 import { SYSCOIN_UTXO_MAINNET_NETWORK } from 'utils/constants';
+import {
+  getFreshNativeBalance,
+  isSameBalanceNetwork,
+  updateNativeBalanceCache,
+} from 'utils/nativeBalanceCache';
 
 import {
   IVaultState,
@@ -90,6 +95,22 @@ const ensureAccountTypeBuckets = (state: IVaultState) => {
   return state;
 };
 
+const restoreNativeBalancesForNetwork = (
+  state: IVaultState,
+  network: INetwork,
+  now = Date.now()
+) => {
+  Object.values(KeyringAccountType).forEach((accountType) => {
+    Object.values(state.accounts[accountType] || {}).forEach((account) => {
+      const cachedBalance = getFreshNativeBalance(account, network, now);
+      account.balances = {
+        ...account.balances,
+        [network.kind]: cachedBalance?.balance ?? -1,
+      } as IKeyringBalances;
+    });
+  });
+};
+
 const VaultState = createSlice({
   name: 'vault',
   initialState,
@@ -97,7 +118,12 @@ const VaultState = createSlice({
     rehydrate(_state: IVaultState, action: PayloadAction<IVaultState>) {
       // Complete replacement - ensures loaded vault state is exactly what was saved
       // This matches the behavior of initializeCleanVaultForSlip44 for consistency
-      return ensureAccountTypeBuckets(action.payload);
+      const rehydratedState = ensureAccountTypeBuckets(action.payload);
+      restoreNativeBalancesForNetwork(
+        rehydratedState,
+        rehydratedState.activeNetwork
+      );
+      return rehydratedState;
     },
     setAccounts(
       state: IVaultState,
@@ -142,22 +168,9 @@ const VaultState = createSlice({
       state.activeChain = activeNetwork.kind;
       state.isBitcoinBased = activeNetwork.kind === INetworkType.Syscoin;
 
-      // Clear ALL accounts' balances when switching networks
-      // Use -1 to indicate "no data" - will show skeleton loader
-      Object.keys(KeyringAccountType).forEach((accountType) => {
-        const accounts = state.accounts[accountType as KeyringAccountType];
-        if (accounts) {
-          Object.keys(accounts).forEach((accountId) => {
-            const id = Number(accountId);
-            if (state.accounts[accountType as KeyringAccountType][id]) {
-              state.accounts[accountType as KeyringAccountType][id].balances = {
-                [INetworkType.Syscoin]: -1,
-                [INetworkType.Ethereum]: -1,
-              };
-            }
-          });
-        }
-      });
+      // Restore a recent network-specific value immediately. Missing or stale
+      // entries retain the established -1 sentinel and lazy-load in the UI.
+      restoreNativeBalancesForNetwork(state, activeNetwork);
 
       state.activeNetwork = activeNetwork;
     },
@@ -170,6 +183,56 @@ const VaultState = createSlice({
       if (state.accounts[type]?.[id]) {
         state.accounts[type][id].balances = action.payload;
       }
+    },
+    setAccountBalanceForNetwork(
+      state: IVaultState,
+      action: PayloadAction<{
+        balance: number | string;
+        id: number;
+        network: INetwork;
+        type: KeyringAccountType;
+        updatedAt?: number;
+      }>
+    ) {
+      const {
+        balance,
+        id,
+        network,
+        type,
+        updatedAt = Date.now(),
+      } = action.payload;
+      const account = state.accounts[type]?.[id];
+      if (!account) throw new Error('Account not found');
+
+      account.nativeBalanceCache = updateNativeBalanceCache(
+        account.nativeBalanceCache,
+        network,
+        balance,
+        updatedAt
+      );
+
+      if (isSameBalanceNetwork(state.activeNetwork, network)) {
+        account.balances = {
+          ...account.balances,
+          [network.kind]: balance,
+        } as IKeyringBalances;
+      }
+    },
+    setAccountBalanceSnapshot(
+      state: IVaultState,
+      action: PayloadAction<{
+        balances: IKeyringBalances;
+        id: number;
+        nativeBalanceCache?: IKeyringAccountState['nativeBalanceCache'];
+        type: KeyringAccountType;
+      }>
+    ) {
+      const { balances, id, nativeBalanceCache, type } = action.payload;
+      const account = state.accounts[type]?.[id];
+      if (!account) throw new Error('Account not found');
+
+      account.balances = balances;
+      account.nativeBalanceCache = nativeBalanceCache;
     },
     createAccount(
       state: IVaultState,
@@ -894,6 +957,8 @@ export const {
   setActiveNetwork,
   setFaucetModalState,
   setAccountBalances,
+  setAccountBalanceForNetwork,
+  setAccountBalanceSnapshot,
   forgetWallet,
   initializeCleanVaultForSlip44,
   removeAccount,

--- a/source/state/vault/nativeBalanceCache.spec.ts
+++ b/source/state/vault/nativeBalanceCache.spec.ts
@@ -1,6 +1,9 @@
 import type { INetwork } from 'types/network';
 import { INetworkType, KeyringAccountType } from 'types/network';
-import { NATIVE_BALANCE_CACHE_TTL_MS } from 'utils/nativeBalanceCache';
+import {
+  getFreshNativeBalance,
+  NATIVE_BALANCE_CACHE_TTL_MS,
+} from 'utils/nativeBalanceCache';
 
 import vaultReducer, {
   setAccountBalanceForNetwork,
@@ -109,5 +112,35 @@ describe('network native balance cache', () => {
     );
 
     expect(getHdAccount(state).balances.ethereum).toBe(-1);
+  });
+
+  it('expires a materialized balance without requiring a network switch', () => {
+    const updatedAt = 1_000_000;
+    const network = evmNetwork(57_057);
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(updatedAt);
+
+    let state = vaultReducer(undefined, { type: 'test/init' });
+    state = vaultReducer(state, setNetworkChange({ activeNetwork: network }));
+    state = vaultReducer(
+      state,
+      setAccountBalanceForNetwork({
+        balance: '12.5',
+        id: 0,
+        network,
+        type: KeyringAccountType.HDAccount,
+        updatedAt,
+      })
+    );
+
+    const account = getHdAccount(state);
+    expect(account.balances.ethereum).toBe('12.5');
+    expect(getFreshNativeBalance(account, network)?.balance).toBe('12.5');
+
+    nowSpy.mockReturnValue(updatedAt + NATIVE_BALANCE_CACHE_TTL_MS);
+
+    // The legacy field remains materialized, but consumers must no longer
+    // treat it as current once its network-specific timestamp expires.
+    expect(account.balances.ethereum).toBe('12.5');
+    expect(getFreshNativeBalance(account, network)).toBeNull();
   });
 });

--- a/source/state/vault/nativeBalanceCache.spec.ts
+++ b/source/state/vault/nativeBalanceCache.spec.ts
@@ -1,0 +1,113 @@
+import type { INetwork } from 'types/network';
+import { INetworkType, KeyringAccountType } from 'types/network';
+import { NATIVE_BALANCE_CACHE_TTL_MS } from 'utils/nativeBalanceCache';
+
+import vaultReducer, {
+  setAccountBalanceForNetwork,
+  setNetworkChange,
+} from './index';
+
+const evmNetwork = (chainId: number): INetwork => ({
+  chainId,
+  currency: 'SYS',
+  kind: INetworkType.Ethereum,
+  label: `EVM ${chainId}`,
+  slip44: 60,
+  url: `https://rpc-${chainId}.example`,
+});
+
+const getHdAccount = (state: ReturnType<typeof vaultReducer>) =>
+  state.accounts[KeyringAccountType.HDAccount][0];
+
+describe('network native balance cache', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('restores a fresh balance when returning to a previously visited network', () => {
+    const now = 1_000_000;
+    jest.spyOn(Date, 'now').mockReturnValue(now);
+    const firstNetwork = evmNetwork(57_057);
+    const secondNetwork = evmNetwork(57_058);
+
+    let state = vaultReducer(undefined, { type: 'test/init' });
+    state = vaultReducer(
+      state,
+      setNetworkChange({ activeNetwork: firstNetwork })
+    );
+    state = vaultReducer(
+      state,
+      setAccountBalanceForNetwork({
+        balance: '12.5',
+        id: 0,
+        network: firstNetwork,
+        type: KeyringAccountType.HDAccount,
+        updatedAt: now,
+      })
+    );
+    state = vaultReducer(
+      state,
+      setNetworkChange({ activeNetwork: secondNetwork })
+    );
+
+    expect(getHdAccount(state).balances.ethereum).toBe(-1);
+    state = vaultReducer(
+      state,
+      setAccountBalanceForNetwork({
+        balance: '7.25',
+        id: 0,
+        network: secondNetwork,
+        type: KeyringAccountType.HDAccount,
+        updatedAt: now,
+      })
+    );
+
+    state = vaultReducer(
+      state,
+      setNetworkChange({ activeNetwork: firstNetwork })
+    );
+
+    expect(getHdAccount(state).balances.ethereum).toBe('12.5');
+
+    state = vaultReducer(
+      state,
+      setNetworkChange({ activeNetwork: secondNetwork })
+    );
+    expect(getHdAccount(state).balances.ethereum).toBe('7.25');
+  });
+
+  it('uses the missing sentinel instead of restoring an expired balance', () => {
+    const updatedAt = 1_000_000;
+    const firstNetwork = evmNetwork(57_057);
+    const secondNetwork = evmNetwork(57_058);
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(updatedAt);
+
+    let state = vaultReducer(undefined, { type: 'test/init' });
+    state = vaultReducer(
+      state,
+      setNetworkChange({ activeNetwork: firstNetwork })
+    );
+    state = vaultReducer(
+      state,
+      setAccountBalanceForNetwork({
+        balance: '12.5',
+        id: 0,
+        network: firstNetwork,
+        type: KeyringAccountType.HDAccount,
+        updatedAt,
+      })
+    );
+
+    nowSpy.mockReturnValue(updatedAt + NATIVE_BALANCE_CACHE_TTL_MS);
+    state = vaultReducer(
+      state,
+      setNetworkChange({ activeNetwork: secondNetwork })
+    );
+    state = vaultReducer(
+      state,
+      setNetworkChange({ activeNetwork: firstNetwork })
+    );
+
+    expect(getHdAccount(state).balances.ethereum).toBe(-1);
+  });
+});

--- a/source/types/network.ts
+++ b/source/types/network.ts
@@ -212,6 +212,11 @@ export type IKeyringBalances = {
   [INetworkType.Ethereum]: number;
 };
 
+export interface INativeBalanceCacheEntry {
+  balance: number | string;
+  updatedAt: number;
+}
+
 export interface IKeyringAccountState {
   address: string;
   balances: IKeyringBalances;
@@ -224,6 +229,9 @@ export interface IKeyringAccountState {
   isSmartAccount?: boolean;
   isTrezorWallet: boolean;
   label: string;
+  // Native balances are network-specific even though `balances` retains the
+  // legacy active-chain shape used throughout the UI.
+  nativeBalanceCache?: Record<string, INativeBalanceCacheEntry>;
   smartAccount?: ISmartAccountMetadata;
   // Per-chain last block scanned for ERC-4337 UserOperationEvent logs
   // (smart accounts only; chainId -> blockNumber)

--- a/source/utils/nativeBalanceCache.ts
+++ b/source/utils/nativeBalanceCache.ts
@@ -1,0 +1,51 @@
+import type {
+  IKeyringAccountState,
+  INativeBalanceCacheEntry,
+  INetwork,
+} from 'types/network';
+
+export const NATIVE_BALANCE_CACHE_TTL_MS = 5 * 60 * 1000;
+const MAX_CACHED_NETWORKS_PER_ACCOUNT = 25;
+
+export const getNativeBalanceCacheKey = (
+  network: Pick<INetwork, 'chainId' | 'kind'>
+): string => `${network.kind}:${network.chainId}`;
+
+export const isSameBalanceNetwork = (
+  first: Pick<INetwork, 'chainId' | 'kind'>,
+  second: Pick<INetwork, 'chainId' | 'kind'>
+): boolean =>
+  first.kind === second.kind &&
+  Number(first.chainId) === Number(second.chainId);
+
+export const getFreshNativeBalance = (
+  account: Pick<IKeyringAccountState, 'nativeBalanceCache'>,
+  network: Pick<INetwork, 'chainId' | 'kind'>,
+  now = Date.now()
+): INativeBalanceCacheEntry | null => {
+  const entry = account.nativeBalanceCache?.[getNativeBalanceCacheKey(network)];
+  if (!entry || now - entry.updatedAt >= NATIVE_BALANCE_CACHE_TTL_MS) {
+    return null;
+  }
+
+  return entry;
+};
+
+export const updateNativeBalanceCache = (
+  cache: IKeyringAccountState['nativeBalanceCache'],
+  network: Pick<INetwork, 'chainId' | 'kind'>,
+  balance: number | string,
+  updatedAt = Date.now()
+): Record<string, INativeBalanceCacheEntry> => {
+  const entries = Object.entries({
+    ...cache,
+    [getNativeBalanceCacheKey(network)]: { balance, updatedAt },
+  })
+    .filter(
+      ([, entry]) => updatedAt - entry.updatedAt < NATIVE_BALANCE_CACHE_TTL_MS
+    )
+    .sort(([, first], [, second]) => second.updatedAt - first.updatedAt)
+    .slice(0, MAX_CACHED_NETWORKS_PER_ACCOUNT);
+
+  return Object.fromEntries(entries);
+};


### PR DESCRIPTION
## Summary

- restore lazy native-balance loading on connection and account-selection screens
- keep live Redux balance updates visible without requiring a popup remount
- cache native balances per account and network for five minutes
- restore fresh cached values on rehydrate and network return without making RPC calls
- deduplicate in-flight account requests and coalesce cache persistence into one delayed wallet save
- send targeted balance/cache state patches instead of retransmitting the full account state

## Root cause

Connection screens explicitly disabled missing-balance fetches. `LazyAccountBalance` also marked itself unmounted whenever its balance dependency changed, so a background Redux update could arrive without updating the rendered value. Separately, the vault stored only one active EVM/UTXO balance and reset it to `-1` on every network switch, discarding values already fetched for the previous chain.

## Impact

Account selectors render immediately with placeholders, populate missing balances in the background, and update in place. Returning to a chain restores unexpired cached values immediately. Rehydrate only reads the cache; it does not fetch every account. Only missing or expired visible account cards use the existing rate-limited lazy RPC path.

## Validation

- Prettier
- ESLint
- TypeScript `--noEmit`
- 54/54 Jest suites
- 493/493 Jest tests
- targeted tests for per-network restoration and expiry
