### PR TITLE
Publish vault state only after network switch commit

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Pali Wallet",
-  "version": "4.0.55",
+  "version": "4.0.56",
   "icons": {
     "16": "assets/all_assets/favicon-16.png",
     "32": "assets/all_assets/favicon-32.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paliwallet",
-  "version": "4.0.55",
+  "version": "4.0.56",
   "description": "A Non-Custodial Crypto Wallet",
   "private": true,
   "repository": {

--- a/source/config/consts.js
+++ b/source/config/consts.js
@@ -80,7 +80,7 @@ const CANARY_EXTENSION_KEY =
 const MV3_OPTIONS = {
   manifest_version: 3,
   name: 'Pali Wallet',
-  version: '4.0.55',
+  version: '4.0.56',
   icons: {
     16: 'assets/all_assets/favicon-16.png',
     32: 'assets/all_assets/favicon-32.png',

--- a/source/routers/useRouterLogic.ts
+++ b/source/routers/useRouterLogic.ts
@@ -9,12 +9,16 @@ import { rehydrate as dappRehydrate } from 'state/dapp';
 import { rehydrateStore } from 'state/rehydrate';
 import store, { RootState } from 'state/store';
 import {
+  rehydrate as vaultRehydrate,
   setAccounts,
   setActiveAccount,
   setAccountBalanceSnapshot,
-  setNetworkChange,
 } from 'state/vault';
-import { setNetworkRuntimeState, setNetworkStatus } from 'state/vaultGlobal';
+import {
+  setActiveSlip44,
+  setNetworkRuntimeState,
+  setNetworkStatus,
+} from 'state/vaultGlobal';
 import { SYSCOIN_UTXO_MAINNET_NETWORK } from 'utils/constants';
 import { loadNavigationState } from 'utils/navigationState';
 
@@ -181,13 +185,8 @@ export const useRouterLogic = () => {
       }
 
       if (message.type === 'CONTROLLER_NETWORK_CHANGE' && message.data) {
-        if (message.data.accounts) {
-          store.dispatch(setAccounts(message.data.accounts));
-        }
-        store.dispatch(setActiveAccount(message.data.activeAccount));
-        store.dispatch(
-          setNetworkChange({ activeNetwork: message.data.activeNetwork })
-        );
+        store.dispatch(vaultRehydrate(message.data.vault));
+        store.dispatch(setActiveSlip44(message.data.activeSlip44));
         store.dispatch(setNetworkStatus(message.data.networkStatus));
         return true;
       }

--- a/source/scripts/Background/controllers/DAppController.spec.ts
+++ b/source/scripts/Background/controllers/DAppController.spec.ts
@@ -1,0 +1,104 @@
+const dispatchMock = jest.fn();
+const getStateMock = jest.fn();
+const saveMainStateMock = jest.fn();
+
+jest.mock('state/store', () => ({
+  __esModule: true,
+  default: {
+    dispatch: (...args: any[]) => dispatchMock(...args),
+    getState: () => getStateMock(),
+  },
+  saveMainState: (...args: any[]) => saveMainStateMock(...args),
+}));
+
+jest.mock('../notification-manager', () => ({
+  notificationManager: {
+    notifyDappConnection: jest.fn(),
+  },
+}));
+
+jest.mock('./message-handler/provider-cache', () => ({
+  clearProviderCache: jest.fn(),
+}));
+
+import { KeyringAccountType } from 'types/network';
+
+import DAppController from './DAppController';
+import { clearProviderCache } from './message-handler/provider-cache';
+
+describe('DAppController account changes', () => {
+  const account = {
+    address: '0x2222222222222222222222222222222222222222',
+    id: 1,
+    xpub: 'connected-xpub',
+  };
+  const host = 'connected.example';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (chrome.runtime as any).id = 'test-extension';
+    (chrome as any).tabs = {
+      query: jest.fn((_query, callback) => callback([])),
+    };
+    (chrome as any).scripting = { executeScript: jest.fn() };
+    saveMainStateMock.mockResolvedValue(undefined);
+    getStateMock.mockReturnValue({
+      dapp: {
+        dapps: {
+          [host]: {
+            accountId: 0,
+            accountType: KeyringAccountType.HDAccount,
+            host,
+          },
+        },
+      },
+      vault: {
+        accounts: {
+          [KeyringAccountType.HDAccount]: { 1: account },
+        },
+        isBitcoinBased: false,
+      },
+    });
+  });
+
+  it('clears cached provider accounts when the persisted connection changes', async () => {
+    const controller = DAppController();
+
+    await controller.changeAccount(
+      host,
+      account.id,
+      KeyringAccountType.HDAccount
+    );
+
+    expect(dispatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          accountId: account.id,
+          accountType: KeyringAccountType.HDAccount,
+          host,
+        }),
+        type: 'dapp/updateDAppAccount',
+      })
+    );
+    expect(clearProviderCache).toHaveBeenCalledTimes(1);
+    expect(saveMainStateMock).toHaveBeenCalledTimes(1);
+    expect(dispatchMock.mock.invocationCallOrder[0]).toBeLessThan(
+      (clearProviderCache as jest.Mock).mock.invocationCallOrder[0]
+    );
+    expect(
+      (clearProviderCache as jest.Mock).mock.invocationCallOrder[0]
+    ).toBeLessThan(saveMainStateMock.mock.invocationCallOrder[0]);
+  });
+
+  it('does not clear the cache when the requested account does not exist', async () => {
+    const controller = DAppController();
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    await controller.changeAccount(host, 99, KeyringAccountType.HDAccount);
+
+    expect(dispatchMock).not.toHaveBeenCalled();
+    expect(clearProviderCache).not.toHaveBeenCalled();
+    expect(saveMainStateMock).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});

--- a/source/scripts/Background/controllers/DAppController.ts
+++ b/source/scripts/Background/controllers/DAppController.ts
@@ -9,6 +9,7 @@ import { IDAppController } from 'types/controllers';
 import { KeyringAccountType } from 'types/network';
 import { removeSensitiveDataFromVault, removeXprv } from 'utils/account';
 
