### PR TITLE
Fix SPT identity trust spoofing

### DIFF
--- a/source/components/TokenIcon.spec.tsx
+++ b/source/components/TokenIcon.spec.tsx
@@ -1,0 +1,28 @@
+jest.mock('components/Icon/Icon', () => ({
+  NftFallbackSvg: () => null,
+}));
+
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { getKnownTokenLogo } from 'utils/tokens';
+
+import { clearTokenIconCache, TokenIcon } from './TokenIcon';
+
+describe('TokenIcon UTXO identity enforcement', () => {
+  afterEach(() => {
+    clearTokenIconCache();
+  });
+
+  it('does not render a legacy official logo for a noncanonical SPT', () => {
+    const officialLogo = getKnownTokenLogo('SYSX', undefined, '123456');
+    expect(officialLogo).not.toBeNull();
+
+    const markup = renderToStaticMarkup(
+      <TokenIcon assetGuid="987654321" logo={officialLogo!} symbol="SYSX" />
+    );
+
+    expect(markup).not.toContain('<img');
+    expect(markup).toContain('>S</span>');
+  });
+});

--- a/source/components/TokenIcon.tsx
+++ b/source/components/TokenIcon.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from 'react';
 import PaliLogo from 'assets/all_assets/favicon-32.png';
 import { NftFallbackSvg } from 'components/Icon/Icon';
 import { NFT_FALLBACK_IMAGE } from 'utils/nftFallback';
-import { getKnownTokenLogo } from 'utils/tokens';
+import { getKnownTokenLogo, sanitizeUtxoTokenLogo } from 'utils/tokens';
 
 // Cache for actual image data URLs (base64) to prevent any network requests
 // Add a simple LRU cap to prevent unbounded growth
