### PR TITLE
fix network account state switching

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Pali Wallet",
-  "version": "4.0.52",
+  "version": "4.0.53",
   "icons": {
     "16": "assets/all_assets/favicon-16.png",
     "32": "assets/all_assets/favicon-32.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paliwallet",
-  "version": "4.0.52",
+  "version": "4.0.53",
   "description": "A Non-Custodial Crypto Wallet",
   "private": true,
   "repository": {

--- a/source/components/Header/RenderAccountsListByBitcoinBased.tsx
+++ b/source/components/Header/RenderAccountsListByBitcoinBased.tsx
@@ -17,6 +17,7 @@ import { useUtils } from 'hooks/useUtils';
 import { RootState } from 'state/store';
 import { selectActiveAccountRef } from 'state/vault';
 import { KeyringAccountType } from 'types/network';
+import { isAccountCompatibleWithNetwork } from 'utils/accountCompatibility';
 import { ellipsis } from 'utils/index';
 
 type RenderAccountsListByBitcoinBasedProps = {
@@ -125,9 +126,6 @@ const RenderAccountsListByBitcoinBased =
     const accounts = useSelector((state: RootState) => state.vault.accounts);
     const activeNetwork = useSelector(
       (state: RootState) => state.vault.activeNetwork
-    );
-    const isBitcoinBased = useSelector(
-      (state: RootState) => state.vault.isBitcoinBased
     );
     const activeAccount = useSelector(selectActiveAccountRef);
     // When the accounts list is scrollable, a first click can be swallowed by inertial scrolling
@@ -289,24 +287,20 @@ const RenderAccountsListByBitcoinBased =
       () =>
         Object.entries(accounts).flatMap(([accountType, accountsOfType]) =>
           Object.values(accountsOfType || {})
-            .filter((account: any) => {
-              if (accountType !== KeyringAccountType.SmartAccount) {
-                return true;
-              }
-
-              return (
-                !isBitcoinBased &&
-                Number(account?.smartAccount?.chainId) ===
-                  Number(activeNetwork.chainId)
-              );
-            })
+            .filter((account: any) =>
+              isAccountCompatibleWithNetwork(
+                account,
+                accountType,
+                activeNetwork
+              )
+            )
             .map((account, index) => ({
               account,
               accountType: accountType as KeyringAccountType,
               index,
             }))
         ),
-      [accounts, activeNetwork.chainId, isBitcoinBased]
+      [accounts, activeNetwork.chainId, activeNetwork.kind]
     );
 
     const isAnySwitching = switchingAccount !== null;

--- a/source/config/consts.js
+++ b/source/config/consts.js
@@ -80,7 +80,7 @@ const CANARY_EXTENSION_KEY =
 const MV3_OPTIONS = {
   manifest_version: 3,
   name: 'Pali Wallet',
-  version: '4.0.52',
+  version: '4.0.53',
   icons: {
     16: 'assets/all_assets/favicon-16.png',
     32: 'assets/all_assets/favicon-32.png',

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -96,6 +96,7 @@ import {
   ITokenDetails,
 } from 'types/tokens';
 import { ICustomRpcParams, IDecodedTx } from 'types/transactions';
+import { isAccountCompatibleWithNetwork } from 'utils/accountCompatibility';
 import {
   fiatPriceMutex,
   networkSwitchMutex,
@@ -108,7 +109,6 @@ import {
 import { formatUnits } from 'utils/ethersV6Compat';
 import { namehash } from 'utils/ethersV6Compat';
 import { Contract } from 'utils/ethersV6Compat';
-import { isHexString } from 'utils/ethersV6Compat';
 import { decodeTransactionData } from 'utils/ethUtil';
 import { getBlacklistTargetsForEvmCallWithContractType } from 'utils/evmCallBlacklist';
 import {
@@ -3013,23 +3013,13 @@ class MainController {
     // This prevents concurrent account switches across all contexts
     return accountSwitchMutex.runExclusive(async () => {
       try {
-        const { accounts, activeNetwork, isBitcoinBased } =
-          store.getState().vault;
-        if (String(type) === KeyringAccountType.SmartAccount) {
-          const account = accounts[type]?.[id] as any;
-          if (isBitcoinBased) {
-            throw new Error(
-              'Smart accounts are only available on EVM networks'
-            );
-          }
-          if (
-            Number(account?.smartAccount?.chainId) !==
-            Number(activeNetwork.chainId)
-          ) {
-            throw new Error(
-              'Smart account is not available on the active network'
-            );
-          }
+        const { accounts, activeNetwork } = store.getState().vault;
+        const account = accounts[type]?.[id];
+        if (!account) {
+          throw new Error('Account not found');
+        }
+        if (!isAccountCompatibleWithNetwork(account, type, activeNetwork)) {
+          throw new Error('Account is not available on the active network');
         }
 
         // Account context changed; rapid polling should not continue against the old active account.
@@ -3139,21 +3129,7 @@ class MainController {
     type: KeyringAccountType,
     network: INetwork
   ): boolean {
-    if (!account) return false;
-
-    if (String(type) === KeyringAccountType.SmartAccount) {
-      return (
-        network.kind === INetworkType.Ethereum &&
-        Number(account?.smartAccount?.chainId) === Number(network.chainId)
-      );
-    }
-
-    const address = account.address;
-    if (typeof address !== 'string') return false;
-
-    return network.kind === INetworkType.Syscoin
-      ? !isHexString(address)
-      : isHexString(address);
+    return isAccountCompatibleWithNetwork(account, type, network);
   }
 
   private getFirstCompatibleAccountForNetwork(network: INetwork) {
@@ -6961,8 +6937,10 @@ class MainController {
       result = await this.account.sys.saveTokenInfo(token);
     }
 
-    // Save wallet state after adding token
-    this.saveWalletState('add-token', true);
+    // Token import is user-authored durable state. Do not report success until
+    // it has crossed the persistence boundary; a network switch can otherwise
+    // replace the active slip44 vault before the debounced save runs.
+    await this.saveWalletState('add-token', true, true);
 
     return result;
   }

--- a/source/scripts/Background/handlers/handleStateChanges.spec.ts
+++ b/source/scripts/Background/handlers/handleStateChanges.spec.ts
@@ -1,0 +1,53 @@
+import store from 'state/store';
+import { INetworkType, KeyringAccountType } from 'types/network';
+
+import { sendFastStatePatches } from './handleStateChanges';
+
+describe('network state patches', () => {
+  beforeEach(() => {
+    (chrome.runtime.sendMessage as jest.Mock).mockClear();
+  });
+
+  it('delivers a new network and its account buckets atomically', () => {
+    const previousState = store.getState();
+    const accounts = {
+      ...previousState.vault.accounts,
+      [KeyringAccountType.HDAccount]: {
+        0: {
+          ...previousState.vault.accounts[KeyringAccountType.HDAccount][0],
+          address: '0x940000000000000000000000000000000000052e',
+        },
+      },
+    };
+    const nextState = {
+      ...previousState,
+      vault: {
+        ...previousState.vault,
+        accounts,
+        activeChain: INetworkType.Ethereum,
+        activeNetwork: {
+          ...previousState.vault.activeNetwork,
+          chainId: 570,
+          kind: INetworkType.Ethereum,
+          slip44: 60,
+          url: 'https://rpc.rollux.com',
+        },
+        isBitcoinBased: false,
+      },
+    };
+
+    sendFastStatePatches(previousState, nextState);
+
+    const messages = (chrome.runtime.sendMessage as jest.Mock).mock.calls.map(
+      ([message]) => message
+    );
+    const networkMessage = messages.find(
+      (message) => message.type === 'CONTROLLER_NETWORK_CHANGE'
+    );
+
+    expect(networkMessage.data.accounts).toBe(accounts);
+    expect(
+      messages.some((message) => message.type === 'CONTROLLER_ACCOUNTS_CHANGE')
+    ).toBe(false);
+  });
+});

--- a/source/scripts/Background/handlers/handleStateChanges.ts
+++ b/source/scripts/Background/handlers/handleStateChanges.ts
@@ -136,7 +136,7 @@ const getOnlyAccountBalanceChange = (
   return balanceChange;
 };
 
-const sendFastStatePatches = (
+export const sendFastStatePatches = (
   previousState: typeof currentState,
   nextState: typeof currentState
 ): boolean => {
@@ -151,17 +151,21 @@ const sendFastStatePatches = (
 
   const previousNetwork = previousState.vault.activeNetwork;
   const nextNetwork = nextState.vault.activeNetwork;
-
-  if (
+  const networkChanged =
     previousNetwork.chainId !== nextNetwork.chainId ||
     previousNetwork.url !== nextNetwork.url ||
-    previousNetwork.kind !== nextNetwork.kind
-  ) {
+    previousNetwork.kind !== nextNetwork.kind;
+
+  if (networkChanged) {
     sendRuntimeMessage({
       type: 'CONTROLLER_NETWORK_CHANGE',
       data: {
         activeAccount: nextState.vault.activeAccount,
         activeNetwork: nextNetwork,
+        // A slip44 switch replaces the account buckets and network together.
+        // Deliver them in one message so the popup cannot render a new network
+        // against accounts left over from the previous address family.
+        accounts: nextState.vault.accounts,
         networkStatus: nextState.vaultGlobal.networkStatus,
       },
     });
@@ -176,6 +180,7 @@ const sendFastStatePatches = (
       : null;
 
   if (
+    !networkChanged &&
     previousState.vault.accounts !== nextState.vault.accounts &&
     !accountBalanceChange
   ) {

--- a/source/utils/accountCompatibility.spec.ts
+++ b/source/utils/accountCompatibility.spec.ts
@@ -1,0 +1,82 @@
+import { INetwork, INetworkType, KeyringAccountType } from 'types/network';
+
+import { isAccountCompatibleWithNetwork } from './accountCompatibility';
+
+const evmNetwork = {
+  chainId: 570,
+  kind: INetworkType.Ethereum,
+} as INetwork;
+const utxoNetwork = {
+  chainId: 5700,
+  kind: INetworkType.Syscoin,
+} as INetwork;
+
+describe('isAccountCompatibleWithNetwork', () => {
+  const evmAccount = {
+    address: '0x940000000000000000000000000000000000052e',
+  } as any;
+  const utxoAccount = { address: 'tsys1qexampleaddress' } as any;
+
+  it('keeps UTXO accounts out of EVM account selection', () => {
+    expect(
+      isAccountCompatibleWithNetwork(
+        evmAccount,
+        KeyringAccountType.HDAccount,
+        evmNetwork
+      )
+    ).toBe(true);
+    expect(
+      isAccountCompatibleWithNetwork(
+        utxoAccount,
+        KeyringAccountType.HDAccount,
+        evmNetwork
+      )
+    ).toBe(false);
+  });
+
+  it('keeps EVM accounts out of UTXO account selection', () => {
+    expect(
+      isAccountCompatibleWithNetwork(
+        utxoAccount,
+        KeyringAccountType.HDAccount,
+        utxoNetwork
+      )
+    ).toBe(true);
+    expect(
+      isAccountCompatibleWithNetwork(
+        evmAccount,
+        KeyringAccountType.HDAccount,
+        utxoNetwork
+      )
+    ).toBe(false);
+  });
+
+  it('only exposes smart accounts on their EVM chain', () => {
+    const smartAccount = {
+      ...evmAccount,
+      smartAccount: { chainId: evmNetwork.chainId },
+    } as any;
+
+    expect(
+      isAccountCompatibleWithNetwork(
+        smartAccount,
+        KeyringAccountType.SmartAccount,
+        evmNetwork
+      )
+    ).toBe(true);
+    expect(
+      isAccountCompatibleWithNetwork(
+        smartAccount,
+        KeyringAccountType.SmartAccount,
+        { ...evmNetwork, chainId: 1 }
+      )
+    ).toBe(false);
+    expect(
+      isAccountCompatibleWithNetwork(
+        smartAccount,
+        KeyringAccountType.SmartAccount,
+        utxoNetwork
+      )
+    ).toBe(false);
+  });
+});

--- a/source/utils/accountCompatibility.ts
+++ b/source/utils/accountCompatibility.ts
@@ -1,0 +1,38 @@
+import {
+  IKeyringAccountState,
+  INetwork,
+  INetworkType,
+  KeyringAccountType,
+} from 'types/network';
+import { isHexString } from 'utils/ethersV6Compat';
+
+type AccountForCompatibility = Pick<IKeyringAccountState, 'address'> &
+  Partial<Pick<IKeyringAccountState, 'smartAccount'>>;
+
+/**
+ * Account buckets can briefly be delivered separately from the active network
+ * while a slip44 switch is being reconciled. Keep incompatible address families
+ * out of both the account picker and account-selection entry points.
+ */
+export const isAccountCompatibleWithNetwork = (
+  account: AccountForCompatibility | null | undefined,
+  type: KeyringAccountType | string,
+  network: INetwork
+): boolean => {
+  if (!account) return false;
+
+  if (String(type) === KeyringAccountType.SmartAccount) {
+    return (
+      network.kind === INetworkType.Ethereum &&
+      Number(account.smartAccount?.chainId) === Number(network.chainId)
+    );
+  }
+
+  if (typeof account.address !== 'string' || account.address.length === 0) {
+    return false;
+  }
+
+  return network.kind === INetworkType.Syscoin
+    ? !isHexString(account.address)
+    : isHexString(account.address);
+};


### PR DESCRIPTION
## Summary

- deliver network changes and replacement account buckets atomically during slip44 switches
- filter and guard account selection by UTXO/EVM address family and smart-account chain
- persist imported tokens before reporting success so an immediate network switch cannot lose an SPT
- add regression coverage for atomic state delivery and account-family compatibility
- bump the release version from 4.0.52 to 4.0.53

## Root cause

The popup received the target network and its account buckets through separate fast state messages. During the gap, it could render the new chain family with accounts from the previous vault. The account menu only scoped smart accounts and did not filter normal UTXO/EVM addresses, so the transient mismatch was visible and selectable. Token imports also returned before the debounced vault write was durable.

## Impact

Switching between UTXO and EVM networks no longer mixes account rows, incompatible accounts cannot be selected through another entry point, and imported SPT state is committed before the import flow completes. Version 4.0.53 is ready for the release build.

## Validation

- focused Jest regressions: 4 suites, 8 tests passed
- ESLint on all changed source files
- release version consistency check across package, generated manifest, and manifest source
- `tsc --pretty --noEmit`
- `git diff --check`