+import { clearProviderCache } from './message-handler/provider-cache';
 import { PaliEvents, PaliSyscoinEvents } from './message-handler/types';
 
 interface IDappsSession {
@@ -250,6 +251,10 @@ const DAppController = (): IDAppController => {
     }
 
     store.dispatch(updateDAppAccount({ host, accountId, date, accountType }));
+    // The connection is already changed in Redux at this point. Invalidate
+    // eth_accounts/provider-state responses before persistence or event
+    // delivery can overlap another request from this host.
+    clearProviderCache();
     await persistDappState('dapp account change');
     _dapps[host].activeAddress = isBitcoinBased
       ? account.xpub

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -36,6 +36,7 @@ import store from 'state/store';
 import {
   loadAndActivateSlip44Vault,
   persistCommittedWalletState,
+  restoreSourceVaultAfterUncommittedSwitch,
   saveMainState,
 } from 'state/store';
 import {
@@ -54,7 +55,7 @@ import {
   setAccountAssets,
   setAccountTransactions,
 } from 'state/vault';
-import { TransactionsType } from 'state/vault/types';
+import { IVaultState, TransactionsType } from 'state/vault/types';
 import vaultCache, {
   getSlip44ForNetwork,
   DEFAULT_EVM_SLIP44,
@@ -813,7 +814,7 @@ class MainController {
 
     // Create a state transaction to ensure atomic updates
     const stateTransaction: {
-      deferredSaveData: { slip44: number; vaultState: any } | null;
+      deferredSaveData: { slip44: number; vaultState: IVaultState } | null;
       needsSessionTransfer: boolean;
       sourceKeyring: KeyringManager | null;
       sourceSlip44: number | null;
@@ -1075,6 +1076,19 @@ class MainController {
         }
       }
     } catch (error) {
+      const sourceVault = stateTransaction.deferredSaveData;
+      if (
+        isSwitchingSlip44 &&
+        sourceVault &&
+        restoreSourceVaultAfterUncommittedSwitch(
+          sourceVault.slip44,
+          sourceVault.vaultState
+        )
+      ) {
+        console.warn(
+          `[MainController] Restored source vault for slip44 ${sourceVault.slip44} after the target switch failed before commit`
+        );
+      }
       console.error('[MainController] Error in switchActiveKeyring:', error);
       throw error;
     }
@@ -1806,7 +1820,7 @@ class MainController {
   // Perform deferred vault save in background (non-blocking)
   private performDeferredVaultSave(deferredSaveData: {
     slip44: number;
-    vaultState: any;
+    vaultState: IVaultState;
   }) {
     // Enqueue immediately so a later switch back to this slip44 cannot commit
     // first and then be overwritten by this older snapshot. The promise remains
@@ -6154,6 +6168,7 @@ class MainController {
   }
   private handleNetworkChangeError = (reason: any) => {
     const { activeNetwork } = store.getState().vault;
+    const { networkTarget } = store.getState().vaultGlobal;
 
     console.error('Network change error:', reason);
     console.error('Error type:', typeof reason);
@@ -6182,7 +6197,9 @@ class MainController {
       return;
     }
 
-    let errorMessage = `Failed to switch to ${activeNetwork.label}`;
+    let errorMessage = `Failed to switch to ${
+      networkTarget?.label || activeNetwork.label
+    }`;
 
     // Try to extract the actual error message from various error structures
     if (reason) {

--- a/source/scripts/Background/controllers/message-handler/method-handlers.ts
+++ b/source/scripts/Background/controllers/message-handler/method-handlers.ts
@@ -9,6 +9,7 @@ import { isHexString } from 'utils/ethersV6Compat';
 import { networkChain } from 'utils/network';
 
 import { popupPromise } from './popup-promise';
+import { executeMethodWithCache } from './provider-cache';
 import { requestCoordinator } from './request-pipeline';
 import {
   generateWalletBundleId,
@@ -19,82 +20,15 @@ import {
 } from './sendCallsBundles';
 import { IEnhancedRequestContext, MethodHandlerType } from './types';
 
-// Cache for provider state methods. Host scoping prevents data crossing site
-// boundaries; the size cap prevents hostile sites from growing it without
-// bound by issuing requests from many subdomains.
-export const MAX_PROVIDER_CACHE_ENTRIES = 100;
-
-interface IProviderStateCacheEntry {
-  expiresAt: number;
-  value: any;
-}
-
-const providerStateCache = new Map<string, IProviderStateCacheEntry>();
-
-const pruneProviderCache = (now: number) => {
-  for (const [key, cached] of providerStateCache) {
-    if (cached.expiresAt <= now) {
-      providerStateCache.delete(key);
-    }
-  }
-};
-
-// Clear cache function
-export function clearProviderCache() {
-  providerStateCache.clear();
-}
+export {
+  clearProviderCache,
+  MAX_PROVIDER_CACHE_ENTRIES,
+} from './provider-cache';
 
 // Base interface for method handlers
 export interface IMethodHandler {
   canHandle(context: IEnhancedRequestContext): boolean;
   handle(context: IEnhancedRequestContext): Promise<any>;
-}
-
-// Generic method executor that uses registry configuration
-async function executeMethodWithCache(
-  context: IEnhancedRequestContext,
-  executor: () => Promise<any>
-): Promise<any> {
-  const { methodConfig } = context;
-
-  // Check if method has caching enabled
-  if (methodConfig.cacheKey && methodConfig.cacheTTL) {
-    const now = Date.now();
-    pruneProviderCache(now);
-    // Provider responses can contain origin-specific account data. Keep every
-    // cache entry scoped to the requesting host so a connected site's result
-    // can never be reused for another site.
-    const originCacheKey = JSON.stringify([
-      methodConfig.cacheKey,
-      context.originalRequest.host,
-    ]);
-    const cached = providerStateCache.get(originCacheKey);
-
-    if (cached) {
-      // Refresh insertion order so the Map also acts as an LRU queue.
-      providerStateCache.delete(originCacheKey);
-      providerStateCache.set(originCacheKey, cached);
-      return cached.value;
-    }
-
-    // Execute and cache the result
-    const result = await executor();
-    const completedAt = Date.now();
-    pruneProviderCache(completedAt);
-    while (providerStateCache.size >= MAX_PROVIDER_CACHE_ENTRIES) {
-      const oldestKey = providerStateCache.keys().next().value;
-      if (oldestKey === undefined) break;
-      providerStateCache.delete(oldestKey);
-    }
-    providerStateCache.set(originCacheKey, {
-      expiresAt: completedAt + methodConfig.cacheTTL,
-      value: result,
-    });
-    return result;
-  }
-
-  // No caching, just execute
-  return executor();
 }
 
 // Check if method requires active account

--- a/source/scripts/Background/controllers/message-handler/provider-cache.ts
+++ b/source/scripts/Background/controllers/message-handler/provider-cache.ts
@@ -1,0 +1,65 @@
+import type { IEnhancedRequestContext } from './types';
+
+// Provider responses can contain origin-specific account data. Host scoping
+// prevents data crossing site boundaries, and the size cap prevents hostile
+// sites from growing the cache without bound through many subdomains.
+export const MAX_PROVIDER_CACHE_ENTRIES = 100;
+
+interface IProviderStateCacheEntry {
+  expiresAt: number;
+  value: any;
+}
+
+const providerStateCache = new Map<string, IProviderStateCacheEntry>();
+
+const pruneProviderCache = (now: number) => {
+  for (const [key, cached] of providerStateCache) {
+    if (cached.expiresAt <= now) {
+      providerStateCache.delete(key);
+    }
+  }
+};
+
+export const clearProviderCache = () => {
+  providerStateCache.clear();
+};
+
+export async function executeMethodWithCache(
+  context: IEnhancedRequestContext,
+  executor: () => Promise<any>
+): Promise<any> {
+  const { methodConfig } = context;
+
+  if (methodConfig.cacheKey && methodConfig.cacheTTL) {
+    const now = Date.now();
+    pruneProviderCache(now);
+    const originCacheKey = JSON.stringify([
+      methodConfig.cacheKey,
+      context.originalRequest.host,
+    ]);
+    const cached = providerStateCache.get(originCacheKey);
+
+    if (cached) {
+      // Refresh insertion order so the Map also acts as an LRU queue.
+      providerStateCache.delete(originCacheKey);
+      providerStateCache.set(originCacheKey, cached);
+      return cached.value;
+    }
+
+    const result = await executor();
+    const completedAt = Date.now();
+    pruneProviderCache(completedAt);
+    while (providerStateCache.size >= MAX_PROVIDER_CACHE_ENTRIES) {
+      const oldestKey = providerStateCache.keys().next().value;
+      if (oldestKey === undefined) break;
+      providerStateCache.delete(oldestKey);
+    }
+    providerStateCache.set(originCacheKey, {
+      expiresAt: completedAt + methodConfig.cacheTTL,
+      value: result,
+    });
+    return result;
+  }
+
+  return executor();
+}

--- a/source/scripts/Background/controllers/message-handler/request-pipeline.account-switching.spec.ts
+++ b/source/scripts/Background/controllers/message-handler/request-pipeline.account-switching.spec.ts
@@ -22,7 +22,6 @@ jest.mock('./method-handlers', () => ({
 import { getController } from 'scripts/Background';
 import { KeyringAccountType } from 'types/network';
 
-import { clearProviderCache } from './method-handlers';
 import {
   accountSwitchingMiddleware,
   requestCoordinator,
@@ -105,7 +104,6 @@ describe('accountSwitchingMiddleware site-level account selection', () => {
       accountB.id,
       KeyringAccountType.Imported
     );
-    expect(clearProviderCache).toHaveBeenCalledTimes(1);
     expect(next).toHaveBeenCalledTimes(1);
   });
 
@@ -134,7 +132,6 @@ describe('accountSwitchingMiddleware site-level account selection', () => {
       accountB.id,
       KeyringAccountType.Imported
     );
-    expect(clearProviderCache).toHaveBeenCalledTimes(1);
     expect(next).toHaveBeenCalledTimes(1);
   });
 
@@ -164,7 +161,6 @@ describe('accountSwitchingMiddleware site-level account selection', () => {
       accountB.id,
       KeyringAccountType.Imported
     );
-    expect(clearProviderCache).toHaveBeenCalledTimes(1);
     expect(next).toHaveBeenCalledTimes(1);
     expect(changeAccount.mock.invocationCallOrder[0]).toBeLessThan(
       next.mock.invocationCallOrder[0]
@@ -197,7 +193,6 @@ describe('accountSwitchingMiddleware site-level account selection', () => {
 
     expect(popupSpy).toHaveBeenCalledTimes(1);
     expect(changeAccount).not.toHaveBeenCalled();
-    expect(clearProviderCache).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalledTimes(1);
   });
 
@@ -221,7 +216,6 @@ describe('accountSwitchingMiddleware site-level account selection', () => {
     ).rejects.toMatchObject({ code: 4100 });
 
     expect(changeAccount).not.toHaveBeenCalled();
-    expect(clearProviderCache).not.toHaveBeenCalled();
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -245,7 +239,6 @@ describe('accountSwitchingMiddleware site-level account selection', () => {
     ).rejects.toMatchObject({ code: 4100 });
 
     expect(changeAccount).not.toHaveBeenCalled();
-    expect(clearProviderCache).not.toHaveBeenCalled();
     expect(next).not.toHaveBeenCalled();
   });
 });

--- a/source/scripts/Background/controllers/message-handler/request-pipeline.ts
+++ b/source/scripts/Background/controllers/message-handler/request-pipeline.ts
@@ -868,7 +868,6 @@ const syncDappAccountAfterSelection = async (
   }
 
   await dapp.changeAccount(host, targetAccount.id, targetAccountType);
-  clearProviderCache();
 };
 
 // Middleware: Account Switching for Blocking Methods

--- a/source/scripts/Background/handlers/handleStateChanges.spec.ts
+++ b/source/scripts/Background/handlers/handleStateChanges.spec.ts
@@ -1,18 +1,34 @@
+import { setPrices } from 'state/price';
 import store from 'state/store';
+import { setNetworkChange } from 'state/vault';
+import {
+  setActiveSlip44,
+  startSwitchNetwork,
+  switchNetworkSuccess,
+} from 'state/vaultGlobal';
 import { INetworkType, KeyringAccountType } from 'types/network';
 
 import {
+  handleObserveStateChanges,
   isHotPathOnlyChange,
   isNetworkSwitchInProgress,
   sendFastStatePatches,
 } from './handleStateChanges';
 
 describe('network state patches', () => {
+  let unsubscribeStateChanges: (() => void) | undefined;
+
   beforeEach(() => {
     (chrome.runtime.sendMessage as jest.Mock).mockClear();
   });
 
-  it('withholds an intermediate vault and publishes it on commit', () => {
+  afterEach(() => {
+    unsubscribeStateChanges?.();
+    unsubscribeStateChanges = undefined;
+    jest.useRealTimers();
+  });
+
+  it('withholds an intermediate vault and publishes it on terminal alignment', () => {
     const initialState = store.getState();
     const previousState = {
       ...initialState,
@@ -109,6 +125,33 @@ describe('network state patches', () => {
     expect(isNetworkSwitchInProgress(keyringCommittedState)).toBe(true);
     expect(chrome.runtime.sendMessage).not.toHaveBeenCalled();
 
+    const failedState = {
+      ...keyringCommittedState,
+      vaultGlobal: {
+        ...keyringCommittedState.vaultGlobal,
+        networkStatus: 'error' as const,
+      },
+    };
+    const failureSentPatch = sendFastStatePatches(
+      keyringCommittedState,
+      failedState
+    );
+    const failureMessages = (
+      chrome.runtime.sendMessage as jest.Mock
+    ).mock.calls.map(([message]) => message);
+    const failureNetworkMessage = failureMessages.find(
+      (message) => message.type === 'CONTROLLER_NETWORK_CHANGE'
+    );
+
+    expect(isNetworkSwitchInProgress(failedState)).toBe(false);
+    expect(failureNetworkMessage.data.activeSlip44).toBe(60);
+    expect(failureNetworkMessage.data.vault).toBe(targetVault);
+    expect(failureNetworkMessage.data.networkStatus).toBe('error');
+    expect(
+      isHotPathOnlyChange(keyringCommittedState, failedState, failureSentPatch)
+    ).toBe(true);
+
+    (chrome.runtime.sendMessage as jest.Mock).mockClear();
     const committedState = {
       ...keyringCommittedState,
       vaultGlobal: {
@@ -144,5 +187,68 @@ describe('network state patches', () => {
     expect(
       isHotPathOnlyChange(keyringCommittedState, committedState, sentPatch)
     ).toBe(true);
+  });
+
+  it('keeps a switch-only vault hydration on the patch fast path', () => {
+    jest.useFakeTimers();
+    unsubscribeStateChanges = handleObserveStateChanges();
+    const currentVault = store.getState().vault;
+    const targetSlip44 = currentVault.activeNetwork.slip44 === 60 ? 57 : 60;
+    const targetNetwork = {
+      ...currentVault.activeNetwork,
+      chainId: Number(currentVault.activeNetwork.chainId) + 1,
+      slip44: targetSlip44,
+      url: 'https://target-switch.example',
+    };
+
+    store.dispatch(startSwitchNetwork(targetNetwork));
+    store.dispatch(setNetworkChange({ activeNetwork: targetNetwork }));
+    store.dispatch(setActiveSlip44(targetSlip44));
+    store.dispatch(switchNetworkSuccess());
+    jest.runOnlyPendingTimers();
+
+    const messages = (chrome.runtime.sendMessage as jest.Mock).mock.calls.map(
+      ([message]) => message
+    );
+    expect(
+      messages.some((message) => message.type === 'CONTROLLER_NETWORK_CHANGE')
+    ).toBe(true);
+    expect(
+      messages.some((message) => message.type === 'CONTROLLER_STATE_CHANGE')
+    ).toBe(false);
+  });
+
+  it('delivers non-patchable updates deferred during a network switch', () => {
+    jest.useFakeTimers();
+    unsubscribeStateChanges = handleObserveStateChanges();
+    const targetNetwork = store.getState().vault.activeNetwork;
+
+    store.dispatch(startSwitchNetwork(targetNetwork));
+    store.dispatch(
+      setPrices({
+        asset: 'usd',
+        price: 123,
+      })
+    );
+
+    expect(
+      (chrome.runtime.sendMessage as jest.Mock).mock.calls.some(
+        ([message]) => message.type === 'CONTROLLER_STATE_CHANGE'
+      )
+    ).toBe(false);
+
+    store.dispatch(switchNetworkSuccess());
+    jest.runOnlyPendingTimers();
+
+    const fullStateMessage = (
+      chrome.runtime.sendMessage as jest.Mock
+    ).mock.calls.find(
+      ([message]) => message.type === 'CONTROLLER_STATE_CHANGE'
+    )?.[0];
+
+    expect(fullStateMessage.data.price.fiat).toEqual({
+      asset: 'usd',
+      price: 123,
+    });
   });
 });

--- a/source/scripts/Background/handlers/handleStateChanges.spec.ts
+++ b/source/scripts/Background/handlers/handleStateChanges.spec.ts
@@ -1,15 +1,27 @@
 import store from 'state/store';
 import { INetworkType, KeyringAccountType } from 'types/network';
 
-import { sendFastStatePatches } from './handleStateChanges';
+import {
+  isHotPathOnlyChange,
+  isNetworkSwitchInProgress,
+  sendFastStatePatches,
+} from './handleStateChanges';
 
 describe('network state patches', () => {
   beforeEach(() => {
     (chrome.runtime.sendMessage as jest.Mock).mockClear();
   });
 
-  it('delivers a new network and its account buckets atomically', () => {
-    const previousState = store.getState();
+  it('withholds an intermediate vault and publishes it on commit', () => {
+    const initialState = store.getState();
+    const previousState = {
+      ...initialState,
+      vaultGlobal: {
+        ...initialState.vaultGlobal,
+        activeSlip44: initialState.vault.activeNetwork.slip44,
+        networkStatus: 'idle' as const,
+      },
+    };
     const accounts = {
       ...previousState.vault.accounts,
       [KeyringAccountType.HDAccount]: {
@@ -19,35 +31,118 @@ describe('network state patches', () => {
         },
       },
     };
-    const nextState = {
-      ...previousState,
-      vault: {
-        ...previousState.vault,
-        accounts,
-        activeChain: INetworkType.Ethereum,
-        activeNetwork: {
-          ...previousState.vault.activeNetwork,
-          chainId: 570,
-          kind: INetworkType.Ethereum,
-          slip44: 60,
-          url: 'https://rpc.rollux.com',
+    const accountAssets = {
+      ...previousState.vault.accountAssets,
+      [KeyringAccountType.HDAccount]: {
+        0: {
+          ethereum: [
+            {
+              balance: 0,
+              chainId: 570,
+              contractAddress: '0x0000000000000000000000000000000000000001',
+              decimals: 18,
+              isNft: false,
+              tokenSymbol: 'TEST',
+            },
+          ],
+          syscoin: [],
         },
-        isBitcoinBased: false,
+      },
+    };
+    const accountTransactions = {
+      ...previousState.vault.accountTransactions,
+      [KeyringAccountType.HDAccount]: {
+        0: { ethereum: { 570: [] }, syscoin: {} },
+      },
+    };
+    const targetVault = {
+      ...previousState.vault,
+      accountAssets,
+      accountTransactions,
+      accounts,
+      activeChain: INetworkType.Ethereum,
+      activeNetwork: {
+        ...previousState.vault.activeNetwork,
+        chainId: 570,
+        kind: INetworkType.Ethereum,
+        slip44: 60,
+        url: 'https://rpc.rollux.com',
+      },
+      isBitcoinBased: false,
+    };
+    const switchingState = {
+      ...previousState,
+      vault: targetVault,
+      vaultGlobal: {
+        ...previousState.vaultGlobal,
+        networkStatus: 'switching' as const,
+        networkTarget: targetVault.activeNetwork,
       },
     };
 
-    sendFastStatePatches(previousState, nextState);
+    sendFastStatePatches(previousState, switchingState);
 
-    const messages = (chrome.runtime.sendMessage as jest.Mock).mock.calls.map(
-      ([message]) => message
+    const switchingMessages = (
+      chrome.runtime.sendMessage as jest.Mock
+    ).mock.calls.map(([message]) => message);
+    expect(isNetworkSwitchInProgress(switchingState)).toBe(true);
+    expect(
+      switchingMessages.some(
+        (message) => message.type === 'CONTROLLER_NETWORK_CHANGE'
+      )
+    ).toBe(false);
+    expect(
+      switchingMessages.some(
+        (message) => message.type === 'CONTROLLER_ACCOUNTS_CHANGE'
+      )
+    ).toBe(false);
+
+    (chrome.runtime.sendMessage as jest.Mock).mockClear();
+    const keyringCommittedState = {
+      ...switchingState,
+      vaultGlobal: {
+        ...switchingState.vaultGlobal,
+        activeSlip44: 60,
+      },
+    };
+    sendFastStatePatches(switchingState, keyringCommittedState);
+    expect(isNetworkSwitchInProgress(keyringCommittedState)).toBe(true);
+    expect(chrome.runtime.sendMessage).not.toHaveBeenCalled();
+
+    const committedState = {
+      ...keyringCommittedState,
+      vaultGlobal: {
+        ...keyringCommittedState.vaultGlobal,
+        networkStatus: 'idle' as const,
+        networkTarget: undefined,
+      },
+    };
+    const sentPatch = sendFastStatePatches(
+      keyringCommittedState,
+      committedState
     );
-    const networkMessage = messages.find(
+    const committedMessages = (
+      chrome.runtime.sendMessage as jest.Mock
+    ).mock.calls.map(([message]) => message);
+    const networkMessage = committedMessages.find(
       (message) => message.type === 'CONTROLLER_NETWORK_CHANGE'
     );
 
-    expect(networkMessage.data.accounts).toBe(accounts);
+    expect(isNetworkSwitchInProgress(committedState)).toBe(false);
+    expect(networkMessage.data.activeSlip44).toBe(60);
+    expect(networkMessage.data.vault).toBe(targetVault);
+    expect(networkMessage.data.vault.accounts).toBe(accounts);
+    expect(networkMessage.data.vault.accountAssets).toBe(accountAssets);
+    expect(networkMessage.data.vault.accountTransactions).toBe(
+      accountTransactions
+    );
     expect(
-      messages.some((message) => message.type === 'CONTROLLER_ACCOUNTS_CHANGE')
+      committedMessages.some(
+        (message) => message.type === 'CONTROLLER_ACCOUNTS_CHANGE'
+      )
     ).toBe(false);
+    expect(
+      isHotPathOnlyChange(keyringCommittedState, committedState, sentPatch)
+    ).toBe(true);
   });
 });

--- a/source/scripts/Background/handlers/handleStateChanges.ts
+++ b/source/scripts/Background/handlers/handleStateChanges.ts
@@ -3,6 +3,7 @@ import store from 'state/store';
 let currentState = store.getState();
 let pendingState: typeof currentState | null = null;
 let stateBroadcastTimeout: ReturnType<typeof setTimeout> | null = null;
+let deferredFullStateBroadcast = false;
 
 const STATE_BROADCAST_DEBOUNCE_MS = 50;
 
@@ -150,13 +151,36 @@ export const isNetworkSwitchInProgress = (state: typeof currentState) => {
   );
 };
 
-const didCommitNetworkSwitch = (
+const didFinishAlignedNetworkSwitch = (
   previousState: typeof currentState,
   nextState: typeof currentState
 ) =>
   previousState.vaultGlobal.networkStatus === 'switching' &&
-  nextState.vaultGlobal.networkStatus === 'idle' &&
+  (nextState.vaultGlobal.networkStatus === 'idle' ||
+    nextState.vaultGlobal.networkStatus === 'error') &&
   !isNetworkSwitchInProgress(nextState);
+
+const hasUnpatchedNonVaultChange = (
+  previousState: typeof currentState,
+  nextState: typeof currentState
+) =>
+  // Dapp has its own full-slice patch. The target vault and active slip44 are
+  // published together on an aligned terminal transition, so only other root
+  // slices need deferring.
+  !shallowEqualExcept(previousState, nextState, [
+    'dapp',
+    'vault',
+    'vaultGlobal',
+  ]) ||
+  !shallowEqualExcept(previousState.vaultGlobal, nextState.vaultGlobal, [
+    'activeSlip44',
+    'isPollingUpdate',
+    'isSwitchingAccount',
+    'isPostNetworkSwitchLoading',
+    'networkQuality',
+    'networkStatus',
+    'networkTarget',
+  ]);
 
 export const sendFastStatePatches = (
   previousState: typeof currentState,
@@ -178,13 +202,13 @@ export const sendFastStatePatches = (
     previousNetwork.url !== nextNetwork.url ||
     previousNetwork.kind !== nextNetwork.kind ||
     previousNetwork.slip44 !== nextNetwork.slip44;
-  const networkSwitchCommitted = didCommitNetworkSwitch(
+  const networkSwitchFinished = didFinishAlignedNetworkSwitch(
     previousState,
     nextState
   );
   const canPublishVault = !isNetworkSwitchInProgress(nextState);
   const publishedVault =
-    canPublishVault && (networkChanged || networkSwitchCommitted);
+    canPublishVault && (networkChanged || networkSwitchFinished);
 
   if (publishedVault) {
     sendRuntimeMessage({
@@ -323,7 +347,7 @@ export const isHotPathOnlyChange = (
   const previousNetwork = previousState.vault.activeNetwork;
   const nextNetwork = nextState.vault.activeNetwork;
   const entireVaultWasPatched =
-    didCommitNetworkSwitch(previousState, nextState) ||
+    didFinishAlignedNetworkSwitch(previousState, nextState) ||
     previousNetwork.chainId !== nextNetwork.chainId ||
     previousNetwork.url !== nextNetwork.url ||
     previousNetwork.kind !== nextNetwork.kind ||
@@ -336,7 +360,7 @@ export const isHotPathOnlyChange = (
 };
 
 export function handleObserveStateChanges() {
-  store.subscribe(() => {
+  return store.subscribe(() => {
     const nextState = store.getState();
     // Use simple reference equality - Redux creates new state objects on changes
     // This is much more efficient than JSON.stringify comparison
@@ -348,10 +372,27 @@ export function handleObserveStateChanges() {
       // keyring and persistence pointer are not committed until the switch
       // succeeds, so never expose this state to the popup.
       if (isNetworkSwitchInProgress(nextState)) {
+        // A full-state update that was already queued, or a non-patchable
+        // update received during the switch, must be delivered once the vault
+        // is safe to publish. Keep only this flag: pendingState itself may
+        // contain an intermediate vault and must not escape to the popup.
+        deferredFullStateBroadcast ||= Boolean(
+          pendingState || hasUnpatchedNonVaultChange(previousState, nextState)
+        );
         pendingState = null;
         return;
       }
-      if (isHotPathOnlyChange(previousState, nextState, sentPatch)) {
+      if (deferredFullStateBroadcast) {
+        deferredFullStateBroadcast = false;
+        scheduleStateBroadcast(nextState);
+        return;
+      }
+      const isHotPathOnly = isHotPathOnlyChange(
+        previousState,
+        nextState,
+        sentPatch
+      );
+      if (isHotPathOnly) {
         if (pendingState) {
           pendingState = nextState;
         }

--- a/source/scripts/Background/handlers/handleStateChanges.ts
+++ b/source/scripts/Background/handlers/handleStateChanges.ts
@@ -136,6 +136,28 @@ const getOnlyAccountBalanceChange = (
   return balanceChange;
 };
 
+export const isNetworkSwitchInProgress = (state: typeof currentState) => {
+  if (state.vaultGlobal.networkStatus === 'switching') {
+    return true;
+  }
+
+  const activeSlip44 = state.vaultGlobal.activeSlip44;
+  const vaultSlip44 = state.vault.activeNetwork.slip44;
+  return (
+    activeSlip44 !== null &&
+    vaultSlip44 !== undefined &&
+    Number(activeSlip44) !== Number(vaultSlip44)
+  );
+};
+
+const didCommitNetworkSwitch = (
+  previousState: typeof currentState,
+  nextState: typeof currentState
+) =>
+  previousState.vaultGlobal.networkStatus === 'switching' &&
+  nextState.vaultGlobal.networkStatus === 'idle' &&
+  !isNetworkSwitchInProgress(nextState);
+
 export const sendFastStatePatches = (
   previousState: typeof currentState,
   nextState: typeof currentState
@@ -154,18 +176,25 @@ export const sendFastStatePatches = (
   const networkChanged =
     previousNetwork.chainId !== nextNetwork.chainId ||
     previousNetwork.url !== nextNetwork.url ||
-    previousNetwork.kind !== nextNetwork.kind;
+    previousNetwork.kind !== nextNetwork.kind ||
+    previousNetwork.slip44 !== nextNetwork.slip44;
+  const networkSwitchCommitted = didCommitNetworkSwitch(
+    previousState,
+    nextState
+  );
+  const canPublishVault = !isNetworkSwitchInProgress(nextState);
+  const publishedVault =
+    canPublishVault && (networkChanged || networkSwitchCommitted);
 
-  if (networkChanged) {
+  if (publishedVault) {
     sendRuntimeMessage({
       type: 'CONTROLLER_NETWORK_CHANGE',
       data: {
-        activeAccount: nextState.vault.activeAccount,
-        activeNetwork: nextNetwork,
-        // A slip44 switch replaces the account buckets and network together.
-        // Deliver them in one message so the popup cannot render a new network
-        // against accounts left over from the previous address family.
-        accounts: nextState.vault.accounts,
+        activeSlip44: nextState.vaultGlobal.activeSlip44,
+        // A slip44 switch replaces every account-owned bucket, not just the
+        // account list. Rehydrate the popup from the exact background vault so
+        // imported assets cannot remain stuck on the vault we just left.
+        vault: nextState.vault,
         networkStatus: nextState.vaultGlobal.networkStatus,
       },
     });
@@ -175,12 +204,15 @@ export const sendFastStatePatches = (
   const previousActiveAccount = previousState.vault.activeAccount;
   const nextActiveAccount = nextState.vault.activeAccount;
   const accountBalanceChange =
+    canPublishVault &&
+    !publishedVault &&
     previousState.vault.accounts !== nextState.vault.accounts
       ? getOnlyAccountBalanceChange(previousState, nextState)
       : null;
 
   if (
-    !networkChanged &&
+    canPublishVault &&
+    !publishedVault &&
     previousState.vault.accounts !== nextState.vault.accounts &&
     !accountBalanceChange
   ) {
@@ -221,8 +253,10 @@ export const sendFastStatePatches = (
   }
 
   if (
-    previousActiveAccount.id !== nextActiveAccount.id ||
-    previousActiveAccount.type !== nextActiveAccount.type
+    canPublishVault &&
+    !publishedVault &&
+    (previousActiveAccount.id !== nextActiveAccount.id ||
+      previousActiveAccount.type !== nextActiveAccount.type)
   ) {
     sendRuntimeMessage({
       type: 'CONTROLLER_ACTIVE_ACCOUNT_CHANGE',
@@ -231,7 +265,7 @@ export const sendFastStatePatches = (
     sentPatch = true;
   }
 
-  if (accountBalanceChange) {
+  if (canPublishVault && !publishedVault && accountBalanceChange) {
     sendRuntimeMessage({
       type: 'CONTROLLER_ACCOUNT_BALANCE_CHANGE',
       data: accountBalanceChange,
@@ -242,7 +276,7 @@ export const sendFastStatePatches = (
   return sentPatch;
 };
 
-const isHotPathOnlyChange = (
+export const isHotPathOnlyChange = (
   previousState: typeof currentState,
   nextState: typeof currentState,
   sentPatch: boolean
@@ -286,23 +320,18 @@ const isHotPathOnlyChange = (
     ['accounts']
   );
 
-  const vaultIsNetworkSwitchOnly = shallowEqualExcept(
-    previousState.vault,
-    nextState.vault,
-    [
-      'accounts',
-      'activeAccount',
-      'activeChain',
-      'activeNetwork',
-      'isBitcoinBased',
-    ]
-  );
+  const previousNetwork = previousState.vault.activeNetwork;
+  const nextNetwork = nextState.vault.activeNetwork;
+  const entireVaultWasPatched =
+    didCommitNetworkSwitch(previousState, nextState) ||
+    previousNetwork.chainId !== nextNetwork.chainId ||
+    previousNetwork.url !== nextNetwork.url ||
+    previousNetwork.kind !== nextNetwork.kind ||
+    previousNetwork.slip44 !== nextNetwork.slip44;
 
   return (
     sentPatch &&
-    (vaultIsActiveAccountOnly ||
-      vaultIsAccountsOnly ||
-      vaultIsNetworkSwitchOnly)
+    (vaultIsActiveAccountOnly || vaultIsAccountsOnly || entireVaultWasPatched)
   );
 };
 
@@ -315,6 +344,13 @@ export function handleObserveStateChanges() {
       const previousState = currentState;
       currentState = nextState;
       const sentPatch = sendFastStatePatches(previousState, nextState);
+      // Loading a slip44 vault is an intermediate background state. The active
+      // keyring and persistence pointer are not committed until the switch
+      // succeeds, so never expose this state to the popup.
+      if (isNetworkSwitchInProgress(nextState)) {
+        pendingState = null;
+        return;
+      }
       if (isHotPathOnlyChange(previousState, nextState, sentPatch)) {
         if (pendingState) {
           pendingState = nextState;

--- a/source/state/store.network-switch.spec.ts
+++ b/source/state/store.network-switch.spec.ts
@@ -1,5 +1,9 @@
-import store, { restoreSourceVaultAfterUncommittedSwitch } from 'state/store';
+import store, {
+  loadAndActivateSlip44Vault,
+  restoreSourceVaultAfterUncommittedSwitch,
+} from 'state/store';
 import { setNetworkChange } from 'state/vault';
+import vaultCache from 'state/vaultCache';
 import { setActiveSlip44 } from 'state/vaultGlobal';
 
 describe('network switch vault rollback', () => {
@@ -43,5 +47,20 @@ describe('network switch vault rollback', () => {
     ).toBe(false);
     expect(store.getState().vault.activeNetwork).toBe(targetNetwork);
     expect(store.getState().vaultGlobal.activeSlip44).toBe(targetSlip44);
+  });
+
+  it('realigns active slip44 when a non-deferred vault load fails', async () => {
+    const loadedVaultSlip44 = store.getState().vault.activeNetwork.slip44;
+    const requestedSlip44 = loadedVaultSlip44 === 60 ? 57 : 60;
+    const loadError = new Error('vault storage unavailable');
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+    jest.spyOn(vaultCache, 'getSlip44Vault').mockRejectedValueOnce(loadError);
+
+    const loaded = await loadAndActivateSlip44Vault(requestedSlip44);
+
+    expect(loaded).toBe(false);
+    expect(store.getState().vault.activeNetwork.slip44).toBe(loadedVaultSlip44);
+    expect(store.getState().vaultGlobal.activeSlip44).toBe(loadedVaultSlip44);
+    errorSpy.mockRestore();
   });
 });

--- a/source/state/store.network-switch.spec.ts
+++ b/source/state/store.network-switch.spec.ts
@@ -1,0 +1,47 @@
+import store, { restoreSourceVaultAfterUncommittedSwitch } from 'state/store';
+import { setNetworkChange } from 'state/vault';
+import { setActiveSlip44 } from 'state/vaultGlobal';
+
+describe('network switch vault rollback', () => {
+  it('restores the source snapshot when slip44 activation did not commit', () => {
+    const sourceSlip44 = store.getState().vault.activeNetwork.slip44;
+    store.dispatch(setActiveSlip44(sourceSlip44));
+    const sourceVault = store.getState().vault;
+    const targetNetwork = {
+      ...sourceVault.activeNetwork,
+      chainId: Number(sourceVault.activeNetwork.chainId) + 1,
+      slip44: sourceSlip44 === 60 ? 57 : 60,
+      url: 'https://uncommitted-target.example',
+    };
+
+    store.dispatch(setNetworkChange({ activeNetwork: targetNetwork }));
+
+    expect(store.getState().vault.activeNetwork).toBe(targetNetwork);
+    expect(
+      restoreSourceVaultAfterUncommittedSwitch(sourceSlip44, sourceVault)
+    ).toBe(true);
+    expect(store.getState().vault).toBe(sourceVault);
+    expect(store.getState().vaultGlobal.activeSlip44).toBe(sourceSlip44);
+  });
+
+  it('does not restore the source after target slip44 activation commits', () => {
+    const sourceVault = store.getState().vault;
+    const sourceSlip44 = sourceVault.activeNetwork.slip44;
+    const targetSlip44 = sourceSlip44 === 60 ? 57 : 60;
+    const targetNetwork = {
+      ...sourceVault.activeNetwork,
+      chainId: Number(sourceVault.activeNetwork.chainId) + 1,
+      slip44: targetSlip44,
+      url: 'https://committed-target.example',
+    };
+
+    store.dispatch(setNetworkChange({ activeNetwork: targetNetwork }));
+    store.dispatch(setActiveSlip44(targetSlip44));
+
+    expect(
+      restoreSourceVaultAfterUncommittedSwitch(sourceSlip44, sourceVault)
+    ).toBe(false);
+    expect(store.getState().vault.activeNetwork).toBe(targetNetwork);
+    expect(store.getState().vaultGlobal.activeSlip44).toBe(targetSlip44);
+  });
+});

--- a/source/state/store.ts
+++ b/source/state/store.ts
@@ -28,6 +28,7 @@ import { IPersistState } from './types';
 import vault, {
   rehydrate as vaultRehydrate,
   initializeCleanVaultForSlip44,
+  restoreVaultSnapshot,
 } from './vault';
 import { IVaultState, IGlobalState } from './vault/types';
 import vaultCache from './vaultCache';
@@ -73,6 +74,18 @@ const store: Store<{
     }).concat(customMiddlewareToAdd), // Concat our custom middleware array
   devTools: nodeEnv !== 'production' && nodeEnv !== 'test',
 });
+
+export function restoreSourceVaultAfterUncommittedSwitch(
+  sourceSlip44: number,
+  sourceVault: IVaultState
+): boolean {
+  if (store.getState().vaultGlobal.activeSlip44 !== sourceSlip44) {
+    return false;
+  }
+
+  store.dispatch(restoreVaultSnapshot(sourceVault));
+  return true;
+}
 
 // Cache the last persisted state locally to avoid the expensive
 // read-&-parse cycle from chrome.storage on every store update. This

--- a/source/state/store.ts
+++ b/source/state/store.ts
@@ -186,6 +186,11 @@ export async function loadAndActivateSlip44Vault(
   targetNetwork?: INetwork,
   deferActiveSlip44Update = false
 ): Promise<boolean> {
+  // If a non-deferred storage/migration step fails, this is still the vault
+  // Redux actually contains. Re-align the global pointer to it in the catch so
+  // mismatch suppression cannot strand background state delivery.
+  const loadedVaultSlip44 = store.getState().vault.activeNetwork.slip44;
+
   try {
     console.log(`[Store] Loading slip44 vault: ${slip44}`);
 
@@ -258,6 +263,13 @@ export async function loadAndActivateSlip44Vault(
       return false;
     }
   } catch (error) {
+    if (
+      !deferActiveSlip44Update &&
+      loadedVaultSlip44 !== null &&
+      loadedVaultSlip44 !== undefined
+    ) {
+      store.dispatch(setActiveSlip44(Number(loadedVaultSlip44)));
+    }
     console.error(`[Store] Failed to load slip44 vault ${slip44}:`, error);
     return false;
   }

--- a/source/state/vault/index.ts
+++ b/source/state/vault/index.ts
@@ -136,6 +136,15 @@ const VaultState = createSlice({
       );
       return rehydratedState;
     },
+    restoreVaultSnapshot(
+      _state: IVaultState,
+      action: PayloadAction<IVaultState>
+    ) {
+      // This snapshot comes from the already-normalized live Redux state. It
+      // is used only to roll back a slip44 switch that failed before commit,
+      // so return it exactly without persisted-state migration or mutation.
+      return action.payload;
+    },
     setAccounts(
       state: IVaultState,
       action: PayloadAction<{
@@ -960,6 +969,7 @@ const VaultState = createSlice({
 
 export const {
   rehydrate,
+  restoreVaultSnapshot,
   setAccountPropertyByIdAndType,
   setActiveAccount,
   setActiveAccountProperty,


### PR DESCRIPTION
## Root cause

The network-switch fast path publishes the target network/accounts as soon as the target slip44 vault is hydrated, while `vaultGlobal.activeSlip44` and the active keyring can still point to the source vault. The partial network message also omits `accountAssets` and `accountTransactions`, leaving the popup with buckets from the vault it just left.

This is the optimized state-delivery path introduced/extended in #828 and #829. The #827 persistence serialization does not modify this broadcaster/router transaction and validates per-slip44 writes.

Review identified four follow-on broadcaster/transaction gaps:

- non-vault full-state updates received during a switch could be discarded when the intermediate vault was withheld
- an aligned target vault was published for `switching → idle`, but not for the terminal `switching → error` path after signer setup failed
- a failure before `activeSlip44` committed could leave the hydrated target vault paired with the source slip44
- a non-deferred startup vault-load failure could leave the target global pointer paired with the previously loaded vault

A separate consistency gap existed in direct `dapp.changeAccount(...)`: it persisted the new dapp connection without invalidating cached provider-state responses, including `eth_accounts`. Only the request-pipeline account-switch path cleared that cache.

## Fix

- suppress vault/account/active-account/balance broadcasts while a network switch is in progress or the vault and active slip44 disagree
- publish the exact already-indexed target vault and committed `activeSlip44` once the switch reaches an aligned terminal state, including signer-network failure
- restore the captured source Redux vault when a cross-slip44 switch fails before target slip44 activation commits
- realign `activeSlip44` to the vault Redux still contains when a non-deferred storage or migration load fails
- rehydrate the popup vault from a single aligned snapshot
- retain a lightweight deferred-work flag for non-vault updates withheld during a switch, then publish the latest safe full state after alignment
- keep ordinary switch-only hydration on the fast path without a duplicate full root-state broadcast
- invalidate the provider-state cache inside `DAppController.changeAccount()`, immediately after the Redux connection change and before persistence
- move the unchanged provider-cache implementation into a cycle-free module and remove the redundant request-pipeline invalidation

No cross-vault filtering, transaction scanning, migration, deep clone, or repair is added.

## Validation

- `yarn type-check`
- `yarn lint --quiet`
- `yarn test:unit --runInBand --coverage=false --silent` — 52 suites, 327 tests
- network-switch regressions verify intermediate UTXO→EVM state remains withheld, aligned success and failure publish the correct vault, pre-commit failure restores the source vault, startup load failure realigns the pointer, switch-only hydration stays patch-only, and non-vault updates are delivered after commit
- direct dapp account-change regression verifies provider cache invalidation occurs after the Redux connection change and before persistence