### PR TITLE
Harden SYSX identity reference and bump 4.0.62

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Pali Wallet",
-  "version": "4.0.61",
+  "version": "4.0.62",
   "icons": {
     "16": "assets/all_assets/favicon-16.png",
     "32": "assets/all_assets/favicon-32.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paliwallet",
-  "version": "4.0.61",
+  "version": "4.0.62",
   "description": "A Non-Custodial Crypto Wallet",
   "private": true,
   "repository": {

--- a/source/components/TransactionDetails/SyscoinTransactionDetailsFromPSBT.tsx
+++ b/source/components/TransactionDetails/SyscoinTransactionDetailsFromPSBT.tsx
@@ -18,6 +18,7 @@ import { selectActiveAccountAssets } from 'state/vault/selectors';
 import { ellipsis } from 'utils/format';
 import { formatSyscoinValue } from 'utils/formatSyscoinValue';
 import { getSyscoinTransactionTypeLabel } from 'utils/syscoinTransactionUtils';
+import { SYSX_ASSET_GUID } from 'utils/tokens';
 
 export interface IDecodedTransaction {
   error?: string;
@@ -527,7 +528,9 @@ const SyscoinTransactionDetailsFromPSBTComponent: React.FC<
                 const assetInfo = assetInfoMap[primaryAsset.assetGuid] || {
                   assetGuid: primaryAsset.assetGuid,
                   symbol:
-                    primaryAsset.assetGuid === '123456' ? 'SYSX' : 'Unknown',
+                    primaryAsset.assetGuid === SYSX_ASSET_GUID
+                      ? 'SYSX'
+                      : 'Unknown',
                   decimals: 8,
                 };
 
@@ -594,7 +597,7 @@ const SyscoinTransactionDetailsFromPSBTComponent: React.FC<
                     assetInfoMap[output.assetInfo.assetGuid] || {
                       assetGuid: output.assetInfo.assetGuid,
                       symbol:
-                        output.assetInfo.assetGuid === '123456'
+                        output.assetInfo.assetGuid === SYSX_ASSET_GUID
                           ? 'SYSX'
                           : 'SPT',
                       decimals: 8,
@@ -616,7 +619,9 @@ const SyscoinTransactionDetailsFromPSBTComponent: React.FC<
                       assetInfo = assetInfoMap[asset.assetGuid] || {
                         assetGuid: asset.assetGuid,
                         symbol:
-                          asset.assetGuid === '123456' ? 'SYSX' : 'Unknown',
+                          asset.assetGuid === SYSX_ASSET_GUID
+                            ? 'SYSX'
+                            : 'Unknown',
                         decimals: 8,
                       };
                       assetAmount = formatSyscoinValue(
@@ -862,7 +867,7 @@ const SyscoinTransactionDetailsFromPSBTComponent: React.FC<
                                   )
                                 : '0'}{' '}
                               {input.assetInfo.symbol ||
-                                (input.assetInfo.assetGuid === '123456'
+                                (input.assetInfo.assetGuid === SYSX_ASSET_GUID
                                   ? 'SYSX'
                                   : 'SPT')}
                             </Typography.Text>

--- a/source/config/consts.js
+++ b/source/config/consts.js
@@ -80,7 +80,7 @@ const CANARY_EXTENSION_KEY =
 const MV3_OPTIONS = {
   manifest_version: 3,
   name: 'Pali Wallet',
-  version: '4.0.61',
+  version: '4.0.62',
   icons: {
     16: 'assets/all_assets/favicon-16.png',
     32: 'assets/all_assets/favicon-32.png',


### PR DESCRIPTION
## What changed

- replace the four hardcoded SYSX asset GUID comparisons in the PSBT transaction details component with the exported `SYSX_ASSET_GUID`
- bump the extension version from `4.0.61` to `4.0.62` in `package.json`, the manifest source, and the checked-in manifest

## Why

The canonical SYSX identity should have one source of truth. This is defense-in-depth following the SPT identity fix and prevents the PSBT display fallback from drifting from the verified-asset registry.

Remote SPT/custom-logo handling is intentionally unchanged. Current Pali SPT imports do not carry issuer metadata images through to persisted assets.

## Validation

- no hardcoded `assetGuid === '123456'` comparisons remain in `SyscoinTransactionDetailsFromPSBT.tsx`
- `yarn generate-manifest`
- focused ESLint
- `yarn type-check`
- full Jest suite: 66 suites, 533 tests passed
- `git diff --check`