### PR TITLE
Validate secret passwords only on submit

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Pali Wallet",
-  "version": "4.0.56",
+  "version": "4.0.57",
   "icons": {
     "16": "assets/all_assets/favicon-16.png",
     "32": "assets/all_assets/favicon-32.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paliwallet",
-  "version": "4.0.56",
+  "version": "4.0.57",
   "description": "A Non-Custodial Crypto Wallet",
   "private": true,
   "repository": {

--- a/source/components/Input/ValidatedPasswordInput.spec.tsx
+++ b/source/components/Input/ValidatedPasswordInput.spec.tsx
@@ -1,0 +1,99 @@
+let inputProps: any;
+
+jest.mock('react', () => {
+  const actual = jest.requireActual('react');
+  return {
+    ...actual,
+    useEffect: (effect: () => void) => effect(),
+  };
+});
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('antd', () => {
+  const React = jest.requireActual('react');
+  return {
+    Form: {
+      Item: ({ children }: any) => children,
+    },
+    Input: (props: any) => {
+      inputProps = props;
+      return React.createElement('div', null, props.suffix);
+    },
+  };
+});
+
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { ValidatedPasswordInput } from './ValidatedPasswordInput';
+
+describe('ValidatedPasswordInput explicit validation', () => {
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    inputProps = undefined;
+    errorSpy = jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it('does not validate partial passwords while typing', async () => {
+    const onValidate = jest.fn().mockResolvedValue('seed words');
+    const onValidationSuccess = jest.fn();
+    const markup = renderToStaticMarkup(
+      <ValidatedPasswordInput
+        onValidate={onValidate}
+        onValidationSuccess={onValidationSuccess}
+        validationTrigger="submit"
+      />
+    );
+
+    inputProps.onChange({ target: { value: 'partial-password' } });
+    await Promise.resolve();
+
+    expect(onValidate).not.toHaveBeenCalled();
+    expect(markup).toContain('buttons.confirm');
+
+    inputProps.onPressEnter({ preventDefault: jest.fn() });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onValidate).toHaveBeenCalledTimes(1);
+    expect(onValidate).toHaveBeenCalledWith('partial-password');
+    expect(onValidationSuccess).toHaveBeenCalledWith(
+      'seed words',
+      'partial-password'
+    );
+  });
+
+  it('shows the persisted lockout duration instead of a wrong-password error', async () => {
+    const lockoutError = new Error(
+      'Too many failed attempts. Please wait 240 seconds before trying again.'
+    );
+    const form = { setFields: jest.fn() };
+    renderToStaticMarkup(
+      <ValidatedPasswordInput
+        form={form}
+        onValidate={jest.fn().mockRejectedValue(lockoutError)}
+        validationTrigger="submit"
+      />
+    );
+
+    inputProps.onChange({ target: { value: 'password' } });
+    inputProps.onPressEnter({ preventDefault: jest.fn() });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(form.setFields).toHaveBeenLastCalledWith([
+      {
+        errors: [lockoutError.message],
+        name: 'password',
+      },
+    ]);
+  });
+});

--- a/source/components/Input/ValidatedPasswordInput.tsx
+++ b/source/components/Input/ValidatedPasswordInput.tsx
@@ -45,6 +45,11 @@ interface IValidatedPasswordInputProps {
   onValidationError?: (error: any) => void;
 
   /**
+   * Callback when the input changes after a validation attempt.
+   */
+  onValidationReset?: () => void;
+
+  /**
    * Callback when validation succeeds
    */
   onValidationSuccess?: (result: any, password: string) => void;
@@ -58,12 +63,19 @@ interface IValidatedPasswordInputProps {
    * Whether the field is required (defaults to true)
    */
   required?: boolean;
+
+  /**
+   * Validate after a typing debounce or only after an explicit Confirm/Enter.
+   * Password operations that consume rate-limit attempts must use 'submit'.
+   */
+  validationTrigger?: 'change' | 'submit';
 }
 
 export const ValidatedPasswordInput: React.FC<IValidatedPasswordInputProps> = ({
   onValidate,
   onValidationSuccess,
   onValidationError,
+  onValidationReset,
   placeholder,
   id,
   form,
@@ -72,11 +84,13 @@ export const ValidatedPasswordInput: React.FC<IValidatedPasswordInputProps> = ({
   required = true,
   errorMessage,
   debounceMs = 300,
+  validationTrigger = 'change',
 }) => {
   const { t } = useTranslation();
 
   // Validation states
   const [isValidating, setIsValidating] = useState(false);
+  const [hasPassword, setHasPassword] = useState(false);
   const [validationStatus, setValidationStatus] = useState<
     'success' | 'error' | ''
   >('');
@@ -95,16 +109,22 @@ export const ValidatedPasswordInput: React.FC<IValidatedPasswordInputProps> = ({
   const onValidateRef = useRef(onValidate);
   const onValidationSuccessRef = useRef(onValidationSuccess);
   const onValidationErrorRef = useRef(onValidationError);
+  const onValidationResetRef = useRef(onValidationReset);
   const formRef = useRef(form);
   const nameRef = useRef(name);
   const errorMessageRef = useRef(errorMessage);
   const validationRunIdRef = useRef(0);
+  const passwordValueRef = useRef('');
+  const performValidationRef = useRef<
+    ((password: string) => Promise<void>) | null
+  >(null);
 
   // Update refs when props change
   useEffect(() => {
     onValidateRef.current = onValidate;
     onValidationSuccessRef.current = onValidationSuccess;
     onValidationErrorRef.current = onValidationError;
+    onValidationResetRef.current = onValidationReset;
     formRef.current = form;
     nameRef.current = name;
     errorMessageRef.current = errorMessage;
@@ -112,6 +132,7 @@ export const ValidatedPasswordInput: React.FC<IValidatedPasswordInputProps> = ({
     onValidate,
     onValidationSuccess,
     onValidationError,
+    onValidationReset,
     form,
     name,
     errorMessage,
@@ -133,6 +154,7 @@ export const ValidatedPasswordInput: React.FC<IValidatedPasswordInputProps> = ({
       // Mark this run as the latest. Any older async results should be ignored.
       const runId = ++validationRunIdRef.current;
 
+      isValidatingRef.current = true;
       setIsValidating(true);
       setValidationStatus('');
 
@@ -178,10 +200,19 @@ export const ValidatedPasswordInput: React.FC<IValidatedPasswordInputProps> = ({
 
         // Set form field error if form is provided
         if (formRef.current) {
+          const lockoutMessage =
+            error instanceof Error &&
+            error.message.startsWith('Too many failed attempts')
+              ? error.message
+              : undefined;
           formRef.current.setFields([
             {
               name: nameRef.current,
-              errors: [errorMessageRef.current || t('start.wrongPassword')],
+              errors: [
+                errorMessageRef.current ||
+                  lockoutMessage ||
+                  t('start.wrongPassword'),
+              ],
             },
           ]);
         }
@@ -193,10 +224,13 @@ export const ValidatedPasswordInput: React.FC<IValidatedPasswordInputProps> = ({
       } finally {
         // Only the latest run should control the loading state
         if (runId === validationRunIdRef.current) {
+          isValidatingRef.current = false;
           setIsValidating(false);
         }
       }
     };
+
+    performValidationRef.current = performValidation;
 
     // Create debounced function
     debouncedValidationRef.current = debounce(performValidation, debounceMs);
@@ -207,6 +241,7 @@ export const ValidatedPasswordInput: React.FC<IValidatedPasswordInputProps> = ({
         debouncedValidationRef.current.cancel();
         debouncedValidationRef.current = null;
       }
+      performValidationRef.current = null;
     };
   }, [debounceMs, t]); // Only depend on debounceMs and t
 
@@ -214,21 +249,34 @@ export const ValidatedPasswordInput: React.FC<IValidatedPasswordInputProps> = ({
   const handlePasswordChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const value = e.target.value;
+      passwordValueRef.current = value;
+      setHasPassword(Boolean(value.trim()));
+      onValidationResetRef.current?.();
+
+      // Immediately invalidate an in-flight result for an older input value.
+      validationRunIdRef.current += 1;
 
       // Only clear validation state visually, don't touch form fields here
       if (validationStatusRef.current) {
         setValidationStatus('');
       }
 
-      if (value.trim() && debouncedValidationRef.current) {
+      if (
+        validationTrigger === 'change' &&
+        value.trim() &&
+        debouncedValidationRef.current
+      ) {
         // Only set loading if we're not already validating
         if (!isValidatingRef.current) {
+          isValidatingRef.current = true;
           setIsValidating(true);
         }
         debouncedValidationRef.current(value);
       } else {
+        debouncedValidationRef.current?.cancel();
         // Only update state if it's different
         if (isValidatingRef.current) {
+          isValidatingRef.current = false;
           setIsValidating(false);
         }
         if (validationStatusRef.current) {
@@ -236,8 +284,21 @@ export const ValidatedPasswordInput: React.FC<IValidatedPasswordInputProps> = ({
         }
       }
     },
-    []
-  ); // No dependencies since we use refs
+    [validationTrigger]
+  );
+
+  const handleExplicitValidation = useCallback(() => {
+    const password = passwordValueRef.current;
+    if (
+      !password.trim() ||
+      isValidatingRef.current ||
+      !performValidationRef.current
+    )
+      return;
+
+    debouncedValidationRef.current?.cancel();
+    void performValidationRef.current(password);
+  }, []);
 
   return (
     <Form.Item
@@ -258,6 +319,27 @@ export const ValidatedPasswordInput: React.FC<IValidatedPasswordInputProps> = ({
         placeholder={placeholder || t('settings.enterYourPassword')}
         id={id}
         onChange={handlePasswordChange}
+        onPressEnter={
+          validationTrigger === 'submit'
+            ? (event) => {
+                event.preventDefault();
+                handleExplicitValidation();
+              }
+            : undefined
+        }
+        suffix={
+          validationTrigger === 'submit' ? (
+            <button
+              type="button"
+              className="text-brand-blue500 text-xs font-medium disabled:opacity-50"
+              disabled={!hasPassword || isValidating}
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={handleExplicitValidation}
+            >
+              {t('buttons.confirm')}
+            </button>
+          ) : undefined
+        }
       />
     </Form.Item>
   );

--- a/source/pages/Settings/ForgetWallet.tsx
+++ b/source/pages/Settings/ForgetWallet.tsx
@@ -128,10 +128,12 @@ const ForgetWalletView = () => {
             onValidate={validatePassword}
             onValidationSuccess={handleValidationSuccess}
             onValidationError={handleValidationError}
+            onValidationReset={handleValidationError}
             placeholder={t('settings.enterYourPassword')}
             id="forget_password"
             form={form}
             name="password"
+            validationTrigger="submit"
           />
 
           {hasAccountFunds && (

--- a/source/pages/Settings/Phrase.tsx
+++ b/source/pages/Settings/Phrase.tsx
@@ -69,10 +69,12 @@ const PhraseView = () => {
             onValidate={validatePassword}
             onValidationSuccess={handleValidationSuccess}
             onValidationError={handleValidationError}
+            onValidationReset={handleValidationError}
             placeholder={t('settings.enterYourPassword')}
             id="phraseview_password"
             form={form}
             name="password"
+            validationTrigger="submit"
           />
 
           <Form.Item name="seed" className="w-full md:max-w-md">

--- a/source/pages/Settings/PrivateKey.tsx
+++ b/source/pages/Settings/PrivateKey.tsx
@@ -132,10 +132,12 @@ const PrivateKeyView = () => {
             onValidate={validatePassword}
             onValidationSuccess={handleValidationSuccess}
             onValidationError={handleValidationError}
+            onValidationReset={handleValidationError}
             placeholder={t('settings.enterYourPassword')}
             form={form}
             name="password"
             className="my-4"
+            validationTrigger="submit"
           />
         </Form>
       )}


### PR DESCRIPTION
## What changed

- require an explicit **Confirm** click or Enter press before validating passwords on Seed Phrase, Forget Wallet, and Your Keys
- invalidate in-flight results and clear revealed seed/private-key data as soon as the password is edited
- surface the persisted rate-limit countdown instead of replacing it with a generic wrong-password error
- add regression coverage proving typing partial passwords does not invoke validation

## Root cause

`ValidatedPasswordInput` debounced validation on every pause while typing. The seed flows call the rate-limited `wallet.getSeed`, so partial passwords were recorded as failed attempts and could reach the five-attempt lockout before the full password was entered.

The private-key flow did not consume attempts for partial passwords because its preliminary unlock check skips rate limiting, but it used the same typing-triggered validation and is changed for consistency and to avoid unnecessary password work.

## Validation

- `yarn type-check` / pre-push TypeScript check
- `yarn lint --quiet`
- targeted Prettier and ESLint checks
- 53 Jest suites passed, 329 tests passed
- focused regression suite: 2 tests passed