### PR TITLE
fix imported asset persistence and exact UTXO account isolation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Pali Wallet",
-  "version": "4.0.53",
+  "version": "4.0.54",
   "icons": {
     "16": "assets/all_assets/favicon-16.png",
     "32": "assets/all_assets/favicon-32.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paliwallet",
-  "version": "4.0.53",
+  "version": "4.0.54",
   "description": "A Non-Custodial Crypto Wallet",
   "private": true,
   "repository": {

--- a/source/config/consts.js
+++ b/source/config/consts.js
@@ -80,7 +80,7 @@ const CANARY_EXTENSION_KEY =
 const MV3_OPTIONS = {
   manifest_version: 3,
   name: 'Pali Wallet',
-  version: '4.0.53',
+  version: '4.0.54',
   icons: {
     16: 'assets/all_assets/favicon-16.png',
     32: 'assets/all_assets/favicon-32.png',

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -22,6 +22,7 @@ import {
   isValidSYSAddress,
 } from '@sidhujag/sysweb3-utils';
 import isEmpty from 'lodash/isEmpty';
+import isEqual from 'lodash/isEqual';
 import isNil from 'lodash/isNil';
 import * as syscoinjs from 'syscoinjs-lib';
 
@@ -158,7 +159,7 @@ import SysAccountController, { ISysAccountController } from './account/syscoin';
 import AssetsManager from './assets';
 import EvmAssetsController from './assets/evm';
 import { IAssetsManager } from './assets/types';
-import { ensureTrailingSlash } from './assets/utils';
+import { canCommitAssetUpdate, ensureTrailingSlash } from './assets/utils';
 import BalancesManager from './balances';
 import { IBalancesManager } from './balances/types';
 import ChainListService from './chainlist';
@@ -198,6 +199,7 @@ class MainController {
   private transactionsManager: ITransactionsManager;
   private balancesManager: IBalancesManager;
   private balanceLoadingRequestId = 0;
+  private assetUpdateRequestId = 0;
   private isNetworkSwitchMainStateDirty = false;
   private smartAccount: SmartAccountController;
   private cancellablePromises: CancellablePromises;
@@ -297,6 +299,9 @@ class MainController {
     if (this.cancellablePromises.assetsPromise) {
       this.cancellablePromises.assetsPromise.cancel();
     }
+    // Prevent an unabortable RPC from an earlier visit to this same network
+    // (A -> B -> A) from committing against the new vault snapshot.
+    this.assetUpdateRequestId += 1;
     this.cancelActiveBalanceUpdate();
     if (this.cancellablePromises.nftsPromise) {
       this.cancellablePromises.nftsPromise.cancel();
@@ -3032,6 +3037,9 @@ class MainController {
         if (this.cancellablePromises.assetsPromise) {
           this.cancellablePromises.assetsPromise.cancel();
         }
+        // Cancellation rejects the wrapper but cannot abort an RPC already in
+        // flight. Invalidate its eventual writeback explicitly.
+        this.assetUpdateRequestId += 1;
         this.cancelActiveBalanceUpdate();
         if (this.cancellablePromises.nftsPromise) {
           this.cancellablePromises.nftsPromise.cancel();
@@ -3243,6 +3251,9 @@ class MainController {
     if (this.cancellablePromises.assetsPromise) {
       this.cancellablePromises.assetsPromise.cancel();
     }
+    // Prevent an unabortable RPC from an earlier visit to this same network
+    // (A -> B -> A) from committing against the new vault snapshot.
+    this.assetUpdateRequestId += 1;
     this.cancelActiveBalanceUpdate();
     if (this.cancellablePromises.nftsPromise) {
       this.cancellablePromises.nftsPromise.cancel();
@@ -5246,10 +5257,13 @@ class MainController {
       }
     }
 
+    const requestId = ++this.assetUpdateRequestId;
     const { accounts, accountAssets } = store.getState().vault;
 
     const currentAccount = accounts[activeAccount.type]?.[activeAccount.id];
-    const currentAssets = accountAssets[activeAccount.type]?.[activeAccount.id];
+    const currentAssets = accountAssets[activeAccount.type]?.[
+      activeAccount.id
+    ] || { ethereum: [], syscoin: [] };
 
     // Check if account exists before proceeding
     if (!currentAccount) {
@@ -5271,16 +5285,29 @@ class MainController {
                 activeNetwork.url,
                 activeNetwork.chainId,
                 web3Provider,
-                currentAssets || { ethereum: [], syscoin: [] }
+                currentAssets
               );
-            const latestNetwork = store.getState().vault.activeNetwork;
+            const latestVault = store.getState().vault;
+            const latestAccount =
+              latestVault.accounts[activeAccount.type]?.[activeAccount.id];
+            const latestAssets =
+              latestVault.accountAssets[activeAccount.type]?.[activeAccount.id];
             if (
-              latestNetwork.chainId !== activeNetwork.chainId ||
-              latestNetwork.kind !== activeNetwork.kind ||
-              latestNetwork.url !== activeNetwork.url
+              !canCommitAssetUpdate({
+                account: currentAccount,
+                activeAccount,
+                assets: currentAssets,
+                latestAccount,
+                latestActiveAccount: latestVault.activeAccount,
+                latestAssets,
+                latestNetwork: latestVault.activeNetwork,
+                latestRequestId: this.assetUpdateRequestId,
+                network: activeNetwork,
+                requestId,
+              })
             ) {
               console.log(
-                '[MainController] Skipping stale asset update after network change'
+                '[MainController] Skipping stale asset update after account, network, or imported-asset change'
               );
               resolve();
               return;
@@ -5311,6 +5338,11 @@ class MainController {
 
             if (validateIfIsInvalidDispatch) {
               // Skip dispatch but still resolve - empty data might be valid
+              resolve();
+              return;
+            }
+
+            if (isEqual(updatedAssets, currentAssets)) {
               resolve();
               return;
             }

--- a/source/scripts/Background/controllers/assets/assetUpdateGuard.spec.ts
+++ b/source/scripts/Background/controllers/assets/assetUpdateGuard.spec.ts
@@ -1,0 +1,87 @@
+import { IAccountAssets } from 'state/vault/types';
+import { INetworkType, KeyringAccountType } from 'types/network';
+
+import { canCommitAssetUpdate } from './utils';
+
+const network = {
+  chainId: 57,
+  kind: INetworkType.Syscoin,
+  slip44: 57,
+  url: 'https://blockbook.syscoin.org/',
+} as any;
+const activeAccount = { id: 0, type: KeyringAccountType.HDAccount };
+const account = {
+  address: 'sys1qaccount',
+  xpub: 'zpub-account',
+} as any;
+const assets: IAccountAssets = {
+  ethereum: [],
+  syscoin: [{ assetGuid: '123', chainId: 57, symbol: 'ONE' } as any],
+};
+
+const canCommit = (overrides: Record<string, any> = {}) =>
+  canCommitAssetUpdate({
+    account,
+    activeAccount,
+    assets,
+    latestAccount: account,
+    latestActiveAccount: activeAccount,
+    latestAssets: assets,
+    latestNetwork: network,
+    latestRequestId: 4,
+    network,
+    requestId: 4,
+    ...overrides,
+  });
+
+describe('asset update commit guard', () => {
+  it('allows a refresh when its account, network, and base assets are unchanged', () => {
+    expect(canCommit()).toBe(true);
+  });
+
+  it('rejects a stale SPT refresh after an imported asset is appended', () => {
+    expect(
+      canCommit({
+        latestAssets: {
+          ...assets,
+          syscoin: [
+            ...assets.syscoin,
+            { assetGuid: '456', chainId: 57, symbol: 'TWO' },
+          ],
+        },
+      })
+    ).toBe(false);
+  });
+
+  it('rejects a stale EVM refresh after an imported token is appended', () => {
+    const evmAssets = {
+      ethereum: [
+        {
+          chainId: 570,
+          contractAddress: '0x0000000000000000000000000000000000000001',
+        },
+      ],
+      syscoin: [],
+    } as IAccountAssets;
+
+    expect(
+      canCommit({
+        assets: evmAssets,
+        latestAssets: {
+          ...evmAssets,
+          ethereum: [
+            ...evmAssets.ethereum,
+            {
+              chainId: 570,
+              contractAddress: '0x0000000000000000000000000000000000000002',
+            },
+          ],
+        },
+      })
+    ).toBe(false);
+  });
+
+  it('rejects an update invalidated by a network round trip', () => {
+    expect(canCommit({ latestRequestId: 6 })).toBe(false);
+  });
+});

--- a/source/scripts/Background/controllers/assets/evm.ts
+++ b/source/scripts/Background/controllers/assets/evm.ts
@@ -568,7 +568,11 @@ const EvmAssetsController = (): IEvmAssetsController => {
       // Combine updated assets with other network assets
       const allAssets = [...updatedAssets, ...otherNetworkAssets];
 
-      return validateAndManageUserAssets(true, allAssets) as ITokenEthProps[];
+      return validateAndManageUserAssets(
+        true,
+        allAssets,
+        accountAssets
+      ) as ITokenEthProps[];
     }
 
     // No API available or API failed - use multicall3 for batch balance fetching
@@ -739,7 +743,8 @@ const EvmAssetsController = (): IEvmAssetsController => {
 
     return validateAndManageUserAssets(
       true,
-      allUpdatedAssets
+      allUpdatedAssets,
+      accountAssets
     ) as ITokenEthProps[];
   };
 

--- a/source/scripts/Background/controllers/assets/index.ts
+++ b/source/scripts/Background/controllers/assets/index.ts
@@ -36,12 +36,20 @@ const AssetsManager = (): IAssetsManager => {
         const getSysAssets = await SysAssetsController().getSysAssetsByXpub(
           currentAccount.xpub,
           activeNetworkUrl,
-          networkChainId
+          networkChainId,
+          currentAssets.syscoin.filter(
+            (asset) => asset.chainId === networkChainId
+          )
         );
 
         return {
           ...currentAssets,
-          syscoin: getSysAssets,
+          syscoin: [
+            ...getSysAssets,
+            ...currentAssets.syscoin.filter(
+              (asset) => asset.chainId !== networkChainId
+            ),
+          ],
         };
 
       case false:

--- a/source/scripts/Background/controllers/assets/sptGating.spec.ts
+++ b/source/scripts/Background/controllers/assets/sptGating.spec.ts
@@ -19,14 +19,14 @@ import AssetsManager from './index';
 const ACCOUNT = { xpub: 'zpub-test', address: 'sys1q...' } as any;
 const CURRENT_ASSETS = {
   ethereum: [],
-  syscoin: [{ assetGuid: '123', balance: 1 }],
+  syscoin: [{ assetGuid: '123', balance: 1, chainId: 57 }],
 } as any;
 
 describe('AssetsManager SPT gating by chain', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     getSysAssetsByXpubMock.mockResolvedValue([
-      { assetGuid: '123', balance: 2 },
+      { assetGuid: '123', balance: 2, chainId: 57 },
     ]);
   });
 
@@ -41,7 +41,15 @@ describe('AssetsManager SPT gating by chain', () => {
     );
 
     expect(getSysAssetsByXpubMock).toHaveBeenCalledTimes(1);
-    expect(result.syscoin).toEqual([{ assetGuid: '123', balance: 2 }]);
+    expect(getSysAssetsByXpubMock).toHaveBeenCalledWith(
+      ACCOUNT.xpub,
+      'https://blockbook.syscoin.org/',
+      57,
+      CURRENT_ASSETS.syscoin
+    );
+    expect(result.syscoin).toEqual([
+      { assetGuid: '123', balance: 2, chainId: 57 },
+    ]);
   });
 
   it('fetches SPT assets on Syscoin testnet (5700)', async () => {
@@ -70,5 +78,29 @@ describe('AssetsManager SPT gating by chain', () => {
     expect(getSysAssetsByXpubMock).not.toHaveBeenCalled();
     // Existing assets are preserved untouched
     expect(result).toEqual(CURRENT_ASSETS);
+  });
+
+  it('preserves imported assets belonging to another chain', async () => {
+    const otherNetworkAsset = {
+      assetGuid: '999',
+      balance: 5,
+      chainId: 5700,
+    };
+    const result = await AssetsManager().utils.updateAssetsFromCurrentAccount(
+      ACCOUNT,
+      true,
+      'https://blockbook.syscoin.org/',
+      57,
+      undefined as any,
+      {
+        ...CURRENT_ASSETS,
+        syscoin: [...CURRENT_ASSETS.syscoin, otherNetworkAsset],
+      }
+    );
+
+    expect(result.syscoin).toEqual([
+      { assetGuid: '123', balance: 2, chainId: 57 },
+      otherNetworkAsset,
+    ]);
   });
 });

--- a/source/scripts/Background/controllers/assets/syscoin.spec.ts
+++ b/source/scripts/Background/controllers/assets/syscoin.spec.ts
@@ -1,0 +1,91 @@
+const fetchBackendAccountCachedMock = jest.fn();
+
+jest.mock('../utils/fetchBackendAccountWrapper', () => ({
+  fetchBackendAccountCached: (...args: any[]) =>
+    fetchBackendAccountCachedMock(...args),
+}));
+
+import SysAssetsController from './syscoin';
+
+describe('SysAssetsController imported asset refresh', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('refreshes chain values without dropping imported metadata', async () => {
+    fetchBackendAccountCachedMock.mockResolvedValue({
+      tokensAsset: [
+        {
+          assetGuid: '123',
+          balance: '250',
+          decimals: 2,
+          name: 'Backend name',
+          path: 'm/0/0',
+          symbol: 'TOK',
+          totalReceived: '250',
+          totalSent: '0',
+          transfers: 1,
+          type: 'SPTAllocated',
+        },
+      ],
+    });
+
+    const importedAsset = {
+      assetGuid: '123',
+      balance: 0,
+      chainId: 57,
+      decimals: 2,
+      description: 'user metadata',
+      image: 'ipfs://token-image',
+      name: 'Imported name',
+      symbol: 'TOK',
+      type: 'SPTAllocated',
+    } as any;
+
+    const result = await SysAssetsController().getSysAssetsByXpub(
+      'zpub-account',
+      'https://blockbook.syscoin.org',
+      57,
+      [importedAsset]
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      assetGuid: '123',
+      balance: 2.5,
+      chainId: 57,
+      description: 'user metadata',
+      image: 'ipfs://token-image',
+    });
+  });
+
+  it('retains a zero-balance imported asset missing from Blockbook', async () => {
+    fetchBackendAccountCachedMock.mockResolvedValue({ tokensAsset: [] });
+    const importedAsset = {
+      assetGuid: '456',
+      balance: 9,
+      chainId: 5700,
+      decimals: 8,
+      description: 'durable metadata',
+      image: 'ipfs://durable-image',
+      name: 'Offline token',
+      symbol: 'OFF',
+      type: 'SPTAllocated',
+    } as any;
+
+    const result = await SysAssetsController().getSysAssetsByXpub(
+      'vpub-account',
+      'https://blockbook-dev.syscoin.org/',
+      5700,
+      [importedAsset]
+    );
+
+    expect(result[0]).toMatchObject({
+      assetGuid: '456',
+      balance: 0,
+      chainId: 5700,
+      description: 'durable metadata',
+      image: 'ipfs://durable-image',
+    });
+  });
+});

--- a/source/scripts/Background/controllers/assets/syscoin.ts
+++ b/source/scripts/Background/controllers/assets/syscoin.ts
@@ -13,7 +13,7 @@ import {
   MAX_TOKENS_DISPLAY,
 } from './constants';
 import { ISysAssetsController, ISysTokensAssetReponse } from './types';
-import { validateAndManageUserAssets, ensureTrailingSlash } from './utils';
+import { ensureTrailingSlash } from './utils';
 
 const SysAssetsControler = (): ISysAssetsController => {
   // Cache for Syscoin asset metadata
@@ -314,7 +314,8 @@ const SysAssetsControler = (): ISysAssetsController => {
   const getSysAssetsByXpub = async (
     xpubOrAddress: string,
     networkUrl: string,
-    networkChainId: number
+    networkChainId: number,
+    existingAssets: ITokenSysProps[] = []
   ): Promise<ISysTokensAssetReponse[]> => {
     // Refresh persisted/imported assets from all used SPT entries so zero-balance
     // tokens still keep their historical sent/received counters.
@@ -402,11 +403,6 @@ const SysAssetsControler = (): ISysAssetsController => {
       });
     });
 
-    // Get existing manually imported tokens from state
-    const { activeAccount, accountAssets } = store.getState().vault;
-    const existingAssets =
-      accountAssets[activeAccount.type]?.[activeAccount.id]?.syscoin || [];
-
     // Use aggregated tokens map for lookups
     const blockchainTokensMap = aggregatedTokensMap;
 
@@ -414,21 +410,26 @@ const SysAssetsControler = (): ISysAssetsController => {
     const updatedTokens: ISysTokensAssetReponse[] = existingAssets
       .filter((asset: ITokenSysProps) => asset.assetGuid !== undefined)
       .map((asset: ITokenSysProps) => {
-        const blockchainToken = blockchainTokensMap.get(asset.assetGuid!);
+        const blockchainToken = blockchainTokensMap.get(
+          String(asset.assetGuid)
+        );
 
         if (blockchainToken) {
-          // Token found in blockchain response - use aggregated data
-          return blockchainToken;
-        } else {
-          // Token not in blockchain response - set balance to 0
+          // Keep user-authored metadata while refreshing chain-derived values.
           return {
-            assetGuid: asset.assetGuid!,
+            ...asset,
+            ...blockchainToken,
+            assetGuid: String(asset.assetGuid),
+            chainId: networkChainId,
+          } as ISysTokensAssetReponse;
+        } else {
+          // Token not in the response still remains imported. Only its live
+          // balance/counters are reset; metadata must remain durable.
+          return {
+            ...asset,
+            assetGuid: String(asset.assetGuid),
             balance: 0,
             unconfirmedBalance: 0,
-            decimals: asset.decimals,
-            name: asset.name || asset.symbol,
-            path: '',
-            symbol: asset.symbol,
             totalReceived: '0',
             totalSent: '0',
             transfers: 0,
@@ -438,18 +439,10 @@ const SysAssetsControler = (): ISysAssetsController => {
         }
       });
 
-    const filteredAssetsLength = updatedTokens.slice(0, MAX_TOKENS_DISPLAY);
-
-    if (filteredAssetsLength && filteredAssetsLength.length > 0) {
-      const treatedAssets = validateAndManageUserAssets(
-        false,
-        filteredAssetsLength
-      ) as ISysTokensAssetReponse[];
-      // Syscoin 5 uses plain text symbols, no decoding needed
-      return treatedAssets;
-    }
-
-    return [];
+    // Return the explicit snapshot supplied by the caller. Reading the live
+    // active account here allowed a network/account switch during the request
+    // to rebuild one account's assets from another account's state.
+    return updatedTokens.slice(0, MAX_TOKENS_DISPLAY);
   };
 
   return {

--- a/source/scripts/Background/controllers/assets/types.ts
+++ b/source/scripts/Background/controllers/assets/types.ts
@@ -45,7 +45,8 @@ export interface ISysAssetsController {
   getSysAssetsByXpub: (
     xpub: string,
     networkUrl: string,
-    networkChainId: number
+    networkChainId: number,
+    existingAssets?: ITokenSysProps[]
   ) => Promise<ISysTokensAssetReponse[]>;
   getUserOwnedTokens: (xpub: string) => Promise<ISysTokensAssetReponse[]>;
   validateSPTOnly: (

--- a/source/scripts/Background/controllers/assets/utils.ts
+++ b/source/scripts/Background/controllers/assets/utils.ts
@@ -6,21 +6,67 @@ import sortBy from 'lodash/sortBy';
 import uniqWith from 'lodash/uniqWith';
 
 import store from 'state/store';
+import { IAccountAssets } from 'state/vault/types';
+import {
+  IKeyringAccountState,
+  INetwork,
+  KeyringAccountType,
+} from 'types/network';
 import { ITokenEthProps } from 'types/tokens';
 
 import { ISysTokensAssetReponse } from './types';
 
+export const canCommitAssetUpdate = ({
+  account,
+  activeAccount,
+  assets,
+  latestAccount,
+  latestActiveAccount,
+  latestAssets,
+  latestNetwork,
+  latestRequestId,
+  network,
+  requestId,
+}: {
+  account: IKeyringAccountState;
+  activeAccount: { id: number; type: KeyringAccountType };
+  assets: IAccountAssets;
+  latestAccount?: IKeyringAccountState;
+  latestActiveAccount: { id: number; type: KeyringAccountType };
+  latestAssets?: IAccountAssets;
+  latestNetwork: INetwork;
+  latestRequestId: number;
+  network: INetwork;
+  requestId: number;
+}): boolean =>
+  requestId === latestRequestId &&
+  latestNetwork.chainId === network.chainId &&
+  latestNetwork.kind === network.kind &&
+  latestNetwork.url === network.url &&
+  latestNetwork.slip44 === network.slip44 &&
+  latestActiveAccount.id === activeAccount.id &&
+  latestActiveAccount.type === activeAccount.type &&
+  latestAccount?.address === account.address &&
+  latestAccount?.xpub === account.xpub &&
+  // Redux/Immer preserves this nested reference until that account's asset
+  // state changes. This O(1) snapshot check catches imports/deletes without a
+  // second deep comparison on every polling cycle.
+  latestAssets === assets;
+
 export const validateAndManageUserAssets = (
   isForEvm: boolean,
-  fetchedAssetsOrTokens: ISysTokensAssetReponse[] | ITokenEthProps[]
+  fetchedAssetsOrTokens: ISysTokensAssetReponse[] | ITokenEthProps[],
+  currentAssets?: ISysTokensAssetReponse[] | ITokenEthProps[]
 ) => {
   if (fetchedAssetsOrTokens.length === 0) return [];
 
-  const { activeAccount, accountAssets } = store.getState().vault;
-
-  const assets = accountAssets[activeAccount.type]?.[activeAccount.id];
-
-  const assetsValueToUse = isForEvm ? assets?.ethereum : assets?.syscoin;
+  const assetsValueToUse =
+    currentAssets ||
+    (() => {
+      const { activeAccount, accountAssets } = store.getState().vault;
+      const assets = accountAssets[activeAccount.type]?.[activeAccount.id];
+      return isForEvm ? assets?.ethereum : assets?.syscoin;
+    })();
   const userClonedAssets = isForEvm
     ? (clone(compact(assetsValueToUse as ITokenEthProps[])) as ITokenEthProps[])
     : (clone(

--- a/source/state/vault/accountProvenance.spec.ts
+++ b/source/state/vault/accountProvenance.spec.ts
@@ -1,0 +1,62 @@
+import { INetworkType, KeyringAccountType } from 'types/network';
+
+import reducer, {
+  createAccount,
+  initializeCleanVaultForSlip44,
+  rehydrate,
+} from './index';
+
+const bitcoinNetwork = {
+  chainId: 0,
+  currency: 'btc',
+  kind: INetworkType.Syscoin,
+  label: 'Bitcoin',
+  slip44: 0,
+  url: 'https://btc1.trezor.io/',
+} as any;
+
+const account = {
+  address: 'bc1qaccount',
+  id: 0,
+  label: 'BTC 1',
+  xpub: 'zpub-bitcoin',
+} as any;
+
+describe('account slip44 provenance', () => {
+  it('stamps newly created accounts with their vault slip44', () => {
+    let state = reducer(
+      undefined,
+      initializeCleanVaultForSlip44(bitcoinNetwork)
+    );
+    state = reducer(
+      state,
+      createAccount({ account, accountType: KeyringAccountType.HDAccount })
+    );
+
+    expect(state.accounts.HDAccount[0].slip44).toBe(0);
+  });
+
+  it('migrates legacy accounts using their persisted vault network', () => {
+    let state = reducer(
+      undefined,
+      initializeCleanVaultForSlip44(bitcoinNetwork)
+    );
+    state = reducer(
+      state,
+      createAccount({ account, accountType: KeyringAccountType.HDAccount })
+    );
+    const legacyState = {
+      ...state,
+      accounts: {
+        ...state.accounts,
+        [KeyringAccountType.HDAccount]: {
+          0: { ...state.accounts.HDAccount[0], slip44: undefined },
+        },
+      },
+    };
+
+    const migratedState = reducer(state, rehydrate(legacyState));
+
+    expect(migratedState.accounts.HDAccount[0].slip44).toBe(0);
+  });
+});

--- a/source/state/vault/index.ts
+++ b/source/state/vault/index.ts
@@ -90,6 +90,17 @@ const ensureAccountTypeBuckets = (state: IVaultState) => {
       state.accountAssets[accountType] = {};
     if (!state.accountTransactions[accountType])
       state.accountTransactions[accountType] = {};
+
+    // Migrate older saved accounts in place. Each persisted vault belongs to
+    // exactly one slip44, so its accounts inherit that durable provenance.
+    Object.values(state.accounts[accountType]).forEach((account) => {
+      if (
+        account.slip44 === undefined &&
+        state.activeNetwork?.slip44 !== undefined
+      ) {
+        account.slip44 = state.activeNetwork.slip44;
+      }
+    });
   });
 
   return state;
@@ -248,6 +259,7 @@ const VaultState = createSlice({
       // Override the initial balances to -1 (indicating "no data")
       const accountWithInitialBalances = {
         ...account,
+        slip44: state.activeNetwork.slip44,
         balances: {
           [INetworkType.Syscoin]: -1,
           [INetworkType.Ethereum]: -1,

--- a/source/types/network.ts
+++ b/source/types/network.ts
@@ -232,6 +232,10 @@ export interface IKeyringAccountState {
   // Native balances are network-specific even though `balances` retains the
   // legacy active-chain shape used throughout the UI.
   nativeBalanceCache?: Record<string, INativeBalanceCacheEntry>;
+  // Accounts are derived inside a slip44-specific vault. Persist that origin so
+  // a delayed popup patch can never present (or select) an account from a
+  // different UTXO network merely because both use non-hex addresses.
+  slip44?: number;
   smartAccount?: ISmartAccountMetadata;
   // Per-chain last block scanned for ERC-4337 UserOperationEvent logs
   // (smart accounts only; chainId -> blockNumber)

--- a/source/utils/accountCompatibility.spec.ts
+++ b/source/utils/accountCompatibility.spec.ts
@@ -5,17 +5,32 @@ import { isAccountCompatibleWithNetwork } from './accountCompatibility';
 const evmNetwork = {
   chainId: 570,
   kind: INetworkType.Ethereum,
+  slip44: 60,
 } as INetwork;
 const utxoNetwork = {
   chainId: 5700,
   kind: INetworkType.Syscoin,
+  slip44: 1,
+} as INetwork;
+const syscoinMainnet = {
+  chainId: 57,
+  kind: INetworkType.Syscoin,
+  slip44: 57,
+} as INetwork;
+const bitcoinMainnet = {
+  chainId: 0,
+  kind: INetworkType.Syscoin,
+  slip44: 0,
 } as INetwork;
 
 describe('isAccountCompatibleWithNetwork', () => {
   const evmAccount = {
     address: '0x940000000000000000000000000000000000052e',
   } as any;
-  const utxoAccount = { address: 'tsys1qexampleaddress' } as any;
+  const utxoAccount = {
+    address: 'tsys1qexampleaddress',
+    slip44: 1,
+  } as any;
 
   it('keeps UTXO accounts out of EVM account selection', () => {
     expect(
@@ -76,6 +91,46 @@ describe('isAccountCompatibleWithNetwork', () => {
         smartAccount,
         KeyringAccountType.SmartAccount,
         utxoNetwork
+      )
+    ).toBe(false);
+  });
+
+  it('keeps accounts isolated between exact UTXO networks', () => {
+    const syscoinAccount = {
+      address: 'sys1qexampleaddress',
+      slip44: 57,
+    } as any;
+    const bitcoinAccount = {
+      address: 'bc1qexampleaddress',
+      slip44: 0,
+    } as any;
+
+    expect(
+      isAccountCompatibleWithNetwork(
+        syscoinAccount,
+        KeyringAccountType.HDAccount,
+        syscoinMainnet
+      )
+    ).toBe(true);
+    expect(
+      isAccountCompatibleWithNetwork(
+        bitcoinAccount,
+        KeyringAccountType.HDAccount,
+        syscoinMainnet
+      )
+    ).toBe(false);
+    expect(
+      isAccountCompatibleWithNetwork(
+        bitcoinAccount,
+        KeyringAccountType.HDAccount,
+        bitcoinMainnet
+      )
+    ).toBe(true);
+    expect(
+      isAccountCompatibleWithNetwork(
+        syscoinAccount,
+        KeyringAccountType.HDAccount,
+        bitcoinMainnet
       )
     ).toBe(false);
   });

--- a/source/utils/accountCompatibility.ts
+++ b/source/utils/accountCompatibility.ts
@@ -7,7 +7,7 @@ import {
 import { isHexString } from 'utils/ethersV6Compat';
 
 type AccountForCompatibility = Pick<IKeyringAccountState, 'address'> &
-  Partial<Pick<IKeyringAccountState, 'smartAccount'>>;
+  Partial<Pick<IKeyringAccountState, 'slip44' | 'smartAccount'>>;
 
 /**
  * Account buckets can briefly be delivered separately from the active network
@@ -32,7 +32,16 @@ export const isAccountCompatibleWithNetwork = (
     return false;
   }
 
-  return network.kind === INetworkType.Syscoin
-    ? !isHexString(account.address)
-    : isHexString(account.address);
+  if (network.kind === INetworkType.Syscoin) {
+    if (isHexString(account.address)) return false;
+
+    // UTXO accounts are not interchangeable: a Bitcoin account (slip44 0)
+    // must not appear on Syscoin (slip44 57), for example. Address-family-only
+    // filtering cannot distinguish those networks.
+    return account.slip44 === undefined
+      ? true
+      : Number(account.slip44) === Number(network.slip44);
+  }
+
+  return isHexString(account.address);
 };


### PR DESCRIPTION
## What changed

- Prevent stale asset refreshes from overwriting ERC-20, NFT, or SPT imports made while an RPC request is in flight.
- Invalidate refresh writebacks across account changes and A → B → A network round trips.
- Refresh Syscoin assets from the captured account snapshot instead of whichever account is globally active when Blockbook returns.
- Preserve imported SPT metadata and zero-balance assets.
- Persist and enforce exact slip44 account provenance so Bitcoin accounts cannot appear or be selected on Syscoin UTXO networks.
- Bump the release version to 4.0.54.

## Root cause

Asset refreshes captured an older asset array, performed asynchronous network work, then replaced the account array without checking whether the user had imported or deleted an asset in the meantime. The Syscoin refresher also re-read live global account state after its request. Account compatibility only distinguished hex EVM addresses from non-hex UTXO addresses, so it treated BTC and SYS accounts as compatible.

## Impact

Imported assets now survive network switches for both EVM and UTXO accounts. Stale background work is discarded with O(1) request/reference checks, and UTXO account menus are isolated by exact slip44.

## Validation

- 50 unit suites passed (319 tests)
- TypeScript type-check passed
- ESLint passed with only one pre-existing naming warning
- i18n consistency passed
- Production Chrome build succeeded and emitted `pali-wallet-production-chrome-4.0.54.zip`