### PR TITLE
Fix vault rehydration across network switches

### DIFF
--- a/e2e/journeys/vault-isolation.journey.spec.ts
+++ b/e2e/journeys/vault-isolation.journey.spec.ts
@@ -20,9 +20,8 @@ const getStoredVaults = async (wallet: PaliWallet) => {
   return worker.evaluate(
     () =>
       new Promise<Record<string, StoredVault | undefined>>((resolve) => {
-        chrome.storage.local.get(
-          ['state-vault-57', 'state-vault-60'],
-          (items) => resolve(items as Record<string, StoredVault | undefined>)
+        chrome.storage.local.get(['state-vault-1', 'state-vault-60'], (items) =>
+          resolve(items as Record<string, StoredVault | undefined>)
         );
       })
   );
@@ -84,8 +83,12 @@ test('vaults keep UTXO and EVM accounts isolated while alternating networks', as
   const wallet = await PaliWallet.launch('vault-isolation');
 
   try {
-    await wallet.step('import fresh seed on Syscoin UTXO', () =>
-      wallet.importSeedAndCreatePassword()
+    await wallet.step(
+      'import fresh seed and switch to Syscoin Testnet',
+      async () => {
+        await wallet.importSeedAndCreatePassword();
+        await wallet.switchNetwork('Syscoin Testnet', 'UTXO');
+      }
     );
 
     await wallet.step('import an SPT into the Syscoin vault', () =>
@@ -105,9 +108,9 @@ test('vaults keep UTXO and EVM accounts isolated while alternating networks', as
     );
 
     await wallet.step(
-      'switch to Rollux and create another EVM account',
+      'switch to zkTanenbaum and create another EVM account',
       async () => {
-        await wallet.switchNetwork('Rollux', 'EVM');
+        await wallet.switchNetwork('zkTanenbaum', 'EVM');
         await createHdAccount(wallet);
         await controllerAction(
           wallet,
@@ -132,7 +135,7 @@ test('vaults keep UTXO and EVM accounts isolated while alternating networks', as
         const state = await getBackgroundState(wallet);
         const vaults = await getStoredVaults(wallet);
         const activeAccounts = getHdAddresses(state.vault);
-        const sysAccounts = getHdAddresses(vaults['state-vault-57']);
+        const sysAccounts = getHdAddresses(vaults['state-vault-1']);
         const evmAccounts = getHdAddresses(vaults['state-vault-60']);
 
         expect({
@@ -159,32 +162,32 @@ test('vaults keep UTXO and EVM accounts isolated while alternating networks', as
           ],
         });
         expect(
-          vaults['state-vault-57']?.accountAssets.HDAccount['0'].syscoin
+          vaults['state-vault-1']?.accountAssets.HDAccount['0'].syscoin
         ).toEqual([
-          expect.objectContaining({ assetGuid: '123456789', chainId: 57 }),
+          expect.objectContaining({ assetGuid: '123456789', chainId: 5700 }),
         ]);
         expect(
           vaults['state-vault-60']?.accountAssets.HDAccount['1'].ethereum
         ).toEqual([
           expect.objectContaining({
             contractAddress: '0x00000000000000000000000000000000000000a1',
-            chainId: 570,
+            chainId: 57057,
           }),
         ]);
       }
     );
 
-    await wallet.step('switch back to Syscoin', async () => {
-      await wallet.switchNetwork('Syscoin Mainnet', 'UTXO');
+    await wallet.step('switch back to Syscoin Testnet', async () => {
+      await wallet.switchNetwork('Syscoin Testnet', 'UTXO');
     });
 
     await wallet.step(
-      'UTXO switch restored only slip44 57 accounts',
+      'UTXO switch restored only slip44 1 accounts',
       async () => {
         const state = await getBackgroundState(wallet);
         const vaults = await getStoredVaults(wallet);
         const activeAccounts = getHdAddresses(state.vault);
-        const sysAccounts = getHdAddresses(vaults['state-vault-57']);
+        const sysAccounts = getHdAddresses(vaults['state-vault-1']);
         const evmAccounts = getHdAddresses(vaults['state-vault-60']);
 
         expect({
@@ -199,8 +202,8 @@ test('vaults keep UTXO and EVM accounts isolated while alternating networks', as
               address: expect.not.stringMatching(/^0x/),
             }),
           ],
-          activeNetwork: expect.objectContaining({ slip44: 57 }),
-          activeSlip44: 57,
+          activeNetwork: expect.objectContaining({ slip44: 1 }),
+          activeSlip44: 1,
           evmAccounts: [
             expect.objectContaining({ address: expect.stringMatching(/^0x/) }),
             expect.objectContaining({ address: expect.stringMatching(/^0x/) }),
@@ -212,14 +215,14 @@ test('vaults keep UTXO and EVM accounts isolated while alternating networks', as
           ],
         });
         expect(state.vault.accountAssets.HDAccount['0'].syscoin).toEqual([
-          expect.objectContaining({ assetGuid: '123456789', chainId: 57 }),
+          expect.objectContaining({ assetGuid: '123456789', chainId: 5700 }),
         ]);
         expect(
           vaults['state-vault-60']?.accountAssets.HDAccount['1'].ethereum
         ).toEqual([
           expect.objectContaining({
             contractAddress: '0x00000000000000000000000000000000000000a1',
-            chainId: 570,
+            chainId: 57057,
           }),
         ]);
       }
@@ -233,7 +236,7 @@ test('vaults keep UTXO and EVM accounts isolated while alternating networks', as
       'persisted slip44 vaults contain one address family',
       async () => {
         const vaults = await getStoredVaults(wallet);
-        const sysAccounts = getHdAddresses(vaults['state-vault-57']);
+        const sysAccounts = getHdAddresses(vaults['state-vault-1']);
         const evmAccounts = getHdAddresses(vaults['state-vault-60']);
 
         expect(sysAccounts).toHaveLength(2);
@@ -245,24 +248,24 @@ test('vaults keep UTXO and EVM accounts isolated while alternating networks', as
           evmAccounts.every(({ address }) => address?.startsWith('0x'))
         ).toBe(true);
         expect(sysAccounts.map(({ label }) => label)).toEqual([
-          'SYS 1',
-          'SYS 2',
+          'SYS-T 1',
+          'SYS-T 2',
         ]);
         expect(evmAccounts.map(({ label }) => label)).toEqual([
           'Account 1',
           'Account 2',
         ]);
         expect(
-          vaults['state-vault-57']?.accountAssets.HDAccount['0'].syscoin
+          vaults['state-vault-1']?.accountAssets.HDAccount['0'].syscoin
         ).toEqual([
-          expect.objectContaining({ assetGuid: '123456789', chainId: 57 }),
+          expect.objectContaining({ assetGuid: '123456789', chainId: 5700 }),
         ]);
         expect(
           vaults['state-vault-60']?.accountAssets.HDAccount['1'].ethereum
         ).toEqual([
           expect.objectContaining({
             contractAddress: '0x00000000000000000000000000000000000000a1',
-            chainId: 570,
+            chainId: 57057,
           }),
         ]);
       }

--- a/e2e/journeys/vault-isolation.journey.spec.ts
+++ b/e2e/journeys/vault-isolation.journey.spec.ts
@@ -1,0 +1,276 @@
+import { expect, test } from '@playwright/test';
+
+import { PaliWallet } from '../harness/pali';
+
+type StoredVault = {
+  accountAssets: Record<
+    string,
+    Record<string, { ethereum: any[]; syscoin: any[] }>
+  >;
+  accounts: Record<
+    string,
+    Record<string, { address?: string; label?: string }>
+  >;
+};
+
+const getStoredVaults = async (wallet: PaliWallet) => {
+  const worker = wallet.context.serviceWorkers()[0];
+  if (!worker) throw new Error('Pali service worker is not available');
+
+  return worker.evaluate(
+    () =>
+      new Promise<Record<string, StoredVault | undefined>>((resolve) => {
+        chrome.storage.local.get(
+          ['state-vault-57', 'state-vault-60'],
+          (items) => resolve(items as Record<string, StoredVault | undefined>)
+        );
+      })
+  );
+};
+
+const getBackgroundState = async (wallet: PaliWallet) =>
+  wallet.page.evaluate(
+    () =>
+      new Promise<any>((resolve) => {
+        chrome.runtime.sendMessage({ type: 'getCurrentState' }, resolve);
+      })
+  );
+
+const controllerAction = async (
+  wallet: PaliWallet,
+  methods: string[],
+  params: unknown[]
+) => {
+  const response = await wallet.page.evaluate(
+    ({ actionMethods, actionParams }) =>
+      new Promise<any>((resolve) => {
+        chrome.runtime.sendMessage(
+          {
+            data: { methods: actionMethods, params: actionParams },
+            type: 'CONTROLLER_ACTION',
+          },
+          resolve
+        );
+      }),
+    { actionMethods: methods, actionParams: params }
+  );
+
+  if (response?.error) {
+    throw new Error(
+      typeof response.error === 'string'
+        ? response.error
+        : response.error.message || JSON.stringify(response.error)
+    );
+  }
+  return response;
+};
+
+const createHdAccount = async (wallet: PaliWallet) => {
+  await wallet.gotoRoute('#/settings/account/new');
+  await wallet.page.locator('#create-btn').click();
+  const okButton = wallet.page.getByRole('button', { name: /^ok$/i }).first();
+  await expect(okButton).toBeVisible({ timeout: 60_000 });
+  await okButton.click();
+  await wallet.page.waitForURL(/#\/home/, { timeout: 30_000 });
+};
+
+const getHdAddresses = (vault: StoredVault | undefined) =>
+  Object.values(vault?.accounts?.HDAccount || {}).map(({ address, label }) => ({
+    address,
+    label,
+  }));
+
+test('vaults keep UTXO and EVM accounts isolated while alternating networks', async () => {
+  const wallet = await PaliWallet.launch('vault-isolation');
+
+  try {
+    await wallet.step('import fresh seed on Syscoin UTXO', () =>
+      wallet.importSeedAndCreatePassword()
+    );
+
+    await wallet.step('import an SPT into the Syscoin vault', () =>
+      controllerAction(
+        wallet,
+        ['wallet', 'saveTokenInfo'],
+        [
+          {
+            assetGuid: '123456789',
+            balance: 0,
+            decimals: 8,
+            description: '',
+            symbol: 'E2ESPT',
+          },
+        ]
+      )
+    );
+
+    await wallet.step(
+      'switch to Rollux and create another EVM account',
+      async () => {
+        await wallet.switchNetwork('Rollux', 'EVM');
+        await createHdAccount(wallet);
+        await controllerAction(
+          wallet,
+          ['wallet', 'saveTokenInfo'],
+          [
+            {
+              balance: 0,
+              contractAddress: '0x00000000000000000000000000000000000000a1',
+              decimals: 18,
+              isNft: false,
+              name: 'E2E Token',
+              tokenSymbol: 'E2E',
+            },
+          ]
+        );
+      }
+    );
+
+    await wallet.step(
+      'EVM switch activated only slip44 60 accounts',
+      async () => {
+        const state = await getBackgroundState(wallet);
+        const vaults = await getStoredVaults(wallet);
+        const activeAccounts = getHdAddresses(state.vault);
+        const sysAccounts = getHdAddresses(vaults['state-vault-57']);
+        const evmAccounts = getHdAddresses(vaults['state-vault-60']);
+
+        expect({
+          activeAccounts,
+          activeNetwork: state.vault.activeNetwork,
+          activeSlip44: state.vaultGlobal.activeSlip44,
+          evmAccounts,
+          sysAccounts,
+        }).toEqual({
+          activeAccounts: [
+            expect.objectContaining({ address: expect.stringMatching(/^0x/) }),
+            expect.objectContaining({ address: expect.stringMatching(/^0x/) }),
+          ],
+          activeNetwork: expect.objectContaining({ slip44: 60 }),
+          activeSlip44: 60,
+          evmAccounts: [
+            expect.objectContaining({ address: expect.stringMatching(/^0x/) }),
+            expect.objectContaining({ address: expect.stringMatching(/^0x/) }),
+          ],
+          sysAccounts: [
+            expect.objectContaining({
+              address: expect.not.stringMatching(/^0x/),
+            }),
+          ],
+        });
+        expect(
+          vaults['state-vault-57']?.accountAssets.HDAccount['0'].syscoin
+        ).toEqual([
+          expect.objectContaining({ assetGuid: '123456789', chainId: 57 }),
+        ]);
+        expect(
+          vaults['state-vault-60']?.accountAssets.HDAccount['1'].ethereum
+        ).toEqual([
+          expect.objectContaining({
+            contractAddress: '0x00000000000000000000000000000000000000a1',
+            chainId: 570,
+          }),
+        ]);
+      }
+    );
+
+    await wallet.step('switch back to Syscoin', async () => {
+      await wallet.switchNetwork('Syscoin Mainnet', 'UTXO');
+    });
+
+    await wallet.step(
+      'UTXO switch restored only slip44 57 accounts',
+      async () => {
+        const state = await getBackgroundState(wallet);
+        const vaults = await getStoredVaults(wallet);
+        const activeAccounts = getHdAddresses(state.vault);
+        const sysAccounts = getHdAddresses(vaults['state-vault-57']);
+        const evmAccounts = getHdAddresses(vaults['state-vault-60']);
+
+        expect({
+          activeAccounts,
+          activeNetwork: state.vault.activeNetwork,
+          activeSlip44: state.vaultGlobal.activeSlip44,
+          evmAccounts,
+          sysAccounts,
+        }).toEqual({
+          activeAccounts: [
+            expect.objectContaining({
+              address: expect.not.stringMatching(/^0x/),
+            }),
+          ],
+          activeNetwork: expect.objectContaining({ slip44: 57 }),
+          activeSlip44: 57,
+          evmAccounts: [
+            expect.objectContaining({ address: expect.stringMatching(/^0x/) }),
+            expect.objectContaining({ address: expect.stringMatching(/^0x/) }),
+          ],
+          sysAccounts: [
+            expect.objectContaining({
+              address: expect.not.stringMatching(/^0x/),
+            }),
+          ],
+        });
+        expect(state.vault.accountAssets.HDAccount['0'].syscoin).toEqual([
+          expect.objectContaining({ assetGuid: '123456789', chainId: 57 }),
+        ]);
+        expect(
+          vaults['state-vault-60']?.accountAssets.HDAccount['1'].ethereum
+        ).toEqual([
+          expect.objectContaining({
+            contractAddress: '0x00000000000000000000000000000000000000a1',
+            chainId: 570,
+          }),
+        ]);
+      }
+    );
+
+    await wallet.step('create another Syscoin account', () =>
+      createHdAccount(wallet)
+    );
+
+    await wallet.step(
+      'persisted slip44 vaults contain one address family',
+      async () => {
+        const vaults = await getStoredVaults(wallet);
+        const sysAccounts = getHdAddresses(vaults['state-vault-57']);
+        const evmAccounts = getHdAddresses(vaults['state-vault-60']);
+
+        expect(sysAccounts).toHaveLength(2);
+        expect(evmAccounts).toHaveLength(2);
+        expect(
+          sysAccounts.every(({ address }) => !address?.startsWith('0x'))
+        ).toBe(true);
+        expect(
+          evmAccounts.every(({ address }) => address?.startsWith('0x'))
+        ).toBe(true);
+        expect(sysAccounts.map(({ label }) => label)).toEqual([
+          'SYS 1',
+          'SYS 2',
+        ]);
+        expect(evmAccounts.map(({ label }) => label)).toEqual([
+          'Account 1',
+          'Account 2',
+        ]);
+        expect(
+          vaults['state-vault-57']?.accountAssets.HDAccount['0'].syscoin
+        ).toEqual([
+          expect.objectContaining({ assetGuid: '123456789', chainId: 57 }),
+        ]);
+        expect(
+          vaults['state-vault-60']?.accountAssets.HDAccount['1'].ethereum
+        ).toEqual([
+          expect.objectContaining({
+            contractAddress: '0x00000000000000000000000000000000000000a1',
+            chainId: 570,
+          }),
+        ]);
+      }
+    );
+
+    await wallet.dispose('passed');
+  } catch (error) {
+    await wallet.dispose('failed');
+    throw error;
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Pali Wallet",
-  "version": "4.0.58",
+  "version": "4.0.59",
   "icons": {
     "16": "assets/all_assets/favicon-16.png",
     "32": "assets/all_assets/favicon-32.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paliwallet",
-  "version": "4.0.58",
+  "version": "4.0.59",
   "description": "A Non-Custodial Crypto Wallet",
   "private": true,
   "repository": {

--- a/source/config/consts.js
+++ b/source/config/consts.js
@@ -80,7 +80,7 @@ const CANARY_EXTENSION_KEY =
 const MV3_OPTIONS = {
   manifest_version: 3,
   name: 'Pali Wallet',
-  version: '4.0.58',
+  version: '4.0.59',
   icons: {
     16: 'assets/all_assets/favicon-16.png',
     32: 'assets/all_assets/favicon-32.png',

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -886,8 +886,10 @@ class MainController {
             `[MainController] Failed to load vault for slip44 ${slip44}:`,
             vaultLoadError
           );
-          // Continue anyway - we'll create a new vault
-          hasExistingVaultState = false;
+          // A failed target hydration is not the same as a missing target
+          // vault. Continuing would create target accounts in the still-active
+          // source vault and permanently mix slip44 account/asset state.
+          throw vaultLoadError;
         }
 
         // Update vault state with correct network info

--- a/source/state/store.network-switch.spec.ts
+++ b/source/state/store.network-switch.spec.ts
@@ -56,9 +56,10 @@ describe('network switch vault rollback', () => {
     const errorSpy = jest.spyOn(console, 'error').mockImplementation();
     jest.spyOn(vaultCache, 'getSlip44Vault').mockRejectedValueOnce(loadError);
 
-    const loaded = await loadAndActivateSlip44Vault(requestedSlip44);
+    await expect(loadAndActivateSlip44Vault(requestedSlip44)).rejects.toBe(
+      loadError
+    );
 
-    expect(loaded).toBe(false);
     expect(store.getState().vault.activeNetwork.slip44).toBe(loadedVaultSlip44);
     expect(store.getState().vaultGlobal.activeSlip44).toBe(loadedVaultSlip44);
     errorSpy.mockRestore();

--- a/source/state/store.ts
+++ b/source/state/store.ts
@@ -271,7 +271,7 @@ export async function loadAndActivateSlip44Vault(
       store.dispatch(setActiveSlip44(Number(loadedVaultSlip44)));
     }
     console.error(`[Store] Failed to load slip44 vault ${slip44}:`, error);
-    return false;
+    throw error;
   }
 }
 

--- a/source/state/vault/index.ts
+++ b/source/state/vault/index.ts
@@ -83,27 +83,28 @@ const initialState: IVaultState = {
   },
 };
 
-const ensureAccountTypeBuckets = (state: IVaultState) => {
-  Object.values(KeyringAccountType).forEach((accountType) => {
-    if (!state.accounts[accountType]) state.accounts[accountType] = {};
-    if (!state.accountAssets[accountType])
-      state.accountAssets[accountType] = {};
-    if (!state.accountTransactions[accountType])
-      state.accountTransactions[accountType] = {};
+const prepareRehydratedVault = (state: IVaultState): IVaultState => {
+  const accounts = { ...state.accounts };
+  const accountAssets = { ...state.accountAssets };
+  const accountTransactions = { ...state.accountTransactions };
 
-    // Migrate older saved accounts in place. Each persisted vault belongs to
-    // exactly one slip44, so its accounts inherit that durable provenance.
-    Object.values(state.accounts[accountType]).forEach((account) => {
-      if (
+  Object.values(KeyringAccountType).forEach((accountType) => {
+    const persistedAccounts = state.accounts[accountType] || {};
+    accounts[accountType] = Object.fromEntries(
+      Object.entries(persistedAccounts).map(([id, account]) => [
+        id,
         account.slip44 === undefined &&
         state.activeNetwork?.slip44 !== undefined
-      ) {
-        account.slip44 = state.activeNetwork.slip44;
-      }
-    });
+          ? { ...account, slip44: state.activeNetwork.slip44 }
+          : account,
+      ])
+    );
+    accountAssets[accountType] = state.accountAssets[accountType] || {};
+    accountTransactions[accountType] =
+      state.accountTransactions[accountType] || {};
   });
 
-  return state;
+  return { ...state, accountAssets, accounts, accountTransactions };
 };
 
 const restoreNativeBalancesForNetwork = (
@@ -111,15 +112,27 @@ const restoreNativeBalancesForNetwork = (
   network: INetwork,
   now = Date.now()
 ) => {
+  const restoredAccounts = { ...state.accounts };
+
   Object.values(KeyringAccountType).forEach((accountType) => {
-    Object.values(state.accounts[accountType] || {}).forEach((account) => {
-      const cachedBalance = getFreshNativeBalance(account, network, now);
-      account.balances = {
-        ...account.balances,
-        [network.kind]: cachedBalance?.balance ?? -1,
-      } as IKeyringBalances;
-    });
+    restoredAccounts[accountType] = Object.fromEntries(
+      Object.entries(state.accounts[accountType] || {}).map(([id, account]) => {
+        const cachedBalance = getFreshNativeBalance(account, network, now);
+        return [
+          id,
+          {
+            ...account,
+            balances: {
+              ...account.balances,
+              [network.kind]: cachedBalance?.balance ?? -1,
+            } as IKeyringBalances,
+          },
+        ];
+      })
+    );
   });
+
+  state.accounts = restoredAccounts;
 };
 
 const VaultState = createSlice({
@@ -129,7 +142,9 @@ const VaultState = createSlice({
     rehydrate(_state: IVaultState, action: PayloadAction<IVaultState>) {
       // Complete replacement - ensures loaded vault state is exactly what was saved
       // This matches the behavior of initializeCleanVaultForSlip44 for consistency
-      const rehydratedState = ensureAccountTypeBuckets(action.payload);
+      // Cached vault snapshots can be frozen Redux objects. Never mutate the
+      // action payload while normalizing persisted state.
+      const rehydratedState = prepareRehydratedVault(action.payload);
       restoreNativeBalancesForNetwork(
         rehydratedState,
         rehydratedState.activeNetwork

--- a/source/state/vault/nativeBalanceCache.spec.ts
+++ b/source/state/vault/nativeBalanceCache.spec.ts
@@ -6,6 +6,7 @@ import {
 } from 'utils/nativeBalanceCache';
 
 import vaultReducer, {
+  rehydrate,
   setAccountBalanceForNetwork,
   setNetworkChange,
 } from './index';
@@ -25,6 +26,23 @@ const getHdAccount = (state: ReturnType<typeof vaultReducer>) =>
 describe('network native balance cache', () => {
   afterEach(() => {
     jest.restoreAllMocks();
+  });
+
+  it('rehydrates a frozen cached vault without mutating it', () => {
+    const network = evmNetwork(57_057);
+    let state = vaultReducer(undefined, { type: 'test/init' });
+    state = vaultReducer(state, setNetworkChange({ activeNetwork: network }));
+    const frozenAccount = getHdAccount(state);
+    const originalBalances = frozenAccount.balances;
+
+    expect(Object.isFrozen(state)).toBe(true);
+    expect(Object.isFrozen(frozenAccount)).toBe(true);
+
+    const rehydrated = vaultReducer(undefined, rehydrate(state));
+
+    expect(rehydrated.activeNetwork).toBe(network);
+    expect(getHdAccount(rehydrated)).not.toBe(frozenAccount);
+    expect(frozenAccount.balances).toBe(originalBalances);
   });
 
   it('restores a fresh balance when returning to a previously visited network', () => {


### PR DESCRIPTION
## What changed

- Rehydrate cached slip44 vaults without mutating frozen Redux snapshots.
- Fail closed and roll back when target-vault hydration fails instead of treating the failure as an empty vault.
- Add a real-extension regression journey that alternates Syscoin UTXO and Rollux, creates accounts, imports an SPT and an EVM token, and inspects `state-vault-57` / `state-vault-60` directly.
- Bump the extension version to 4.0.59.

## Root cause

The native-balance cache work in 4.0.52 changed `vaultRehydrate` to mutate its action payload. VaultCache can return frozen Redux snapshots. Returning to a cached slip44 therefore threw during rehydration. The load path swallowed that exception as if no target vault existed, then continued the network switch on the source vault. This produced the observed `SYS 1 / Account 2 / SYS 3` sequence and replaced the wrong account asset bucket.

## Impact

UTXO and EVM accounts remain isolated in their own slip44 vaults, account numbering stays local to each vault, and imported EVM/SPT assets survive cross-network round trips.

## Verification

- `yarn test --runInBand` — 62 suites, 519 tests passed
- `yarn type-check`
- `yarn lint` — no errors (one existing smart-account naming warning)
- `yarn build:chrome`
- `yarn e2e:harness vault-isolation` — passed on a fresh browser profile with persisted vault assertions