### PR TITLE
Filter smart accounts and refine request throttling

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Pali Wallet",
-  "version": "4.0.59",
+  "version": "4.0.60",
   "icons": {
     "16": "assets/all_assets/favicon-16.png",
     "32": "assets/all_assets/favicon-32.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paliwallet",
-  "version": "4.0.59",
+  "version": "4.0.60",
   "description": "A Non-Custodial Crypto Wallet",
   "private": true,
   "repository": {

--- a/source/config/consts.js
+++ b/source/config/consts.js
@@ -80,7 +80,7 @@ const CANARY_EXTENSION_KEY =
 const MV3_OPTIONS = {
   manifest_version: 3,
   name: 'Pali Wallet',
-  version: '4.0.59',
+  version: '4.0.60',
   icons: {
     16: 'assets/all_assets/favicon-16.png',
     32: 'assets/all_assets/favicon-32.png',

--- a/source/pages/Settings/ManageAccounts.tsx
+++ b/source/pages/Settings/ManageAccounts.tsx
@@ -18,6 +18,7 @@ import { useUtils } from 'hooks/index';
 import { useController } from 'hooks/useController';
 import { RootState } from 'state/store';
 import { IKeyringAccountState, KeyringAccountType } from 'types/network';
+import { isAccountCompatibleWithNetwork } from 'utils/accountCompatibility';
 import { ellipsis } from 'utils/index';
 import { navigateWithContext } from 'utils/navigationState';
 
@@ -90,6 +91,9 @@ const ACCOUNT_TYPE_CONFIG = {
 
 const ManageAccountsView = React.memo(() => {
   const accounts = useSelector((state: RootState) => state.vault.accounts);
+  const activeNetwork = useSelector(
+    (state: RootState) => state.vault.activeNetwork
+  );
   const activeAccountRef = useSelector(
     (state: RootState) => state.vault.activeAccount
   );
@@ -293,12 +297,16 @@ const ManageAccountsView = React.memo(() => {
   const accountsList = useMemo(
     () =>
       Object.entries(accounts).flatMap(([accountType, accountsOfType]) =>
-        Object.values(accountsOfType || {}).map((account) => ({
-          account: account as IKeyringAccountState,
-          accountType: accountType as KeyringAccountType,
-        }))
+        Object.values(accountsOfType || {})
+          .filter((account) =>
+            isAccountCompatibleWithNetwork(account, accountType, activeNetwork)
+          )
+          .map((account) => ({
+            account: account as IKeyringAccountState,
+            accountType: accountType as KeyringAccountType,
+          }))
       ),
-    [accounts]
+    [accounts, activeNetwork]
   );
 
   return (

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -631,7 +631,7 @@ class MainController {
   // Rate limiting for failed unlock attempts (persisted to storage)
   private failedUnlockAttempts = 0;
   private lastFailedUnlockTime = 0;
-  private readonly MAX_FAILED_ATTEMPTS = 5;
+  private readonly MAX_FAILED_ATTEMPTS = 10;
   private readonly LOCKOUT_DURATION = 5 * 60 * 1000; // 5 minutes in milliseconds
   private readonly RATE_LIMIT_STORAGE_KEY = 'pali_rate_limit_state';
   private rateLimitInitialized = false;

--- a/source/scripts/Background/controllers/message-handler/middleware/spamFilterMiddleware.spec.ts
+++ b/source/scripts/Background/controllers/message-handler/middleware/spamFilterMiddleware.spec.ts
@@ -1,0 +1,66 @@
+jest.mock('../popup-promise', () => ({ popupPromise: jest.fn() }));
+jest.mock('../request-pipeline', () => ({
+  requestCoordinator: { coordinatePopupRequest: jest.fn() },
+}));
+jest.mock('state/store', () => ({
+  __esModule: true,
+  default: {
+    dispatch: jest.fn(),
+    getState: jest.fn(),
+  },
+}));
+
+import store from 'state/store';
+
+import { spamFilterMiddleware } from './spamFilterMiddleware';
+
+const mockedStore = store as unknown as {
+  dispatch: jest.Mock;
+  getState: jest.Mock;
+};
+
+const context = {
+  methodConfig: { hasPopup: true },
+  originalRequest: {
+    host: 'example.test',
+    method: 'personal_sign',
+  },
+} as any;
+
+describe('spamFilterMiddleware fulfilled request handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedStore.getState.mockReturnValue({
+      spamFilter: {
+        config: {
+          blockDurationMs: 60_000,
+          enabled: true,
+          requestThreshold: 3,
+          timeWindowMs: 10_000,
+        },
+        dapps: {},
+      },
+    });
+  });
+
+  it('resets the popup burst after a fulfilled request', async () => {
+    const next = jest.fn().mockResolvedValue('signed');
+
+    await expect(spamFilterMiddleware(context, next)).resolves.toBe('signed');
+
+    expect(
+      mockedStore.dispatch.mock.calls.map(([action]) => action.type)
+    ).toEqual(['spamFilter/recordRequest', 'spamFilter/resetDappRequests']);
+  });
+
+  it('keeps a rejected request in the popup burst', async () => {
+    const rejection = new Error('User rejected the request');
+    const next = jest.fn().mockRejectedValue(rejection);
+
+    await expect(spamFilterMiddleware(context, next)).rejects.toBe(rejection);
+
+    expect(
+      mockedStore.dispatch.mock.calls.map(([action]) => action.type)
+    ).toEqual(['spamFilter/recordRequest']);
+  });
+});

--- a/source/scripts/Background/controllers/message-handler/middleware/spamFilterMiddleware.ts
+++ b/source/scripts/Background/controllers/message-handler/middleware/spamFilterMiddleware.ts
@@ -2,7 +2,12 @@ import { ethErrors } from 'helpers/errors';
 
 import { popupPromise } from '../popup-promise';
 import { Middleware, requestCoordinator } from '../request-pipeline';
-import { recordRequest, blockDapp, showWarning } from 'state/spamFilter';
+import {
+  recordRequest,
+  blockDapp,
+  resetDappRequests,
+  showWarning,
+} from 'state/spamFilter';
 import {
   isDappBlocked,
   shouldShowSpamWarning,
@@ -16,9 +21,9 @@ import cleanErrorStack from 'utils/cleanErrorStack';
  *
  * Features:
  * - Tracks popup request counts per dapp within a time window
- * - Shows warning after threshold is reached (default: 3 requests in 10 seconds)
+ * - Shows warning after threshold is reached (default: 3 unresolved requests in 10 seconds)
  * - User can choose to temporarily block the dapp (default: 1 minute)
- * - Grace period after warning to prevent duplicate warnings (default: 30 seconds)
+ * - Resets an allowed burst so normal follow-up requests are not interrupted
  * - Blocked dapps get authorization errors without showing popups
  */
 export const spamFilterMiddleware: Middleware = async (context, next) => {
@@ -54,42 +59,54 @@ export const spamFilterMiddleware: Middleware = async (context, next) => {
       `[SpamFilter] Popup spam threshold reached for ${host}, showing warning`
     );
 
-    // Mark that we're showing the warning (grace period will prevent duplicates)
+    // Mark the warning as active so concurrent requests do not open duplicates.
     store.dispatch(showWarning({ host }));
 
-    // Show spam warning popup through coordinator
-    const result = await requestCoordinator.coordinatePopupRequest(
-      context,
-      () =>
-        popupPromise({
-          host,
-          route: 'spam-warning' as any,
-          eventName: 'spamWarningResponse',
-          data: {
-            requestCount:
-              updatedState.spamFilter.dapps[host]?.requests.length || 0,
-          },
-        }),
-      'spam-warning' as any
-    );
-
-    // Handle user response
-    if (result && (result as any).action === 'block') {
-      console.log(`[SpamFilter] User chose to block ${host}`);
-      store.dispatch(blockDapp({ host }));
-
-      // Throw error to block this request
-      throw cleanErrorStack(
-        ethErrors.provider.unauthorized('Request blocked due to spam filter.')
+    try {
+      // Show spam warning popup through coordinator
+      const result = await requestCoordinator.coordinatePopupRequest(
+        context,
+        () =>
+          popupPromise({
+            host,
+            route: 'spam-warning' as any,
+            eventName: 'spamWarningResponse',
+            data: {
+              requestCount:
+                updatedState.spamFilter.dapps[host]?.requests.length || 0,
+            },
+          }),
+        'spam-warning' as any
       );
-    }
 
-    // If user chose not to block, continue with grace period
-    console.log(
-      `[SpamFilter] User chose not to block ${host}, continuing with grace period`
-    );
+      // Handle user response
+      if (result && (result as any).action === 'block') {
+        console.log(`[SpamFilter] User chose to block ${host}`);
+        store.dispatch(blockDapp({ host }));
+
+        // Throw error to block this request
+        throw cleanErrorStack(
+          ethErrors.provider.unauthorized('Request blocked due to spam filter.')
+        );
+      }
+
+      console.log(
+        `[SpamFilter] User chose not to block ${host}, resetting request burst`
+      );
+    } finally {
+      // Start a fresh burst after allow or popup dismissal. Without this reset,
+      // every later popup request immediately retriggers the warning. Preserve
+      // the blocked state when the user explicitly chose to block the site.
+      if (!isDappBlocked(store.getState(), host)) {
+        store.dispatch(resetDappRequests({ host }));
+      }
+    }
   }
 
-  // Continue to next middleware
-  return next();
+  // A completed popup is legitimate interaction, not an accumulating spam
+  // burst. Rejected or failed requests remain recorded so repeated unwanted
+  // prompts can still reach the warning threshold.
+  const result = await next();
+  store.dispatch(resetDappRequests({ host }));
+  return result;
 };

--- a/source/state/spamFilter/index.spec.ts
+++ b/source/state/spamFilter/index.spec.ts
@@ -1,0 +1,52 @@
+import reducer, { recordRequest, resetDappRequests, showWarning } from '.';
+import { shouldShowSpamWarning } from './selectors';
+
+describe('spam filter popup threshold', () => {
+  const host = 'example.test';
+
+  beforeEach(() => {
+    jest.spyOn(Date, 'now').mockReturnValue(10_000);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('warns after three unresolved popup requests in the burst window', () => {
+    let state = reducer(undefined, { type: '@@INIT' });
+
+    for (let request = 0; request < 2; request += 1) {
+      state = reducer(state, recordRequest({ host, method: 'personal_sign' }));
+    }
+
+    expect(shouldShowSpamWarning({ spamFilter: state }, host)).toBe(false);
+
+    state = reducer(
+      state,
+      recordRequest({ host, method: 'eth_sendTransaction' })
+    );
+
+    expect(shouldShowSpamWarning({ spamFilter: state }, host)).toBe(true);
+  });
+
+  it('suppresses duplicate warnings and resets an allowed burst', () => {
+    let state = reducer(undefined, { type: '@@INIT' });
+
+    for (let request = 0; request < 3; request += 1) {
+      state = reducer(state, recordRequest({ host, method: 'personal_sign' }));
+    }
+
+    state = reducer(state, showWarning({ host }));
+    expect(shouldShowSpamWarning({ spamFilter: state }, host)).toBe(false);
+
+    (Date.now as jest.Mock).mockReturnValue(12_000);
+    state = reducer(state, resetDappRequests({ host }));
+
+    expect(state.dapps[host]).toMatchObject({
+      lastResetTime: 12_000,
+      requests: [],
+      warningShown: false,
+    });
+    expect(shouldShowSpamWarning({ spamFilter: state }, host)).toBe(false);
+  });
+});

--- a/source/state/spamFilter/index.ts
+++ b/source/state/spamFilter/index.ts
@@ -88,6 +88,7 @@ const spamFilterSlice = createSlice({
       if (state.dapps[host]) {
         state.dapps[host].requests = [];
         state.dapps[host].warningShown = false;
+        state.dapps[host].lastResetTime = Date.now();
       }
     },
 

--- a/source/state/spamFilter/selectors.ts
+++ b/source/state/spamFilter/selectors.ts
@@ -36,6 +36,13 @@ export const shouldShowSpamWarning = (
     return false;
   }
 
+  // A warning popup is already handling this burst. The request coordinator
+  // will queue the underlying request, so opening another warning only
+  // interrupts the user twice for the same activity.
+  if (dappState.warningShown) {
+    return false;
+  }
+
   // Don't show warning if already blocked
   if (isDappBlocked(state, host)) {
     return false;

--- a/source/types/security.ts
+++ b/source/types/security.ts
@@ -33,11 +33,12 @@ export interface ISpamFilterState {
 }
 
 export interface ISpamFilterConfig {
-  // Time window to count requests (default: 10000ms = 10s)
+  // How long to block after the user chooses to block (default: 60000ms = 1min)
   blockDurationMs: number;
-  // How long to block (default: 60000ms = 1min)
+  // Feature flag to enable/disable spam filter
   enabled: boolean;
+  // Number of unresolved requests before warning (default: 3)
   requestThreshold: number;
-  // Number of requests before warning (default: 3)
-  timeWindowMs: number; // Feature flag to enable/disable spam filter
+  // Time window to count requests (default: 10000ms = 10s)
+  timeWindowMs: number;
 }


### PR DESCRIPTION
## Summary
- filter Manage Accounts with the active network so smart accounts only appear on their deployment chain
- reset the dapp popup spam counter after fulfilled requests while retaining the three-unresolved-request warning threshold
- suppress duplicate spam warnings and reset allowed or dismissed warning bursts
- increase password lockout threshold from 5 to 10 failed attempts

## Validation
- yarn test --runInBand (64 suites, 523 tests)
- yarn type-check
- focused ESLint on changed files
- git diff --check