@@ -58,10 +58,10 @@ export const TokenIcon: React.FC<ITokenIconProps> = React.memo(
     size = 24,
     symbol,
   }) => {
-    const knownLogo = getKnownTokenLogo(symbol, contractAddress);
-    const resolvedLogo = contractAddress
-      ? knownLogo || logo
-      : logo || knownLogo;
+    const knownLogo = getKnownTokenLogo(symbol, contractAddress, assetGuid);
+    const safeProvidedLogo =
+      assetGuid !== undefined ? sanitizeUtxoTokenLogo(logo, assetGuid) : logo;
+    const resolvedLogo = knownLogo || safeProvidedLogo;
 
     // Create a unique cache key
     const getCacheKey = () => {

--- a/source/pages/Home/Panel/components/Assets/SyscoinDetails.tsx
+++ b/source/pages/Home/Panel/components/Assets/SyscoinDetails.tsx
@@ -19,6 +19,7 @@ import {
   camelCaseToText,
   syscoinKeysOfInterest,
   adjustUrl,
+  getKnownSyscoinAsset,
   getTokenLogo,
 } from 'utils/index';
 import { navigateBack } from 'utils/navigationState';
@@ -37,7 +38,10 @@ export const SyscoinAssetDetails = ({
   const location = useLocation();
   const [isCopied, copy] = useCopyClipboard();
   const [isLoadingMarketData, setIsLoadingMarketData] = useState(false);
-  const [marketData, setMarketData] = useState<any>(null);
+  const [marketDataState, setMarketDataState] = useState<{
+    assetGuid: string;
+    data: any;
+  } | null>(null);
   const [hasFetchedData, setHasFetchedData] = useState(false);
 
   // Use a ref to track if a request is in progress to prevent duplicates
@@ -73,6 +77,12 @@ export const SyscoinAssetDetails = ({
     };
   }
 
+  const currentAssetGuid = String(asset?.assetGuid || id);
+  const marketData =
+    marketDataState?.assetGuid === currentAssetGuid
+      ? marketDataState.data
+      : null;
+
   // All hooks must be called before any early returns
   // Memoize formattedAsset and assetSymbol calculation
   const { formattedAsset, assetSymbol } = useMemo(() => {
@@ -103,14 +113,13 @@ export const SyscoinAssetDetails = ({
     return { formattedAsset: formatted, assetSymbol: symbol };
   }, [asset]);
 
-  // Reset fetch state when asset changes
+  // Reset fetch state when asset identity changes. Market data is also tagged
+  // with this GUID so a late response for the previous asset never renders.
   useEffect(() => {
-    if (asset?.assetGuid !== id) {
-      setHasFetchedData(false);
-      setMarketData(null);
-      fetchingRef.current = false;
-    }
-  }, [asset?.assetGuid, id]);
+    setHasFetchedData(false);
+    setMarketDataState(null);
+    fetchingRef.current = false;
+  }, [currentAssetGuid]);
 
   // Trigger fresh data fetch for newly imported assets
   useEffect(() => {
@@ -161,8 +170,7 @@ export const SyscoinAssetDetails = ({
   // Try to fetch CoinGecko data for known Syscoin assets
   useEffect(() => {
     const fetchMarketData = async () => {
-      if (!asset || !assetSymbol || hasFetchedData || fetchingRef.current)
-        return;
+      if (!asset || hasFetchedData || fetchingRef.current) return;
 
       // Set the ref to prevent duplicate calls
       fetchingRef.current = true;
@@ -170,15 +178,10 @@ export const SyscoinAssetDetails = ({
       setIsLoadingMarketData(true);
 
       try {
-        // Map known Syscoin assets to CoinGecko IDs
-        const symbolToCoinGeckoId: Record<string, string> = {
-          SYSX: 'syscoin', // SYSX token maps to syscoin on CoinGecko
-          SYS: 'syscoin', // Native SYS
-          BTC: 'bitcoin',
-          // Add more mappings as needed
-        };
-
-        const coinGeckoId = symbolToCoinGeckoId[assetSymbol.value];
+        // Asset symbols are issuer-controlled. Only immutable GUID identity can
+        // attach official market data or verification to an SPT.
+        const knownAsset = getKnownSyscoinAsset(currentAssetGuid);
+        const coinGeckoId = knownAsset?.coinGeckoId;
 
         if (coinGeckoId) {
           console.log(
@@ -192,9 +195,12 @@ export const SyscoinAssetDetails = ({
 
           if (response.ok) {
             const data = await response.json();
-            setMarketData({
-              ...data,
-              isVerified: true,
+            setMarketDataState({
+              assetGuid: currentAssetGuid,
+              data: {
+                ...data,
+                isVerified: knownAsset.isVerified,
+              },
             });
 
             console.log(
@@ -207,7 +213,7 @@ export const SyscoinAssetDetails = ({
           }
         } else {
           console.log(
-            `[SyscoinAssetDetails] No CoinGecko mapping found for symbol: ${assetSymbol.value}`
+            `[SyscoinAssetDetails] No CoinGecko mapping found for asset GUID: ${currentAssetGuid}`
           );
         }
       } catch (error) {
@@ -225,7 +231,7 @@ export const SyscoinAssetDetails = ({
     };
 
     fetchMarketData();
-  }, [asset, assetSymbol, hasFetchedData]);
+  }, [asset, currentAssetGuid, hasFetchedData]);
 
   useEffect(() => {
     if (!isCopied) return;
@@ -495,12 +501,20 @@ export const SyscoinAssetDetails = ({
             marketData?.image?.small ||
             marketData?.image?.thumb ||
             asset?.image ||
-            getTokenLogo(assetSymbol?.value, false)) && (
+            getTokenLogo(
+              assetSymbol?.value,
+              false,
+              asset?.assetGuid || id
+            )) && (
             <div className="group relative p-2">
               <TokenIcon
                 logo={
                   asset?.image ||
-                  getTokenLogo(assetSymbol?.value, false) ||
+                  getTokenLogo(
+                    assetSymbol?.value,
+                    false,
+                    asset?.assetGuid || id
+                  ) ||
                   marketData?.image?.large ||
                   marketData?.image?.small ||
                   marketData?.image?.thumb ||

--- a/source/pages/Home/Panel/components/Assets/SyscoinList.tsx
+++ b/source/pages/Home/Panel/components/Assets/SyscoinList.tsx
@@ -147,7 +147,10 @@ export const SyscoinAssetsList = () => {
                 <Tooltip content={asset.name || asset.symbol}>
                   <span className="inline-flex items-center justify-center">
                     <TokenIcon
-                      logo={asset.image || getTokenLogo(asset.symbol)}
+                      logo={
+                        asset.image ||
+                        getTokenLogo(asset.symbol, true, asset.assetGuid)
+                      }
                       assetGuid={String(asset.assetGuid)}
                       symbol={asset.symbol}
                       size={24}

--- a/source/pages/Home/Panel/components/Transactions/UTXO/UtxoList.tsx
+++ b/source/pages/Home/Panel/components/Transactions/UTXO/UtxoList.tsx
@@ -293,12 +293,22 @@ const UtxoTransactionsListComponentBase = ({
           >
             <span className={`${sptSignClass}`}>{sptSignChar}</span>
             {(sptAssetInfo?.image ||
-              (sptAssetInfo?.symbol && getTokenLogo(sptAssetInfo.symbol))) && (
+              (sptAssetInfo?.symbol &&
+                getTokenLogo(
+                  sptAssetInfo.symbol,
+                  true,
+                  sptAssetInfo.assetGuid
+                ))) && (
               <Tooltip content={sptAssetInfo?.name || sptAssetInfo?.symbol}>
                 <span className="inline-flex items-center justify-center">
                   <TokenIcon
                     logo={
-                      sptAssetInfo.image || getTokenLogo(sptAssetInfo.symbol)
+                      sptAssetInfo.image ||
+                      getTokenLogo(
+                        sptAssetInfo.symbol,
+                        true,
+                        sptAssetInfo.assetGuid
+                      )
                     }
                     assetGuid={sptAssetInfo.assetGuid}
                     symbol={sptAssetInfo.symbol}

--- a/source/pages/Tokens/SyscoinImport.tsx
+++ b/source/pages/Tokens/SyscoinImport.tsx
@@ -222,7 +222,7 @@ export const SyscoinImport: React.FC = () => {
           name: token.name || token.symbol || '',
           balance: displayBalance,
           decimals: decimals,
-          logo: getTokenLogo(token.symbol || ''),
+          logo: getTokenLogo(token.symbol || '', true, token.assetGuid),
           assetGuid: token.assetGuid || '',
           type: token.type || 'SPTAllocated',
         };
@@ -236,7 +236,7 @@ export const SyscoinImport: React.FC = () => {
 
     try {
       // Get token logo URL for known tokens
-      const tokenLogo = getTokenLogo(asset.symbol);
+      const tokenLogo = getTokenLogo(asset.symbol, true, asset.assetGuid);
 
       // Convert to ITokenSysProps format for vault storage
       const tokenToSave: ITokenSysProps = {

--- a/source/utils/tokens.spec.ts
+++ b/source/utils/tokens.spec.ts
@@ -1,0 +1,53 @@
+import {
+  getKnownSyscoinAsset,
+  getKnownTokenLogo,
+  getTokenLogo,
+  sanitizeUtxoTokenLogo,
+} from './tokens';
+
+describe('known token identity', () => {
+  it.each(['SYSX', 'SYS', 'BTC'])(
+    'does not trust the attacker-controlled %s symbol for an arbitrary SPT',
+    (symbol) => {
+      expect(getKnownTokenLogo(symbol, undefined, '987654321')).toBeNull();
+    }
+  );
+
+  it('does not attach reserved branding when no immutable identity is supplied', () => {
+    expect(getKnownTokenLogo('SYSX')).toBeNull();
+  });
+
+  it('recognizes canonical SYSX by its consensus asset GUID', () => {
+    expect(
+      getKnownTokenLogo('UNTRUSTED_SYMBOL', undefined, '123456')
+    ).toContain('/blockchains/syscoin/info/logo.png');
+    expect(getKnownSyscoinAsset(123456)).toMatchObject({
+      coinGeckoId: 'syscoin',
+      isVerified: true,
+    });
+  });
+
+  it('drops legacy reserved logos from a noncanonical SPT', () => {
+    const officialLogo = getKnownTokenLogo('SYSX', undefined, '123456');
+    expect(officialLogo).not.toBeNull();
+
+    expect(sanitizeUtxoTokenLogo(officialLogo!, '987654321')).toBeUndefined();
+    expect(sanitizeUtxoTokenLogo(officialLogo!, '123456')).toBe(officialLogo);
+  });
+
+  it('preserves non-reserved custom SPT logos', () => {
+    const customLogo = 'https://assets.example/token.png';
+    expect(sanitizeUtxoTokenLogo(customLogo, '987654321')).toBe(customLogo);
+  });
+
+  it('preserves the configured EVM token identity lookup', () => {
+    expect(
+      getKnownTokenLogo('zkSYS', '0x6EBb170f69D886916D9ee9E585CE39E626CbC35d')
+    ).not.toBeNull();
+  });
+
+  it('preserves the generic fallback for an unknown custom SPT', () => {
+    expect(getTokenLogo('CUSTOM', true, '987654321')).not.toBeNull();
+    expect(getTokenLogo('CUSTOM', false, '987654321')).toBeNull();
+  });
+});

--- a/source/utils/tokens.ts
+++ b/source/utils/tokens.ts
@@ -9,9 +9,55 @@ const CONFIGURED_ZKSYS_TOKEN_ADDRESSES = new Set(
   )
 );
 
+const SYSCOIN_LOGO_URL =
+  'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/syscoin/info/logo.png';
+const BITCOIN_LOGO_URL =
+  'https://raw.githubusercontent.com/spothq/cryptocurrency-icons/master/128/color/btc.png';
+
+export const SYSX_ASSET_GUID = '123456';
+
+interface IKnownSyscoinAsset {
+  coinGeckoId: string;
+  isVerified: true;
+  logo: string;
+}
+
+const KNOWN_SYSCOIN_ASSETS: Readonly<Record<string, IKnownSyscoinAsset>> = {
+  [SYSX_ASSET_GUID]: {
+    coinGeckoId: 'syscoin',
+    isVerified: true,
+    logo: SYSCOIN_LOGO_URL,
+  },
+};
+
+// Reserved logos previously assigned by symbol. They must not survive on a
+// noncanonical SPT if they were persisted by an older wallet build.
+const RESERVED_UTXO_LOGOS = new Set([SYSCOIN_LOGO_URL, BITCOIN_LOGO_URL]);
+
+export const getKnownSyscoinAsset = (
+  assetGuid?: number | string
+): IKnownSyscoinAsset | null => {
+  if (assetGuid === undefined || assetGuid === null) return null;
+
+  return KNOWN_SYSCOIN_ASSETS[String(assetGuid)] || null;
+};
+
+export const sanitizeUtxoTokenLogo = (
+  logo: string | undefined,
+  assetGuid?: number | string
+): string | undefined => {
+  if (!logo) return logo;
+
+  const knownAsset = getKnownSyscoinAsset(assetGuid);
+  if (knownAsset?.logo === logo) return logo;
+
+  return RESERVED_UTXO_LOGOS.has(logo) ? undefined : logo;
+};
+
 export const getKnownTokenLogo = (
-  symbol?: string,
-  contractAddress?: string
+  _symbol?: string,
+  contractAddress?: string,
+  assetGuid?: number | string
 ): string | null => {
   if (
     contractAddress &&
@@ -24,30 +70,26 @@ export const getKnownTokenLogo = (
     return null;
   }
 
-  switch (symbol?.toUpperCase()) {
-    case 'SYSX':
-    case 'SYS':
-      return 'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/syscoin/info/logo.png';
-    case 'BTC':
-      return 'https://raw.githubusercontent.com/spothq/cryptocurrency-icons/master/128/color/btc.png';
-    default:
-      return null;
-  }
+  return getKnownSyscoinAsset(assetGuid)?.logo || null;
 };
 
 /**
- * Get token logo URL based on symbol
- * @param symbol - Token symbol
+ * Get a token logo without treating an issuer-controlled symbol as identity.
+ * @param symbol - Token symbol used only to decide whether a generic fallback is useful
  * @param includePaliLogo - Whether to return Pali logo for unknown tokens (default: true)
+ * @param assetGuid - Immutable Syscoin asset identity for UTXO tokens
  * @returns Logo URL or null/undefined
  */
 export const getTokenLogo = (
   symbol: string | undefined,
-  includePaliLogo = true
+  includePaliLogo = true,
+  assetGuid?: number | string
 ): string | null => {
+  const knownLogo = getKnownTokenLogo(symbol, undefined, assetGuid);
+  if (knownLogo) return knownLogo;
   if (!symbol) return null;
 
-  return getKnownTokenLogo(symbol) || (includePaliLogo ? PaliLogo : null);
+  return includePaliLogo ? PaliLogo : null;
 };
 
 /**


### PR DESCRIPTION
## What changed

- key official Syscoin SPT branding and CoinGecko verification on immutable asset GUID instead of issuer-controlled symbols
- recognize canonical SYSX through consensus asset GUID `123456`
- strip legacy official SYS/BTC logos previously persisted on noncanonical SPTs
- pass asset GUID through import, list, transaction, and icon rendering paths
- bind asynchronous market data to the originating asset GUID so stale responses cannot cross asset identities
- add exploit and preserved-behavior regression coverage

## Root cause

SPT symbols are issuer-controlled, but `SYSX`, `SYS`, and `BTC` symbols were treated as trusted identity. An attacker-controlled SPT could therefore receive an official logo, real CoinGecko market data, and a verified badge.

## Impact

Arbitrary SPTs no longer receive wallet-generated official branding or verification based on their symbol. Canonical SYSX, the configured EVM token identity, custom SPT logos, and the generic fallback retain their existing behavior.

## Validation

- focused exploit/control tests: 10 passed
- full Jest suite: 66 suites, 533 tests passed
- `yarn type-check`
- `yarn lint` (one unrelated existing naming warning)
- `git diff --check`