### PR TITLE
Fix bridged SPT and NFT amount handling

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Pali Wallet",
-  "version": "4.0.62",
+  "version": "4.0.63",
   "icons": {
     "16": "assets/all_assets/favicon-16.png",
     "32": "assets/all_assets/favicon-32.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paliwallet",
-  "version": "4.0.62",
+  "version": "4.0.63",
   "description": "A Non-Custodial Crypto Wallet",
   "private": true,
   "repository": {

--- a/source/components/ImportableAssetsList/ImportableAssetsList.tsx
+++ b/source/components/ImportableAssetsList/ImportableAssetsList.tsx
@@ -13,7 +13,8 @@ import { getTokenTypeBadgeColor } from 'utils/tokens';
 
 interface IImportableAsset {
   assetGuid?: string;
-  balance: number;
+  assetType?: 'SYSX' | 'ERC20' | 'ERC721' | 'ERC1155';
+  balance: number | string;
   chainId?: number;
   contractAddress?: string;
   decimals?: number;
@@ -21,6 +22,7 @@ interface IImportableAsset {
   isNft?: boolean;
   logo?: string;
   name?: string;
+  originDecimals?: number;
   symbol: string;
   tokenId?: string;
   tokenStandard?: string;
@@ -146,7 +148,7 @@ const ImportableAssetsListComponent: React.FC<IImportableAssetsListProps> = ({
                         ? '—'
                         : formatFullPrecisionBalance(
                             asset.balance || 0,
-                            Math.min(asset.decimals || 8, 4) // Limit displayed decimals
+                            Math.min(asset.decimals ?? 8, 4) // Limit displayed decimals
                           )}
                     </span>
                     <span
@@ -185,10 +187,10 @@ const ImportableAssetsListComponent: React.FC<IImportableAssetsListProps> = ({
                 {asset.type && assetType === 'utxo' && (
                   <div
                     className={`px-2 py-0.5 rounded-full text-[10px] font-medium flex-shrink-0 mr-4 ${getTokenTypeBadgeColor(
-                      asset.type
+                      asset.assetType || asset.type
                     )}`}
                   >
-                    SPT
+                    {asset.assetType || 'SPT'}
                   </div>
                 )}
               </div>

--- a/source/components/TransactionDetails/SyscoinTransactionDetailsFromPSBT.tsx
+++ b/source/components/TransactionDetails/SyscoinTransactionDetailsFromPSBT.tsx
@@ -17,12 +17,17 @@ import { RootState } from 'state/store';
 import { selectActiveAccountAssets } from 'state/vault/selectors';
 import { ellipsis } from 'utils/format';
 import { formatSyscoinValue } from 'utils/formatSyscoinValue';
+import {
+  getAssetReviewRows,
+  getSyscoinPsbtReviewError,
+} from 'utils/syscoinPsbtReview';
 import { getSyscoinTransactionTypeLabel } from 'utils/syscoinTransactionUtils';
 import { SYSX_ASSET_GUID } from 'utils/tokens';
 
 export interface IDecodedTransaction {
   error?: string;
   fee?: number;
+  feeSatoshis?: string;
   locktime?: number;
   size?: number;
   syscoin?: {
@@ -31,7 +36,7 @@ export interface IDecodedTransaction {
         assetGuid: string;
         values?: Array<{
           n: number;
-          value: number;
+          value: number | string;
           valueFormatted?: string;
         }>;
       }>;
@@ -71,12 +76,14 @@ export interface IDecodedTransaction {
       type: string;
     };
     value: number;
+    valueSatoshis?: string;
   }>;
   vsize?: number;
   weight?: number;
 }
 
 interface ISyscoinTransactionDetailsProps {
+  onReviewStateChange?: (reviewError: string | null) => void;
   psbt?: string;
   showTechnicalDetails?: boolean;
   showTransactionOptions?: boolean;
@@ -197,6 +204,7 @@ const SyscoinTransactionDetailsFromPSBTComponent: React.FC<
   transaction,
   showTechnicalDetails = true,
   showTransactionOptions = false,
+  onReviewStateChange,
 }) => {
   const { controllerEmitter } = useController();
   const { useCopyClipboard, alert } = useUtils();
@@ -245,17 +253,27 @@ const SyscoinTransactionDetailsFromPSBTComponent: React.FC<
               (a: any) => a.assetGuid === assetGuid
             );
 
-            if (localAsset) {
+            const hasCompleteLocalMetadata =
+              localAsset?.assetType === 'SYSX' ||
+              (Boolean(localAsset?.assetType) &&
+                Boolean(localAsset?.contract) &&
+                Number.isInteger(localAsset?.originDecimals) &&
+                (localAsset?.assetType === 'ERC20' ||
+                  Boolean(localAsset?.tokenId)));
+
+            if (hasCompleteLocalMetadata) {
               assetMap[assetGuid] = localAsset;
             } else {
-              // If not found locally, fetch from network
+              // Persisted assets created before bridge metadata support do not
+              // identify their origin type. Refresh them before allowing a
+              // dapp-requested signature instead of trusting stale defaults.
               try {
                 const assetData = await controllerEmitter(
                   ['wallet', 'addSysDefaultToken'],
                   [assetGuid, activeNetwork.url]
                 );
                 if (assetData && typeof assetData === 'object') {
-                  assetMap[assetGuid] = assetData;
+                  assetMap[assetGuid] = { ...localAsset, ...assetData };
                 }
               } catch (error) {
                 console.log(
@@ -309,6 +327,15 @@ const SyscoinTransactionDetailsFromPSBTComponent: React.FC<
       copyJson(JSON.stringify(jsonData, null, 2));
     }
   };
+
+  const reviewError = getSyscoinPsbtReviewError(decodedTx, assetInfoMap);
+  const assetReviewRows = decodedTx
+    ? getAssetReviewRows(decodedTx, assetInfoMap)
+    : [];
+
+  useEffect(() => {
+    onReviewStateChange?.(reviewError);
+  }, [onReviewStateChange, reviewError]);
 
   if (loading && !initialLoadDone) {
     return (
@@ -491,13 +518,17 @@ const SyscoinTransactionDetailsFromPSBTComponent: React.FC<
         )}
 
         {/* Fee */}
-        {decodedTx.fee !== undefined && (
+        {(decodedTx.feeSatoshis !== undefined ||
+          decodedTx.fee !== undefined) && (
           <div className="flex justify-between items-center gap-2">
             <Typography.Text className="text-brand-gray200 text-xs sm:text-sm flex-shrink-0">
               {t('send.networkFee')}:
             </Typography.Text>
             <Typography.Text className="text-white text-xs sm:text-sm text-right">
-              {decodedTx.fee} {activeNetwork.currency.toUpperCase()}
+              {decodedTx.feeSatoshis !== undefined
+                ? formatSyscoinValue(decodedTx.feeSatoshis, 8)
+                : decodedTx.fee}{' '}
+              {activeNetwork.currency.toUpperCase()}
             </Typography.Text>
           </div>
         )}
@@ -514,6 +545,69 @@ const SyscoinTransactionDetailsFromPSBTComponent: React.FC<
           </div>
         )}
       </div>
+
+      {reviewError && (
+        <div className="bg-warning-error bg-opacity-10 border border-warning-error rounded-lg p-3">
+          <div className="flex items-start gap-2">
+            <WarningOutlined className="text-warning-error mt-0.5" />
+            <Typography.Text className="text-warning-error text-xs sm:text-sm">
+              {reviewError}
+            </Typography.Text>
+          </div>
+        </div>
+      )}
+
+      {decodedTx.vout && decodedTx.vout.length > 0 && (
+        <div className="bg-brand-blue800 rounded-lg p-4 space-y-3">
+          <Typography.Text className="text-white text-sm font-medium block">
+            Transaction outputs
+          </Typography.Text>
+          {decodedTx.vout.map((output) => {
+            const recipient = output.scriptPubKey?.addresses?.[0];
+            const rawValue = output.valueSatoshis;
+
+            return (
+              <div
+                key={`review-output-${output.n}`}
+                className="pt-2 border-t border-alpha-whiteAlpha100 space-y-2"
+              >
+                <div className="flex justify-between items-center gap-3">
+                  <Typography.Text className="text-brand-gray200 text-xs sm:text-sm">
+                    Output #{output.n}:
+                  </Typography.Text>
+                  <Typography.Text className="text-white text-xs sm:text-sm font-semibold text-right">
+                    {rawValue !== undefined
+                      ? formatSyscoinValue(rawValue, 8)
+                      : output.value}{' '}
+                    {activeNetwork.currency.toUpperCase()}
+                  </Typography.Text>
+                </div>
+                {recipient ? (
+                  <CopyableField
+                    label="Recipient"
+                    value={recipient}
+                    displayValue={ellipsis(recipient, 10, 10)}
+                    monospace
+                    copyMessage={t('home.addressCopied')}
+                    className="text-xs sm:text-sm"
+                    labelClassName="text-xs sm:text-sm"
+                    valueClassName="text-xs sm:text-sm"
+                  />
+                ) : (
+                  <div className="flex justify-between items-center gap-3">
+                    <Typography.Text className="text-brand-gray200 text-xs sm:text-sm">
+                      Output type:
+                    </Typography.Text>
+                    <Typography.Text className="text-white text-xs sm:text-sm text-right">
+                      {output.scriptPubKey?.type || 'Unknown'}
+                    </Typography.Text>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
 
       {/* Asset Transfers - show all assets involved */}
       {(() => (
@@ -564,6 +658,74 @@ const SyscoinTransactionDetailsFromPSBTComponent: React.FC<
                           valueClassName="text-xs sm:text-sm"
                         />
                       </div>
+
+                      {assetInfo.assetType && (
+                        <div className="flex justify-between items-center gap-3">
+                          <Typography.Text className="text-brand-gray200 text-xs sm:text-sm">
+                            Standard:
+                          </Typography.Text>
+                          <Typography.Text className="text-white text-xs sm:text-sm font-semibold text-right">
+                            {assetInfo.assetType}
+                          </Typography.Text>
+                        </div>
+                      )}
+
+                      {assetInfo.contract && (
+                        <CopyableField
+                          label="Origin contract"
+                          value={assetInfo.contract}
+                          displayValue={ellipsis(assetInfo.contract, 10, 10)}
+                          monospace
+                          copyMessage={t('home.addressCopied')}
+                          className="text-xs sm:text-sm"
+                          labelClassName="text-xs sm:text-sm"
+                          valueClassName="text-xs sm:text-sm"
+                        />
+                      )}
+
+                      {assetInfo.tokenId && (
+                        <CopyableField
+                          label="Token ID"
+                          value={assetInfo.tokenId}
+                          displayValue={ellipsis(assetInfo.tokenId, 10, 10)}
+                          monospace
+                          className="text-xs sm:text-sm"
+                          labelClassName="text-xs sm:text-sm"
+                          valueClassName="text-xs sm:text-sm"
+                        />
+                      )}
+
+                      {assetReviewRows
+                        .filter(
+                          (row) => row.assetGuid === primaryAsset.assetGuid
+                        )
+                        .map((row) => (
+                          <div
+                            key={`${row.assetGuid}-${row.outputIndex}`}
+                            className="pt-2 border-t border-alpha-whiteAlpha100 space-y-2"
+                          >
+                            <div className="flex justify-between items-center gap-3">
+                              <Typography.Text className="text-brand-gray200 text-xs sm:text-sm">
+                                {row.isBurn ? 'Burn amount:' : 'Amount:'}
+                              </Typography.Text>
+                              <Typography.Text className="text-white text-xs sm:text-sm font-semibold text-right">
+                                {row.amount} {row.symbol}
+                              </Typography.Text>
+                            </div>
+                            {row.recipient && (
+                              <CopyableField
+                                label="Recipient"
+                                value={row.recipient}
+                                displayValue={ellipsis(row.recipient, 10, 10)}
+                                monospace
+                                copyMessage={t('home.addressCopied')}
+                                className="text-xs sm:text-sm"
+                                labelClassName="text-xs sm:text-sm"
+                                valueClassName="text-xs sm:text-sm"
+                              />
+                            )}
+                          </div>
+                        ))}
                     </div>
                   </div>
                 );
@@ -606,7 +768,7 @@ const SyscoinTransactionDetailsFromPSBTComponent: React.FC<
                   if (output.assetInfo.value) {
                     assetAmount = formatSyscoinValue(
                       output.assetInfo.value.toString(),
-                      assetInfo.decimals || 8
+                      assetInfo.decimals ?? 8
                     );
                   }
                 } else if (decodedTx.syscoin?.allocations?.assets) {
@@ -626,7 +788,7 @@ const SyscoinTransactionDetailsFromPSBTComponent: React.FC<
                       };
                       assetAmount = formatSyscoinValue(
                         allocation.value.toString(),
-                        assetInfo.decimals || 8
+                        assetInfo.decimals ?? 8
                       );
                       break;
                     }
@@ -863,7 +1025,7 @@ const SyscoinTransactionDetailsFromPSBTComponent: React.FC<
                               {input.assetInfo.value
                                 ? formatSyscoinValue(
                                     input.assetInfo.value.toString(),
-                                    input.assetInfo.decimals || 8
+                                    input.assetInfo.decimals ?? 8
                                   )
                                 : '0'}{' '}
                               {input.assetInfo.symbol ||
@@ -935,5 +1097,6 @@ export const SyscoinTransactionDetailsFromPSBT = React.memo(
     prevProps.psbt === nextProps.psbt &&
     prevProps.transaction?.psbt === nextProps.transaction?.psbt &&
     prevProps.showTechnicalDetails === nextProps.showTechnicalDetails &&
-    prevProps.showTransactionOptions === nextProps.showTransactionOptions
+    prevProps.showTransactionOptions === nextProps.showTransactionOptions &&
+    prevProps.onReviewStateChange === nextProps.onReviewStateChange
 );

--- a/source/components/TransactionDetails/SyscoinTransactionDetailsFromPSBT.tsx
+++ b/source/components/TransactionDetails/SyscoinTransactionDetailsFromPSBT.tsx
@@ -563,7 +563,17 @@ const SyscoinTransactionDetailsFromPSBTComponent: React.FC<
             Transaction outputs
           </Typography.Text>
           {decodedTx.vout.map((output) => {
-            const recipient = output.scriptPubKey?.addresses?.[0];
+            const outputType = output.scriptPubKey?.type;
+            const isCanonicalAddressOutput = [
+              'pubkeyhash',
+              'scripthash',
+              'witness_v0_keyhash',
+              'witness_v0_scripthash',
+              'witness_v1_taproot',
+            ].includes(outputType);
+            const recipient = isCanonicalAddressOutput
+              ? output.scriptPubKey?.addresses?.[0]
+              : undefined;
             const rawValue = output.valueSatoshis;
 
             return (
@@ -594,14 +604,25 @@ const SyscoinTransactionDetailsFromPSBTComponent: React.FC<
                     valueClassName="text-xs sm:text-sm"
                   />
                 ) : (
-                  <div className="flex justify-between items-center gap-3">
-                    <Typography.Text className="text-brand-gray200 text-xs sm:text-sm">
-                      Output type:
-                    </Typography.Text>
-                    <Typography.Text className="text-white text-xs sm:text-sm text-right">
-                      {output.scriptPubKey?.type || 'Unknown'}
-                    </Typography.Text>
-                  </div>
+                  <>
+                    <div className="flex justify-between items-center gap-3">
+                      <Typography.Text className="text-brand-gray200 text-xs sm:text-sm">
+                        Output type:
+                      </Typography.Text>
+                      <Typography.Text className="text-white text-xs sm:text-sm text-right">
+                        {outputType || 'Unknown'}
+                      </Typography.Text>
+                    </div>
+                    <CopyableField
+                      label="Output script"
+                      value={output.scriptPubKey?.hex || ''}
+                      monospace
+                      copyMessage={t('home.addressCopied')}
+                      className="text-xs sm:text-sm items-start"
+                      labelClassName="text-xs sm:text-sm"
+                      valueClassName="text-xs sm:text-sm break-all"
+                    />
+                  </>
                 )}
               </div>
             );

--- a/source/config/consts.js
+++ b/source/config/consts.js
@@ -80,7 +80,7 @@ const CANARY_EXTENSION_KEY =
 const MV3_OPTIONS = {
   manifest_version: 3,
   name: 'Pali Wallet',
-  version: '4.0.62',
+  version: '4.0.63',
   icons: {
     16: 'assets/all_assets/favicon-16.png',
     32: 'assets/all_assets/favicon-32.png',

--- a/source/pages/Home/Panel/components/Assets/SyscoinDetails.tsx
+++ b/source/pages/Home/Panel/components/Assets/SyscoinDetails.tsx
@@ -70,7 +70,7 @@ export const SyscoinAssetDetails = ({
       symbol: navigationState.symbol || 'Unknown',
       name: navigationState.name || navigationState.symbol || 'Unknown Token',
       balance: navigationState.balance || 0,
-      decimals: navigationState.decimals || 8,
+      decimals: navigationState.decimals ?? 8,
       chainId: activeNetwork.chainId,
       type: navigationState.type || 'SPTAllocated',
       image: navigationState.logo,

--- a/source/pages/Home/Panel/components/Assets/SyscoinList.tsx
+++ b/source/pages/Home/Panel/components/Assets/SyscoinList.tsx
@@ -26,6 +26,7 @@ import {
 } from 'state/vault/selectors';
 import { formatCurrency, truncate, getTokenLogo } from 'utils/index';
 import { navigateWithContext } from 'utils/navigationState';
+import { hasNonZeroAssetDelta } from 'utils/syscoinAssetAmount';
 
 //todo: create a loading state
 export const SyscoinAssetsList = () => {
@@ -180,8 +181,7 @@ export const SyscoinAssetsList = () => {
                     </span>
 
                     {/* Pending if token has non-zero unconfirmed delta or an unconfirmed transfer exists */}
-                    {((typeof asset.unconfirmedBalance === 'number' &&
-                      asset.unconfirmedBalance !== 0) ||
+                    {(hasNonZeroAssetDelta(asset.unconfirmedBalance) ||
                       pendingAssetGuids.has(String(asset.assetGuid))) && (
                       <span
                         className="px-2 py-0.5 text-[9px] bg-yellow-500/20 text-yellow-500 rounded-full border border-yellow-500/20 font-medium animate-pulse"

--- a/source/pages/Send/SendSys.tsx
+++ b/source/pages/Send/SendSys.tsx
@@ -497,7 +497,8 @@ export const SendSys = () => {
       } else {
         const builderAmount = toEightDecimalBuilderAmount(
           String(amount),
-          assetDecimals
+          assetDecimals,
+          selectedAsset.assetType
         );
 
         // For tokens, we need to estimate the fee for display
@@ -881,7 +882,11 @@ export const SendSys = () => {
 
                       if (selectedAsset) {
                         try {
-                          assertValidAssetAmount(inputAmount, assetDecimals);
+                          assertValidAssetAmount(
+                            inputAmount,
+                            assetDecimals,
+                            selectedAsset.assetType
+                          );
                         } catch {
                           return Promise.reject(
                             new Error(t('send.invalidAmount'))

--- a/source/pages/Send/SendSys.tsx
+++ b/source/pages/Send/SendSys.tsx
@@ -36,6 +36,7 @@ import {
   isAssetAmountWithinBalance,
   toEightDecimalBuilderAmount,
 } from 'utils/syscoinAssetAmount';
+import { getRefreshedSyscoinAssetSelection } from 'utils/syscoinAssetSelection';
 import { sanitizeErrorMessage } from 'utils/syscoinErrorSanitizer';
 import { isValidSYSAddress } from 'utils/validations';
 
@@ -93,21 +94,15 @@ export const SendSys = () => {
   useEffect(() => {
     if (!selectedAsset || !accountAssets?.syscoin) return;
 
-    const refreshedAsset = Object.values(accountAssets.syscoin).find(
-      (asset) => String(asset.assetGuid) === String(selectedAsset.assetGuid)
+    const refreshedAsset = getRefreshedSyscoinAssetSelection(
+      selectedAsset,
+      accountAssets.syscoin
     );
 
-    if (
-      refreshedAsset &&
-      String(refreshedAsset.balance || 0) !== String(selectedAsset.balance || 0)
-    ) {
+    if (refreshedAsset) {
       setSelectedAsset(refreshedAsset);
     }
-  }, [
-    accountAssets?.syscoin,
-    selectedAsset?.assetGuid,
-    selectedAsset?.balance,
-  ]);
+  }, [accountAssets?.syscoin, selectedAsset]);
 
   // Save navigation state when user completes interaction
   const saveCurrentState = useCallback(async () => {

--- a/source/pages/Send/SendSys.tsx
+++ b/source/pages/Send/SendSys.tsx
@@ -22,10 +22,8 @@ import { ITokenSysProps } from 'types/tokens';
 import { handleTransactionError } from 'utils/errorHandling';
 import { formatSyscoinValue } from 'utils/formatSyscoinValue';
 import {
-  truncate,
   isNFT,
   getAssetBalance,
-  formatCurrency,
   ellipsis,
   MINIMUM_FEE,
   adjustUrl,
@@ -33,6 +31,11 @@ import {
   navigateWithContext,
   saveNavigationState,
 } from 'utils/index';
+import {
+  assertValidAssetAmount,
+  isAssetAmountWithinBalance,
+  toEightDecimalBuilderAmount,
+} from 'utils/syscoinAssetAmount';
 import { sanitizeErrorMessage } from 'utils/syscoinErrorSanitizer';
 import { isValidSYSAddress } from 'utils/validations';
 
@@ -96,7 +99,7 @@ export const SendSys = () => {
 
     if (
       refreshedAsset &&
-      Number(refreshedAsset.balance || 0) !== Number(selectedAsset.balance || 0)
+      String(refreshedAsset.balance || 0) !== String(selectedAsset.balance || 0)
     ) {
       setSelectedAsset(refreshedAsset);
     }
@@ -210,28 +213,17 @@ export const SendSys = () => {
   );
 
   const assetDecimals = useMemo(
-    () =>
-      selectedAsset && selectedAsset?.decimals ? selectedAsset.decimals : 8,
+    () => selectedAsset?.decimals ?? 8,
     [selectedAsset?.decimals]
-  );
-
-  const formattedAssetBalance = useMemo(
-    () =>
-      selectedAsset &&
-      truncate(
-        formatCurrency(String(+selectedAsset.balance), selectedAsset.decimals),
-        14
-      ),
-    [selectedAsset, assetDecimals]
   );
 
   // Keep balance as string to preserve precision
   const balanceStr = useMemo(
     () =>
       selectedAsset
-        ? formattedAssetBalance || '0'
+        ? String(selectedAsset.balance ?? '0')
         : activeAccount?.balances[INetworkType.Syscoin] || '0',
-    [selectedAsset, formattedAssetBalance, activeAccount?.balances]
+    [selectedAsset, activeAccount?.balances]
   );
 
   const handleMaxButton = useCallback(() => {
@@ -503,6 +495,11 @@ export const SendSys = () => {
           returnContext
         );
       } else {
+        const builderAmount = toEightDecimalBuilderAmount(
+          String(amount),
+          assetDecimals
+        );
+
         // For tokens, we need to estimate the fee for display
         let tokenFeeEstimate = MINIMUM_FEE; // Default
         let tokenPsbt = null;
@@ -511,7 +508,7 @@ export const SendSys = () => {
             ['wallet', 'syscoinTransaction', 'getEstimateSysTransactionFee'],
             [
               {
-                amount: amount, // Keep as string to preserve precision
+                amount: builderAmount,
                 receivingAddress: receiver,
                 feeRate,
                 txOptions: { rbf: RBF },
@@ -882,21 +879,37 @@ export const SendSys = () => {
                         );
                       }
 
-                      // Get balance as string to preserve precision
-                      let validationBalanceStr: string;
                       if (selectedAsset) {
-                        // For assets, the balance is already formatted
-                        validationBalanceStr = formattedAssetBalance
-                          ? String(formattedAssetBalance)
-                          : '0';
-                      } else {
-                        // For native SYS, balance is already in decimal format
-                        validationBalanceStr = activeAccount?.balances[
-                          INetworkType.Syscoin
-                        ]
-                          ? String(activeAccount.balances[INetworkType.Syscoin])
-                          : '0';
+                        try {
+                          assertValidAssetAmount(inputAmount, assetDecimals);
+                        } catch {
+                          return Promise.reject(
+                            new Error(t('send.invalidAmount'))
+                          );
+                        }
+
+                        if (
+                          !isAssetAmountWithinBalance(
+                            inputAmount,
+                            String(selectedAsset.balance ?? '0'),
+                            assetDecimals
+                          )
+                        ) {
+                          return Promise.reject(
+                            new Error(t('send.insufficientFunds'))
+                          );
+                        }
+
+                        return Promise.resolve();
                       }
+
+                      // Get balance as string to preserve precision
+                      // Native SYS balance is already in decimal format.
+                      const validationBalanceStr = activeAccount?.balances[
+                        INetworkType.Syscoin
+                      ]
+                        ? String(activeAccount.balances[INetworkType.Syscoin])
+                        : '0';
 
                       // Use currency.js with 8 decimal precision for safe comparison
                       try {

--- a/source/pages/Tokens/SyscoinImport.tsx
+++ b/source/pages/Tokens/SyscoinImport.tsx
@@ -210,7 +210,7 @@ export const SyscoinImport: React.FC = () => {
   const convertToImportableAssets = useCallback(
     (tokens: (ISysTokensAssetReponse | ITokenSysProps)[]) =>
       tokens.map((token) => {
-        const decimals = token.decimals || 8;
+        const decimals = token.decimals ?? 8;
 
         // The balance field is already in display units (e.g., 0.02 means 0.02 tokens)
         // No need to convert from satoshis since the API returns display values
@@ -224,6 +224,10 @@ export const SyscoinImport: React.FC = () => {
           decimals: decimals,
           logo: getTokenLogo(token.symbol || '', true, token.assetGuid),
           assetGuid: token.assetGuid || '',
+          assetType: token.assetType,
+          contract: token.contract,
+          originDecimals: token.originDecimals,
+          tokenId: token.tokenId,
           type: token.type || 'SPTAllocated',
         };
       }),
@@ -245,6 +249,10 @@ export const SyscoinImport: React.FC = () => {
         name: asset.name || asset.symbol,
         decimals: asset.decimals,
         balance: asset.balance,
+        assetType: asset.assetType,
+        contract: asset.contract,
+        originDecimals: asset.originDecimals,
+        tokenId: asset.tokenId,
         chainId: asset.chainId || activeNetwork.chainId,
         type: asset.type || 'SPTAllocated',
         // Store image URL only for known tokens

--- a/source/pages/Transactions/Sign.tsx
+++ b/source/pages/Transactions/Sign.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
@@ -27,6 +27,13 @@ const Sign: React.FC<ISign> = ({ signOnly = false }) => {
   const [initialLoading, setInitialLoading] = useState(true);
   const [confirmed, setConfirmed] = useState(false);
   const [errorMsg, setErrorMsg] = useState('');
+  const [reviewError, setReviewError] = useState<string | null>(
+    'Transaction details are loading'
+  );
+
+  const handleReviewStateChange = useCallback((error: string | null) => {
+    setReviewError(error);
+  }, []);
 
   // Use shallow equality checks to prevent unnecessary re-renders
   const { activeAccount: activeAccountData, accounts } = useSelector(
@@ -63,6 +70,11 @@ const Sign: React.FC<ISign> = ({ signOnly = false }) => {
   }, [data]);
 
   const onSubmit = async () => {
+    if (reviewError) {
+      setErrorMsg(reviewError);
+      return;
+    }
+
     setLoading(true);
 
     try {
@@ -206,6 +218,7 @@ const Sign: React.FC<ISign> = ({ signOnly = false }) => {
                 psbt={data}
                 showTechnicalDetails={false}
                 showTransactionOptions={false}
+                onReviewStateChange={handleReviewStateChange}
               />
             </div>
           </div>
@@ -237,7 +250,7 @@ const Sign: React.FC<ISign> = ({ signOnly = false }) => {
               <Button
                 variant="primary"
                 type="submit"
-                disabled={confirmed}
+                disabled={confirmed || Boolean(reviewError)}
                 loading={loading}
                 onClick={onSubmit}
               >

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -3,6 +3,7 @@
 import {
   KeyringManager,
   CustomJsonRpcProvider,
+  PsbtUtils,
 } from '@sidhujag/sysweb3-keyring';
 import {
   getSysRpc,
@@ -149,6 +150,7 @@ import type {
   SmartAccountPackedUserOperation,
 } from 'utils/smartAccount';
 import { chromeStorage } from 'utils/storageAPI';
+import { getSyscoinPsbtValueSummary } from 'utils/syscoinPsbtValues';
 import { getKnownTokenLogo } from 'utils/tokens';
 import {
   isTransactionInBlock,
@@ -6542,7 +6544,30 @@ class MainController {
   // Add decodeRawTransaction method for PSBT/transaction details display
   public decodeRawTransaction = (psbtOrHex: any, isRawHex = false) => {
     try {
-      return this.syscoinTransaction.decodeRawTransaction(psbtOrHex, isRawHex);
+      const decoded = this.syscoinTransaction.decodeRawTransaction(
+        psbtOrHex,
+        isRawHex
+      );
+
+      if (!isRawHex) {
+        const psbt = PsbtUtils.fromPali(
+          psbtOrHex,
+          store.getState().vault.activeNetwork
+        );
+        const summary = getSyscoinPsbtValueSummary(psbt);
+        if (
+          !Array.isArray(decoded.vout) ||
+          decoded.vout.length !== summary.outputValuesSatoshis.length
+        ) {
+          throw new Error('Decoded outputs do not match the PSBT');
+        }
+        decoded.feeSatoshis = summary.feeSatoshis;
+        decoded.vout.forEach((output: any, index: number) => {
+          output.valueSatoshis = summary.outputValuesSatoshis[index];
+        });
+      }
+
+      return decoded;
     } catch (error) {
       console.error('Error decoding raw transaction:', error);
       throw new Error(`Failed to decode raw transaction: ${error.message}`);

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -6565,6 +6565,11 @@ class MainController {
         decoded.vout.forEach((output: any, index: number) => {
           output.valueSatoshis = summary.outputValuesSatoshis[index];
         });
+        if (decoded.syscoin) {
+          decoded.syscoin.allocations = summary.assetAllocations.length
+            ? { assets: summary.assetAllocations }
+            : null;
+        }
       }
 
       return decoded;

--- a/source/scripts/Background/controllers/assets/syscoin.spec.ts
+++ b/source/scripts/Background/controllers/assets/syscoin.spec.ts
@@ -52,7 +52,7 @@ describe('SysAssetsController imported asset refresh', () => {
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
       assetGuid: '123',
-      balance: 2.5,
+      balance: '2.5',
       chainId: 57,
       description: 'user metadata',
       image: 'ipfs://token-image',
@@ -82,10 +82,51 @@ describe('SysAssetsController imported asset refresh', () => {
 
     expect(result[0]).toMatchObject({
       assetGuid: '456',
-      balance: 0,
+      balance: '0',
       chainId: 5700,
       description: 'durable metadata',
       image: 'ipfs://durable-image',
+    });
+  });
+
+  it('preserves zero-decimal NFT and ERC-1155 balances', async () => {
+    fetchBackendAccountCachedMock.mockResolvedValue({
+      tokensAsset: [
+        {
+          assetGuid: '4294967297',
+          balance: '2',
+          decimals: 0,
+          symbol: 'NFT',
+          totalReceived: '2',
+          totalSent: '0',
+          transfers: 1,
+          type: 'SPTAllocated',
+        },
+      ],
+    });
+
+    const result = await SysAssetsController().getSysAssetsByXpub(
+      'zpub-account',
+      'https://blockbook.syscoin.org',
+      57,
+      [
+        {
+          assetGuid: '4294967297',
+          balance: 0,
+          chainId: 57,
+          decimals: 0,
+          name: 'NFT',
+          symbol: 'NFT',
+          type: 'SPTAllocated',
+        } as any,
+      ]
+    );
+
+    expect(result[0]).toMatchObject({
+      assetGuid: '4294967297',
+      balance: '2',
+      decimals: 0,
+      totalReceived: '2',
     });
   });
 });

--- a/source/scripts/Background/controllers/assets/syscoin.ts
+++ b/source/scripts/Background/controllers/assets/syscoin.ts
@@ -128,20 +128,18 @@ const SysAssetsControler = (): ISysAssetsController => {
       .map(([assetGuid, tokens]) => {
         // Take the first token as the base (for metadata)
         const firstToken = tokens[0];
-        const decimals = firstToken.decimals || 8;
+        const decimals = firstToken.decimals ?? 8;
 
         // Sum up balances from all UTXOs for this asset
-        let totalConfirmedBalance = 0;
-        let totalUnconfirmedBalance = 0;
+        let totalConfirmedBalance = BigInt(0);
+        let totalUnconfirmedBalance = BigInt(0);
         let totalSent = BigInt(0);
         let totalReceived = BigInt(0);
         let totalTransfers = 0;
 
         tokens.forEach((token: any) => {
           // Add confirmed balance
-          totalConfirmedBalance += parseFloat(
-            formatUnits(String(token.balance || 0), decimals)
-          );
+          totalConfirmedBalance += BigInt(String(token.balance || 0));
 
           // Add unconfirmed delta (can be positive or negative)
           // Blockbook now provides per-address SPT unconfirmed deltas
@@ -149,9 +147,7 @@ const SysAssetsControler = (): ISysAssetsController => {
             token.unconfirmedBalance !== undefined
               ? token.unconfirmedBalance
               : 0;
-          totalUnconfirmedBalance += parseFloat(
-            formatUnits(String(unconfirmedRaw || 0), decimals)
-          );
+          totalUnconfirmedBalance += BigInt(String(unconfirmedRaw || 0));
 
           // Sum up totals (using BigInt to avoid precision issues)
           totalSent += BigInt(token.totalSent || 0);
@@ -160,15 +156,24 @@ const SysAssetsControler = (): ISysAssetsController => {
         });
 
         // Real-time balance is confirmed + unconfirmed delta
-        const displayBalance = totalConfirmedBalance + totalUnconfirmedBalance;
+        const displayBalance = formatUnits(
+          (totalConfirmedBalance + totalUnconfirmedBalance).toString(),
+          decimals
+        );
 
         return {
           ...firstToken,
           assetGuid: assetGuid,
           // Use aggregated balances
           balance: displayBalance,
-          confirmedBalance: totalConfirmedBalance,
-          unconfirmedBalance: totalUnconfirmedBalance,
+          confirmedBalance: formatUnits(
+            totalConfirmedBalance.toString(),
+            decimals
+          ),
+          unconfirmedBalance: formatUnits(
+            totalUnconfirmedBalance.toString(),
+            decimals
+          ),
           totalSent: formatUnits(totalSent.toString(), decimals),
           totalReceived: formatUnits(totalReceived.toString(), decimals),
           transfers: totalTransfers,
@@ -222,7 +227,7 @@ const SysAssetsControler = (): ISysAssetsController => {
       }
 
       // Get user's balance for this asset (optional)
-      let balance: number = 0;
+      let balance = '0';
       try {
         // Blockbook doesn't support filtering by assetGuid, so we fetch all tokens
         const requestOptions = 'details=tokenBalances&tokens=nonzero';
@@ -244,15 +249,15 @@ const SysAssetsControler = (): ISysAssetsController => {
 
         if (matchingTokens.length > 0) {
           // Convert from satoshis to display format and aggregate across all UTXOs
-          const decimals = assetData.decimals || 8;
+          const decimals = assetData.decimals ?? 8;
 
           // Sum up balances from all UTXOs for this asset
-          balance = matchingTokens.reduce((total: number, token: any) => {
-            const tokenBalance = parseFloat(
-              formatUnits(String(token.balance || 0), decimals)
-            );
-            return total + tokenBalance;
-          }, 0);
+          const rawBalance = matchingTokens.reduce(
+            (total: bigint, token: any) =>
+              total + BigInt(String(token.balance || 0)),
+            BigInt(0)
+          );
+          balance = formatUnits(rawBalance.toString(), decimals);
 
           console.log(
             `[SysAssetsController] Found ${matchingTokens.length} UTXOs for asset ${assetGuid}, total balance: ${balance}`
@@ -269,6 +274,7 @@ const SysAssetsControler = (): ISysAssetsController => {
       // Return validated token details
       const tokenDetails: ITokenSysProps = {
         assetGuid: assetGuid,
+        assetType: assetData.assetType,
         symbol: cleanTokenSymbol(assetData.symbol),
         name: cleanTokenSymbol(assetData.symbol), // Syscoin assets often use symbol as name - keep intact
         decimals: assetData.decimals,
@@ -277,6 +283,8 @@ const SysAssetsControler = (): ISysAssetsController => {
         totalSupply: assetData.totalSupply,
         description: assetData.metaData || '',
         contract: assetData.contract || '', // NEVM contract if bridged
+        originDecimals: assetData.originDecimals,
+        tokenId: assetData.tokenId,
         chainId: store.getState().vault.activeNetwork.chainId,
         type: 'SPTAllocated',
       };
@@ -358,27 +366,23 @@ const SysAssetsControler = (): ISysAssetsController => {
     tokensByAssetGuid.forEach((tokens, assetGuid) => {
       // Take the first token as the base (for metadata)
       const firstToken = tokens[0];
-      const decimals = firstToken.decimals || 8;
+      const decimals = firstToken.decimals ?? 8;
 
       // Sum up balances from all UTXOs for this asset
-      let totalConfirmedBalance = 0;
-      let totalUnconfirmedBalance = 0;
+      let totalConfirmedBalance = BigInt(0);
+      let totalUnconfirmedBalance = BigInt(0);
       let totalSent = BigInt(0);
       let totalReceived = BigInt(0);
       let totalTransfers = 0;
 
       tokens.forEach((token: any) => {
         // Add confirmed balance
-        totalConfirmedBalance += parseFloat(
-          formatUnits(String(token.balance || 0), decimals)
-        );
+        totalConfirmedBalance += BigInt(String(token.balance || 0));
 
         // Add unconfirmed delta (positive for receiver, negative for sender)
         const unconfirmedRaw =
           token.unconfirmedBalance !== undefined ? token.unconfirmedBalance : 0;
-        totalUnconfirmedBalance += parseFloat(
-          formatUnits(String(unconfirmedRaw || 0), decimals)
-        );
+        totalUnconfirmedBalance += BigInt(String(unconfirmedRaw || 0));
 
         // Sum up totals (using BigInt to avoid precision issues)
         totalSent += BigInt(token.totalSent || 0);
@@ -387,14 +391,23 @@ const SysAssetsControler = (): ISysAssetsController => {
       });
 
       // Real-time balance is confirmed + unconfirmed delta
-      const displayBalance = totalConfirmedBalance + totalUnconfirmedBalance;
+      const displayBalance = formatUnits(
+        (totalConfirmedBalance + totalUnconfirmedBalance).toString(),
+        decimals
+      );
 
       aggregatedTokensMap.set(assetGuid, {
         ...firstToken,
         assetGuid: assetGuid,
         balance: displayBalance,
-        confirmedBalance: totalConfirmedBalance,
-        unconfirmedBalance: totalUnconfirmedBalance,
+        confirmedBalance: formatUnits(
+          totalConfirmedBalance.toString(),
+          decimals
+        ),
+        unconfirmedBalance: formatUnits(
+          totalUnconfirmedBalance.toString(),
+          decimals
+        ),
         totalSent: formatUnits(totalSent.toString(), decimals),
         totalReceived: formatUnits(totalReceived.toString(), decimals),
         transfers: totalTransfers,
@@ -428,8 +441,8 @@ const SysAssetsControler = (): ISysAssetsController => {
           return {
             ...asset,
             assetGuid: String(asset.assetGuid),
-            balance: 0,
-            unconfirmedBalance: 0,
+            balance: '0',
+            unconfirmedBalance: '0',
             totalReceived: '0',
             totalSent: '0',
             transfers: 0,

--- a/source/scripts/Background/controllers/assets/types.ts
+++ b/source/scripts/Background/controllers/assets/types.ts
@@ -58,18 +58,22 @@ export interface ISysAssetsController {
 
 export interface ISysTokensAssetReponse {
   assetGuid: string;
-  balance: number;
+  assetType?: 'SYSX' | 'ERC20' | 'ERC721' | 'ERC1155';
+  balance: number | string;
   chainId?: number;
-  confirmedBalance?: number;
+  confirmedBalance?: number | string;
+  contract?: string;
   decimals: number;
   name: string;
+  originDecimals?: number;
   path: string;
   symbol: string;
+  tokenId?: string;
   totalReceived: string;
   totalSent: string;
   transfers: number;
   type: string;
-  unconfirmedBalance?: number;
+  unconfirmedBalance?: number | string;
 }
 
 // EVM TYPES

--- a/source/types/tokens.ts
+++ b/source/types/tokens.ts
@@ -98,7 +98,8 @@ export interface IWatchAssetTokenProps {
 
 export interface ITokenSysProps {
   assetGuid?: string;
-  balance?: number;
+  assetType?: 'SYSX' | 'ERC20' | 'ERC721' | 'ERC1155';
+  balance?: number | string;
   chainId?: number;
   contract?: string; // NEVM contract address for cross-chain assets
   decimals?: number;
@@ -107,8 +108,10 @@ export interface ITokenSysProps {
   maxSupply?: string;
   metaData?: string; // Syscoin 5 - general metadata field
   name?: string;
+  originDecimals?: number;
   path?: string;
   symbol?: string;
+  tokenId?: string;
   totalReceived?: string;
   totalSent?: string;
   totalSupply?: string;
@@ -119,11 +122,14 @@ export interface ITokenSysProps {
 // Interface for getSysAssetMetadata response (matches getAsset return type)
 export interface ISysAssetMetadata {
   assetGuid: string;
+  assetType?: 'SYSX' | 'ERC20' | 'ERC721' | 'ERC1155';
   contract: string;
   decimals: number;
   maxSupply: string;
   metaData?: string; // Syscoin 5 - general metadata field
+  originDecimals?: number;
   symbol: string;
+  tokenId?: string;
   totalSupply: string;
 }
 

--- a/source/utils/syscoinAssetAmount.spec.ts
+++ b/source/utils/syscoinAssetAmount.spec.ts
@@ -1,5 +1,6 @@
 import {
   assertValidAssetAmount,
+  hasNonZeroAssetDelta,
   isAssetAmountWithinBalance,
   toEightDecimalBuilderAmount,
 } from './syscoinAssetAmount';
@@ -42,6 +43,15 @@ describe('Syscoin asset amount conversion', () => {
   it('rejects malformed, zero, and negative amounts', () => {
     for (const amount of ['', '0', '-1', '1e2', '1.2.3', '1'.repeat(21)]) {
       expect(() => assertValidAssetAmount(amount, 8)).toThrow();
+    }
+  });
+
+  it('detects exact nonzero unconfirmed balance strings', () => {
+    for (const amount of [1, -1, '0.00000001', '-0.00000001']) {
+      expect(hasNonZeroAssetDelta(amount)).toBe(true);
+    }
+    for (const amount of [undefined, 0, '0', '0.00000000', '-0.0', 'invalid']) {
+      expect(hasNonZeroAssetDelta(amount)).toBe(false);
     }
   });
 });

--- a/source/utils/syscoinAssetAmount.spec.ts
+++ b/source/utils/syscoinAssetAmount.spec.ts
@@ -1,0 +1,47 @@
+import {
+  assertValidAssetAmount,
+  isAssetAmountWithinBalance,
+  toEightDecimalBuilderAmount,
+} from './syscoinAssetAmount';
+
+describe('Syscoin asset amount conversion', () => {
+  it('converts zero-decimal NFT quantities to exact builder units', () => {
+    expect(toEightDecimalBuilderAmount('1', 0)).toBe('0.00000001');
+    expect(toEightDecimalBuilderAmount('25', 0)).toBe('0.00000025');
+  });
+
+  it('preserves eight-decimal fungible SPT amounts', () => {
+    expect(toEightDecimalBuilderAmount('1.23000000', 8)).toBe('1.23000000');
+  });
+
+  it('supports native SPT precisions without using Number', () => {
+    expect(toEightDecimalBuilderAmount('1.23', 2)).toBe('0.00000123');
+    expect(toEightDecimalBuilderAmount('90071992.54740991', 8)).toBe(
+      '90071992.54740991'
+    );
+  });
+
+  it('compares large ERC-1155 balances without Number precision loss', () => {
+    expect(
+      isAssetAmountWithinBalance('9007199254740992', '9007199254740993', 0)
+    ).toBe(true);
+    expect(
+      isAssetAmountWithinBalance('9007199254740994', '9007199254740993', 0)
+    ).toBe(false);
+  });
+
+  it('rejects fractional NFT quantities and excess precision', () => {
+    expect(() => assertValidAssetAmount('1.5', 0)).toThrow(
+      'Amount supports at most 0 decimal places'
+    );
+    expect(() => assertValidAssetAmount('1.001', 2)).toThrow(
+      'Amount supports at most 2 decimal places'
+    );
+  });
+
+  it('rejects malformed, zero, and negative amounts', () => {
+    for (const amount of ['', '0', '-1', '1e2', '1.2.3', '1'.repeat(21)]) {
+      expect(() => assertValidAssetAmount(amount, 8)).toThrow();
+    }
+  });
+});

--- a/source/utils/syscoinAssetAmount.spec.ts
+++ b/source/utils/syscoinAssetAmount.spec.ts
@@ -7,8 +7,11 @@ import {
 
 describe('Syscoin asset amount conversion', () => {
   it('converts zero-decimal NFT quantities to exact builder units', () => {
-    expect(toEightDecimalBuilderAmount('1', 0)).toBe('0.00000001');
-    expect(toEightDecimalBuilderAmount('25', 0)).toBe('0.00000025');
+    expect(toEightDecimalBuilderAmount('1', 0, 'ERC721')).toBe('0.00000001');
+    expect(toEightDecimalBuilderAmount('25', 0, 'ERC1155')).toBe('0.00000025');
+    expect(() => toEightDecimalBuilderAmount('2', 0, 'ERC721')).toThrow(
+      'ERC721 transfers require exactly one token'
+    );
   });
 
   it('preserves eight-decimal fungible SPT amounts', () => {

--- a/source/utils/syscoinAssetAmount.ts
+++ b/source/utils/syscoinAssetAmount.ts
@@ -1,4 +1,5 @@
 const SYSCOIN_BUILDER_DECIMALS = 8;
+type AssetType = 'SYSX' | 'ERC20' | 'ERC721' | 'ERC1155';
 
 const normalizeDecimals = (decimals: number): number => {
   if (
@@ -15,7 +16,8 @@ const normalizeDecimals = (decimals: number): number => {
 const parseAssetAmount = (
   amount: string,
   decimals: number,
-  allowZero = false
+  allowZero = false,
+  assetType?: AssetType
 ): bigint => {
   const normalizedDecimals = normalizeDecimals(decimals);
   const normalizedAmount = String(amount).trim();
@@ -41,15 +43,19 @@ const parseAssetAmount = (
   if (rawAmount < BigInt(0) || (!allowZero && rawAmount === BigInt(0))) {
     throw new Error('Amount must be greater than zero');
   }
+  if (assetType === 'ERC721' && rawAmount !== BigInt(1)) {
+    throw new Error('ERC721 transfers require exactly one token');
+  }
 
   return rawAmount;
 };
 
 export const assertValidAssetAmount = (
   amount: string,
-  decimals: number
+  decimals: number,
+  assetType?: AssetType
 ): void => {
-  parseAssetAmount(amount, decimals);
+  parseAssetAmount(amount, decimals, false, assetType);
 };
 
 export const isAssetAmountWithinBalance = (
@@ -86,9 +92,15 @@ export const hasNonZeroAssetDelta = (
  */
 export const toEightDecimalBuilderAmount = (
   amount: string,
-  decimals: number
+  decimals: number,
+  assetType?: AssetType
 ): string => {
-  const rawAmount = parseAssetAmount(amount, decimals).toString();
+  const rawAmount = parseAssetAmount(
+    amount,
+    decimals,
+    false,
+    assetType
+  ).toString();
   const padded = rawAmount.padStart(SYSCOIN_BUILDER_DECIMALS + 1, '0');
 
   return `${padded.slice(0, -SYSCOIN_BUILDER_DECIMALS)}.${padded.slice(

--- a/source/utils/syscoinAssetAmount.ts
+++ b/source/utils/syscoinAssetAmount.ts
@@ -1,0 +1,86 @@
+const SYSCOIN_BUILDER_DECIMALS = 8;
+
+const normalizeDecimals = (decimals: number): number => {
+  if (
+    !Number.isInteger(decimals) ||
+    decimals < 0 ||
+    decimals > SYSCOIN_BUILDER_DECIMALS
+  ) {
+    throw new Error('Asset decimals must be an integer between 0 and 8');
+  }
+
+  return decimals;
+};
+
+const parseAssetAmount = (
+  amount: string,
+  decimals: number,
+  allowZero = false
+): bigint => {
+  const normalizedDecimals = normalizeDecimals(decimals);
+  const normalizedAmount = String(amount).trim();
+  const match = /^(0|[1-9]\d*)(?:\.(\d+))?$/.exec(normalizedAmount);
+
+  if (!match) {
+    throw new Error('Amount must be a positive decimal number');
+  }
+  if (match[1].length > 20) {
+    throw new Error('Amount is too large');
+  }
+
+  const fraction = match[2] || '';
+  if (fraction.length > normalizedDecimals) {
+    throw new Error(
+      `Amount supports at most ${normalizedDecimals} decimal places`
+    );
+  }
+
+  const rawAmount = BigInt(
+    `${match[1]}${fraction.padEnd(normalizedDecimals, '0')}`
+  );
+  if (rawAmount < BigInt(0) || (!allowZero && rawAmount === BigInt(0))) {
+    throw new Error('Amount must be greater than zero');
+  }
+
+  return rawAmount;
+};
+
+export const assertValidAssetAmount = (
+  amount: string,
+  decimals: number
+): void => {
+  parseAssetAmount(amount, decimals);
+};
+
+export const isAssetAmountWithinBalance = (
+  amount: string,
+  balance: string,
+  decimals: number
+): boolean => {
+  try {
+    return (
+      parseAssetAmount(amount, decimals) <=
+      parseAssetAmount(balance, decimals, true)
+    );
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * The installed keyring API accepts asset amounts in an eight-decimal display
+ * format. Convert the selected asset's display precision into that exact
+ * format without passing through Number; the keyring then reconstructs the
+ * intended raw UTXO asset units.
+ */
+export const toEightDecimalBuilderAmount = (
+  amount: string,
+  decimals: number
+): string => {
+  const rawAmount = parseAssetAmount(amount, decimals).toString();
+  const padded = rawAmount.padStart(SYSCOIN_BUILDER_DECIMALS + 1, '0');
+
+  return `${padded.slice(0, -SYSCOIN_BUILDER_DECIMALS)}.${padded.slice(
+    -SYSCOIN_BUILDER_DECIMALS
+  )}`;
+};

--- a/source/utils/syscoinAssetAmount.ts
+++ b/source/utils/syscoinAssetAmount.ts
@@ -67,6 +67,17 @@ export const isAssetAmountWithinBalance = (
   }
 };
 
+export const hasNonZeroAssetDelta = (
+  amount: number | string | undefined
+): boolean => {
+  if (amount === undefined) return false;
+
+  const normalizedAmount = String(amount).trim();
+  if (!/^-?(?:\d+(?:\.\d*)?|\.\d+)$/.test(normalizedAmount)) return false;
+
+  return !/^-?0*(?:\.0*)?$/.test(normalizedAmount);
+};
+
 /**
  * The installed keyring API accepts asset amounts in an eight-decimal display
  * format. Convert the selected asset's display precision into that exact

--- a/source/utils/syscoinAssetBuilder.spec.ts
+++ b/source/utils/syscoinAssetBuilder.spec.ts
@@ -1,0 +1,60 @@
+jest.unmock('syscoinjs-lib');
+
+import { SyscoinTransactions } from '@sidhujag/sysweb3-keyring/cjs/transactions/syscoin';
+
+import { toEightDecimalBuilderAmount } from './syscoinAssetAmount';
+
+// Exercise the installed keyring implementation used by Pali, not a duplicate
+// amount parser. The package does not export this class from its public index.
+
+describe('Pali asset amount to keyring builder', () => {
+  const buildAssetOutput = async (
+    amount: string,
+    assetType: 'ERC721' | 'ERC1155'
+  ) => {
+    const assetAllocationSend = jest.fn().mockResolvedValue({
+      fee: 100,
+      psbt: { toBase64: () => 'unsigned-psbt' },
+    });
+    const readOnlySigner = {
+      main: { assetAllocationSend, blockbookURL: 'https://blockbook.test' },
+    };
+    const state = {
+      accounts: {
+        HDAccount: { 0: { address: 'sys1-source', xpub: 'xpub-source' } },
+      },
+      activeAccountId: 0,
+      activeAccountType: 'HDAccount',
+      activeNetwork: { chainId: 57, currency: 'sys', slip44: 57 },
+    };
+    const transactions = new SyscoinTransactions(
+      () => ({ hd: {}, main: readOnlySigner.main }),
+      () => readOnlySigner,
+      () => state,
+      async () => 'sys1-change',
+      {},
+      {}
+    );
+
+    await transactions.getEstimateSysTransactionFee({
+      amount: toEightDecimalBuilderAmount(amount, 0, assetType),
+      feeRate: 0.00000001,
+      receivingAddress: 'sys1-recipient',
+      token: { guid: '4294967297', symbol: 'NFT' },
+    });
+
+    const assetMap = assetAllocationSend.mock.calls[0][1] as Map<
+      string,
+      { outputs: Array<{ value: { toString: () => string } }> }
+    >;
+    return assetMap.get('4294967297')!.outputs[0].value.toString();
+  };
+
+  it('serializes an ERC721 quantity of one as one raw asset unit', async () => {
+    await expect(buildAssetOutput('1', 'ERC721')).resolves.toBe('1');
+  });
+
+  it('serializes ERC1155 integer quantities without 1e8 scaling', async () => {
+    await expect(buildAssetOutput('25', 'ERC1155')).resolves.toBe('25');
+  });
+});

--- a/source/utils/syscoinAssetSelection.spec.ts
+++ b/source/utils/syscoinAssetSelection.spec.ts
@@ -1,0 +1,34 @@
+import { getRefreshedSyscoinAssetSelection } from './syscoinAssetSelection';
+
+describe('Syscoin selected asset refresh', () => {
+  it('replaces stale NFT metadata even when the balance is unchanged', () => {
+    const selectedAsset = {
+      assetGuid: '4294967297',
+      balance: '1',
+      decimals: 8,
+    };
+    const refreshedAsset = {
+      ...selectedAsset,
+      assetType: 'ERC721' as const,
+      decimals: 0,
+      tokenId: '1',
+    };
+
+    expect(
+      getRefreshedSyscoinAssetSelection(selectedAsset, [refreshedAsset])
+    ).toBe(refreshedAsset);
+  });
+
+  it('does not replace an unchanged selection with an equivalent Redux copy', () => {
+    const selectedAsset = {
+      assetGuid: '4294967297',
+      assetType: 'ERC721' as const,
+      balance: '1',
+      decimals: 0,
+    };
+
+    expect(
+      getRefreshedSyscoinAssetSelection(selectedAsset, [{ ...selectedAsset }])
+    ).toBeNull();
+  });
+});

--- a/source/utils/syscoinAssetSelection.ts
+++ b/source/utils/syscoinAssetSelection.ts
@@ -1,0 +1,27 @@
+import { ITokenSysProps } from 'types/tokens';
+
+export const getRefreshedSyscoinAssetSelection = (
+  selectedAsset: ITokenSysProps,
+  accountAssets: ITokenSysProps[]
+): ITokenSysProps | null => {
+  const refreshedAsset = accountAssets.find(
+    (asset) => String(asset.assetGuid) === String(selectedAsset.assetGuid)
+  );
+
+  if (!refreshedAsset) return null;
+
+  const fields = new Set([
+    ...Object.keys(selectedAsset),
+    ...Object.keys(refreshedAsset),
+  ]);
+  const hasChanged = [...fields].some((field) => {
+    const selectedValue = (selectedAsset as Record<string, unknown>)[field];
+    const refreshedValue = (refreshedAsset as Record<string, unknown>)[field];
+
+    return field === 'balance'
+      ? String(selectedValue ?? 0) !== String(refreshedValue ?? 0)
+      : selectedValue !== refreshedValue;
+  });
+
+  return hasChanged ? refreshedAsset : null;
+};

--- a/source/utils/syscoinPsbtReview.spec.ts
+++ b/source/utils/syscoinPsbtReview.spec.ts
@@ -121,7 +121,7 @@ describe('Syscoin PSBT review', () => {
         },
         txtype: 'assetallocation_burn_to_ethereum',
       },
-      vout: [{ n: 1, scriptPubKey: { type: 'nulldata' } }],
+      vout: [{ n: 1, scriptPubKey: { hex: '6a0100', type: 'nulldata' } }],
     };
     const metadata = {
       '123': {
@@ -139,5 +139,43 @@ describe('Syscoin PSBT review', () => {
 
     decoded.syscoin.allocations.assets[0].values[0].value = '123000000';
     expect(getSyscoinPsbtReviewError(decoded, metadata)).toBeNull();
+  });
+
+  it('fails closed when an asset transaction has no exact allocations', () => {
+    expect(
+      getSyscoinPsbtReviewError(
+        {
+          feeSatoshis: '1000',
+          syscoin: { allocations: null, txtype: 'assetallocation_send' },
+          vout: [],
+        },
+        {}
+      )
+    ).toBe('Unable to verify Syscoin asset allocations');
+  });
+
+  it('requires the exact script for addressless outputs', () => {
+    const decoded = decodedTransfer('123456', '123000000');
+    (decoded.vout[0] as any).scriptPubKey = {
+      addresses: [],
+      type: 'pubkey',
+    };
+
+    expect(
+      getSyscoinPsbtReviewError(decoded, {
+        '123456': { assetType: 'SYSX', decimals: 8 },
+      })
+    ).toBe('Unable to verify output 1 script');
+
+    (decoded.vout[0] as any).scriptPubKey = {
+      addresses: [],
+      hex: '2102',
+      type: 'pubkey',
+    };
+    expect(
+      getSyscoinPsbtReviewError(decoded, {
+        '123456': { assetType: 'SYSX', decimals: 8 },
+      })
+    ).toBeNull();
   });
 });

--- a/source/utils/syscoinPsbtReview.spec.ts
+++ b/source/utils/syscoinPsbtReview.spec.ts
@@ -1,0 +1,143 @@
+import {
+  getAssetReviewRows,
+  getSyscoinPsbtReviewError,
+} from './syscoinPsbtReview';
+
+const decodedTransfer = (assetGuid: string, value: string) => ({
+  feeSatoshis: '1000',
+  syscoin: {
+    allocations: { assets: [{ assetGuid, values: [{ n: 1, value }] }] },
+    txtype: 'assetallocation_send',
+  },
+  vout: [
+    {
+      n: 1,
+      scriptPubKey: {
+        addresses: ['tsys1-recipient'],
+        type: 'witness_v0_keyhash',
+      },
+    },
+  ],
+});
+
+describe('Syscoin PSBT review', () => {
+  it('shows zero-decimal NFT and ERC-1155 quantities exactly', () => {
+    const decoded = decodedTransfer('4294967297', '2');
+    const metadata = {
+      '4294967297': {
+        assetType: 'ERC1155' as const,
+        contract: '0x1111111111111111111111111111111111111111',
+        decimals: 0,
+        originDecimals: 0,
+        symbol: 'NFT',
+        assetGuid: '4294967297',
+        tokenId: '7',
+      },
+    };
+
+    expect(getSyscoinPsbtReviewError(decoded, metadata)).toBeNull();
+    expect(getAssetReviewRows(decoded, metadata)).toEqual([
+      {
+        amount: '2',
+        assetGuid: '4294967297',
+        outputIndex: 1,
+        rawAmount: '2',
+        recipient: 'tsys1-recipient',
+        isBurn: false,
+        symbol: 'NFT',
+      },
+    ]);
+  });
+
+  it('shows fungible SPT amounts using eight decimals', () => {
+    const decoded = decodedTransfer('123456', '123000000');
+    const metadata = {
+      '123456': {
+        assetType: 'SYSX' as const,
+        decimals: 8,
+        symbol: 'SYSX',
+        assetGuid: '123456',
+      },
+    };
+
+    expect(getAssetReviewRows(decoded, metadata)[0].amount).toBe('1.23');
+  });
+
+  it('fails closed when bridged NFT metadata falls back to eight decimals', () => {
+    expect(
+      getSyscoinPsbtReviewError(decodedTransfer('4294967297', '1'), {
+        '4294967297': {
+          assetType: 'ERC1155',
+          contract: '0x1111111111111111111111111111111111111111',
+          decimals: 8,
+          originDecimals: 0,
+          symbol: '4294967297',
+          tokenId: '7',
+        },
+      })
+    ).toBe('NFT asset 4294967297 must use zero-decimal units');
+  });
+
+  it('fails closed on missing metadata, invalid amounts, and unknown types', () => {
+    expect(getSyscoinPsbtReviewError(decodedTransfer('123', '1'), {})).toBe(
+      'Unable to verify decimals for asset 123'
+    );
+
+    expect(
+      getSyscoinPsbtReviewError(decodedTransfer('123', '-1'), {
+        '123': {
+          assetType: 'ERC20',
+          contract: '0x1111111111111111111111111111111111111111',
+          decimals: 8,
+          originDecimals: 8,
+          symbol: 'SPT',
+        },
+      })
+    ).toBe('Asset 123 has an invalid output amount');
+
+    expect(
+      getSyscoinPsbtReviewError(
+        { syscoin: { txtype: 'mystery_operation' }, vout: [] },
+        {}
+      )
+    ).toBe('Unsupported Syscoin transaction type: mystery_operation');
+
+    expect(
+      getSyscoinPsbtReviewError(
+        { syscoin: { txtype: 'bitcoin' }, vout: [] },
+        {}
+      )
+    ).toBe('Unable to verify the transaction fee');
+  });
+
+  it('rejects a nonrepresentable low-decimal ERC20 bridge burn', () => {
+    const decoded = {
+      feeSatoshis: '1000',
+      syscoin: {
+        allocations: {
+          assets: [
+            { assetGuid: '123', values: [{ n: 1, value: '123000001' }] },
+          ],
+        },
+        txtype: 'assetallocation_burn_to_ethereum',
+      },
+      vout: [{ n: 1, scriptPubKey: { type: 'nulldata' } }],
+    };
+    const metadata = {
+      '123': {
+        assetType: 'ERC20' as const,
+        contract: '0x1111111111111111111111111111111111111111',
+        decimals: 8,
+        originDecimals: 2,
+        symbol: 'TWO',
+      },
+    };
+
+    expect(getSyscoinPsbtReviewError(decoded, metadata)).toBe(
+      'Burn amount for asset 123 is not representable with 2 origin decimals'
+    );
+
+    decoded.syscoin.allocations.assets[0].values[0].value = '123000000';
+    expect(getSyscoinPsbtReviewError(decoded, metadata)).toBeNull();
+  });
+});

--- a/source/utils/syscoinPsbtReview.spec.ts
+++ b/source/utils/syscoinPsbtReview.spec.ts
@@ -63,6 +63,66 @@ describe('Syscoin PSBT review', () => {
     expect(getAssetReviewRows(decoded, metadata)[0].amount).toBe('1.23');
   });
 
+  it('accepts native SPTs without bridge origin metadata', () => {
+    const decoded = decodedTransfer('987654', '12345');
+    const metadata = {
+      '987654': {
+        assetGuid: '987654',
+        contract: '',
+        decimals: 2,
+        symbol: 'NATIVE',
+      },
+    };
+
+    expect(getSyscoinPsbtReviewError(decoded, metadata)).toBeNull();
+    expect(getAssetReviewRows(decoded, metadata)[0].amount).toBe('123.45');
+  });
+
+  it('still requires an origin type for bridge-shaped metadata', () => {
+    expect(
+      getSyscoinPsbtReviewError(decodedTransfer('4294967297', '1'), {
+        '4294967297': {
+          contract: '0x1111111111111111111111111111111111111111',
+          decimals: 0,
+          originDecimals: 0,
+          tokenId: '0',
+        },
+      })
+    ).toBe('Unable to verify the origin type for asset 4294967297');
+
+    expect(
+      getSyscoinPsbtReviewError(decodedTransfer('987654', '1'), {
+        '987654': {
+          contract: '0x1111111111111111111111111111111111111111',
+          decimals: 8,
+          originDecimals: 8,
+        },
+      })
+    ).toBe('Unable to verify the origin type for asset 987654');
+  });
+
+  it('accepts bridged NFT token ID zero but rejects malformed IDs', () => {
+    const metadata = {
+      '4294967297': {
+        assetType: 'ERC721' as const,
+        contract: '0x1111111111111111111111111111111111111111',
+        decimals: 0,
+        originDecimals: 0,
+        symbol: 'ZERO',
+        tokenId: '0',
+      },
+    };
+
+    expect(
+      getSyscoinPsbtReviewError(decodedTransfer('4294967297', '1'), metadata)
+    ).toBeNull();
+
+    metadata['4294967297'].tokenId = '-1';
+    expect(
+      getSyscoinPsbtReviewError(decodedTransfer('4294967297', '1'), metadata)
+    ).toBe('Unable to verify token ID for asset 4294967297');
+  });
+
   it('fails closed when bridged NFT metadata falls back to eight decimals', () => {
     expect(
       getSyscoinPsbtReviewError(decodedTransfer('4294967297', '1'), {

--- a/source/utils/syscoinPsbtReview.spec.ts
+++ b/source/utils/syscoinPsbtReview.spec.ts
@@ -63,66 +63,6 @@ describe('Syscoin PSBT review', () => {
     expect(getAssetReviewRows(decoded, metadata)[0].amount).toBe('1.23');
   });
 
-  it('accepts native SPTs without bridge origin metadata', () => {
-    const decoded = decodedTransfer('987654', '12345');
-    const metadata = {
-      '987654': {
-        assetGuid: '987654',
-        contract: '',
-        decimals: 2,
-        symbol: 'NATIVE',
-      },
-    };
-
-    expect(getSyscoinPsbtReviewError(decoded, metadata)).toBeNull();
-    expect(getAssetReviewRows(decoded, metadata)[0].amount).toBe('123.45');
-  });
-
-  it('still requires an origin type for bridge-shaped metadata', () => {
-    expect(
-      getSyscoinPsbtReviewError(decodedTransfer('4294967297', '1'), {
-        '4294967297': {
-          contract: '0x1111111111111111111111111111111111111111',
-          decimals: 0,
-          originDecimals: 0,
-          tokenId: '0',
-        },
-      })
-    ).toBe('Unable to verify the origin type for asset 4294967297');
-
-    expect(
-      getSyscoinPsbtReviewError(decodedTransfer('987654', '1'), {
-        '987654': {
-          contract: '0x1111111111111111111111111111111111111111',
-          decimals: 8,
-          originDecimals: 8,
-        },
-      })
-    ).toBe('Unable to verify the origin type for asset 987654');
-  });
-
-  it('accepts bridged NFT token ID zero but rejects malformed IDs', () => {
-    const metadata = {
-      '4294967297': {
-        assetType: 'ERC721' as const,
-        contract: '0x1111111111111111111111111111111111111111',
-        decimals: 0,
-        originDecimals: 0,
-        symbol: 'ZERO',
-        tokenId: '0',
-      },
-    };
-
-    expect(
-      getSyscoinPsbtReviewError(decodedTransfer('4294967297', '1'), metadata)
-    ).toBeNull();
-
-    metadata['4294967297'].tokenId = '-1';
-    expect(
-      getSyscoinPsbtReviewError(decodedTransfer('4294967297', '1'), metadata)
-    ).toBe('Unable to verify token ID for asset 4294967297');
-  });
-
   it('fails closed when bridged NFT metadata falls back to eight decimals', () => {
     expect(
       getSyscoinPsbtReviewError(decodedTransfer('4294967297', '1'), {

--- a/source/utils/syscoinPsbtReview.ts
+++ b/source/utils/syscoinPsbtReview.ts
@@ -59,24 +59,13 @@ const getAssetMetadataError = (
 
   const isNftGuid = BigInt(assetGuid) >> BigInt(32) > BigInt(0);
   const assetType = metadata?.assetType;
+  if (!assetType) {
+    return `Unable to verify the origin type for asset ${assetGuid}`;
+  }
   if (assetGuid === '123456') {
     if (assetType !== 'SYSX' || decimals !== 8) {
       return 'SYSX metadata does not match its canonical identity';
     }
-    return null;
-  }
-
-  if (!assetType) {
-    const hasBridgeOriginMetadata =
-      Boolean(metadata?.contract) ||
-      metadata?.originDecimals !== undefined ||
-      metadata?.tokenId !== undefined;
-    if (isNftGuid || hasBridgeOriginMetadata) {
-      return `Unable to verify the origin type for asset ${assetGuid}`;
-    }
-
-    // Native SPTs have no bridge origin. Their consensus GUID, precision, and
-    // decoded integer amounts are sufficient for transaction review.
     return null;
   }
 
@@ -109,7 +98,10 @@ const getAssetMetadataError = (
   if (!/^0x[0-9a-fA-F]{40}$/.test(metadata.contract || '')) {
     return `Unable to verify origin contract for asset ${assetGuid}`;
   }
-  if (!/^\d+$/.test(metadata.tokenId || '')) {
+  if (
+    !/^\d+$/.test(metadata.tokenId || '') ||
+    BigInt(metadata.tokenId!) <= BigInt(0)
+  ) {
     return `Unable to verify token ID for asset ${assetGuid}`;
   }
 

--- a/source/utils/syscoinPsbtReview.ts
+++ b/source/utils/syscoinPsbtReview.ts
@@ -1,0 +1,216 @@
+import { formatSyscoinValue } from './formatSyscoinValue';
+import { normalizeSyscoinTransactionType } from './syscoinTransactionUtils';
+
+interface IAssetMetadata {
+  assetGuid?: string;
+  assetType?: 'SYSX' | 'ERC20' | 'ERC721' | 'ERC1155';
+  contract?: string;
+  decimals?: number;
+  originDecimals?: number;
+  symbol?: string;
+  tokenId?: string;
+}
+
+interface IDecodedAssetValue {
+  n: number;
+  value: number | string;
+}
+
+interface IDecodedAsset {
+  assetGuid: string;
+  values?: IDecodedAssetValue[];
+}
+
+interface IDecodedReviewTransaction {
+  error?: string;
+  feeSatoshis?: string;
+  syscoin?: {
+    allocations?: { assets?: IDecodedAsset[] };
+    txtype?: string;
+  };
+  vout?: Array<{
+    n: number;
+    scriptPubKey?: { addresses?: string[]; type?: string };
+  }>;
+}
+
+export interface IAssetReviewRow {
+  amount: string;
+  assetGuid: string;
+  isBurn: boolean;
+  outputIndex: number;
+  rawAmount: string;
+  recipient?: string;
+  symbol: string;
+}
+
+const getAssetMetadataError = (
+  assetGuid: string,
+  metadata: IAssetMetadata | undefined
+): string | null => {
+  if (!/^\d+$/.test(assetGuid)) {
+    return `Unable to verify asset GUID ${assetGuid}`;
+  }
+
+  const decimals = metadata?.decimals;
+  if (!Number.isInteger(decimals) || decimals! < 0 || decimals! > 8) {
+    return `Unable to verify decimals for asset ${assetGuid}`;
+  }
+
+  const isNftGuid = BigInt(assetGuid) >> BigInt(32) > BigInt(0);
+  const assetType = metadata?.assetType;
+  if (!assetType) {
+    return `Unable to verify the origin type for asset ${assetGuid}`;
+  }
+  if (assetGuid === '123456') {
+    if (assetType !== 'SYSX' || decimals !== 8) {
+      return 'SYSX metadata does not match its canonical identity';
+    }
+    return null;
+  }
+
+  if (assetType === 'ERC20') {
+    if (isNftGuid || decimals !== 8) {
+      return `ERC20 asset ${assetGuid} must use an eight-decimal UTXO representation`;
+    }
+    if (
+      !Number.isInteger(metadata.originDecimals) ||
+      metadata.originDecimals! < 0 ||
+      metadata.originDecimals! > 255
+    ) {
+      return `Unable to verify origin decimals for asset ${assetGuid}`;
+    }
+    if (!/^0x[0-9a-fA-F]{40}$/.test(metadata.contract || '')) {
+      return `Unable to verify origin contract for asset ${assetGuid}`;
+    }
+    return null;
+  }
+
+  if (
+    (assetType !== 'ERC721' && assetType !== 'ERC1155') ||
+    !isNftGuid ||
+    decimals !== 0 ||
+    metadata.originDecimals !== 0
+  ) {
+    return `NFT asset ${assetGuid} must use zero-decimal units`;
+  }
+
+  if (!/^0x[0-9a-fA-F]{40}$/.test(metadata.contract || '')) {
+    return `Unable to verify origin contract for asset ${assetGuid}`;
+  }
+  if (
+    !/^\d+$/.test(metadata.tokenId || '') ||
+    BigInt(metadata.tokenId!) <= BigInt(0)
+  ) {
+    return `Unable to verify token ID for asset ${assetGuid}`;
+  }
+
+  return null;
+};
+
+export const getSyscoinPsbtReviewError = (
+  decodedTx: IDecodedReviewTransaction | null,
+  assetInfoMap: Record<string, IAssetMetadata>
+): string | null => {
+  if (!decodedTx) return 'Transaction details are not available';
+  if (decodedTx.error) return decodedTx.error;
+
+  const txType = decodedTx.syscoin?.txtype;
+  if (
+    txType &&
+    txType.toLowerCase() !== 'bitcoin' &&
+    !normalizeSyscoinTransactionType(txType)
+  ) {
+    return `Unsupported Syscoin transaction type: ${txType}`;
+  }
+
+  if (!/^\d+$/.test(decodedTx.feeSatoshis || '')) {
+    return 'Unable to verify the transaction fee';
+  }
+
+  const assets = decodedTx.syscoin?.allocations?.assets || [];
+  const normalizedType = normalizeSyscoinTransactionType(txType);
+  for (const asset of assets) {
+    const metadataError = getAssetMetadataError(
+      asset.assetGuid,
+      assetInfoMap[asset.assetGuid]
+    );
+    if (metadataError) return metadataError;
+
+    if (!asset.values?.length) {
+      return `Asset ${asset.assetGuid} has no decoded outputs`;
+    }
+
+    for (const value of asset.values) {
+      const rawAmount = String(value.value);
+      if (!/^\d+$/.test(rawAmount) || BigInt(rawAmount) <= BigInt(0)) {
+        return `Asset ${asset.assetGuid} has an invalid output amount`;
+      }
+
+      const output = decodedTx.vout?.find(
+        (candidate) => candidate.n === value.n
+      );
+      if (!output) {
+        return `Asset ${asset.assetGuid} references a missing output`;
+      }
+
+      if (
+        normalizedType === 'assetallocationburntoethereum' &&
+        output.scriptPubKey?.type === 'nulldata' &&
+        assetInfoMap[asset.assetGuid]?.assetType === 'ERC20'
+      ) {
+        const originDecimals = assetInfoMap[asset.assetGuid].originDecimals!;
+        if (originDecimals < 8) {
+          const factor = BigInt(`1${'0'.repeat(8 - originDecimals)}`);
+          if (BigInt(rawAmount) % factor !== BigInt(0)) {
+            return `Burn amount for asset ${asset.assetGuid} is not representable with ${originDecimals} origin decimals`;
+          }
+        }
+      }
+    }
+
+    if (
+      normalizedType === 'assetallocationburntoethereum' &&
+      !asset.values.some((value) =>
+        decodedTx.vout?.some(
+          (output) =>
+            output.n === value.n && output.scriptPubKey?.type === 'nulldata'
+        )
+      )
+    ) {
+      return `Burn amount for asset ${asset.assetGuid} is not bound to the burn output`;
+    }
+  }
+
+  return null;
+};
+
+export const getAssetReviewRows = (
+  decodedTx: IDecodedReviewTransaction,
+  assetInfoMap: Record<string, IAssetMetadata>
+): IAssetReviewRow[] =>
+  (decodedTx.syscoin?.allocations?.assets || []).flatMap((asset) => {
+    const metadata = assetInfoMap[asset.assetGuid];
+    const decimals = metadata?.decimals;
+
+    return (asset.values || []).map((value) => {
+      const rawAmount = String(value.value);
+      const output = decodedTx.vout?.find(
+        (candidate) => candidate.n === value.n
+      );
+
+      return {
+        amount: Number.isInteger(decimals)
+          ? formatSyscoinValue(rawAmount, decimals)
+          : `${rawAmount} base units`,
+        assetGuid: asset.assetGuid,
+        outputIndex: value.n,
+        rawAmount,
+        recipient: output?.scriptPubKey?.addresses?.[0],
+        isBurn: output?.scriptPubKey?.type === 'nulldata',
+        symbol:
+          metadata?.symbol ||
+          (asset.assetGuid === '123456' ? 'SYSX' : 'Unknown'),
+      };
+    });
+  });

--- a/source/utils/syscoinPsbtReview.ts
+++ b/source/utils/syscoinPsbtReview.ts
@@ -25,12 +25,12 @@ interface IDecodedReviewTransaction {
   error?: string;
   feeSatoshis?: string;
   syscoin?: {
-    allocations?: { assets?: IDecodedAsset[] };
+    allocations?: { assets?: IDecodedAsset[] } | null;
     txtype?: string;
   };
   vout?: Array<{
     n: number;
-    scriptPubKey?: { addresses?: string[]; type?: string };
+    scriptPubKey?: { addresses?: string[]; hex?: string; type?: string };
   }>;
 }
 
@@ -43,6 +43,19 @@ export interface IAssetReviewRow {
   recipient?: string;
   symbol: string;
 }
+
+const getCanonicalOutputRecipient = (
+  output: NonNullable<IDecodedReviewTransaction['vout']>[number] | undefined
+): string | undefined =>
+  [
+    'pubkeyhash',
+    'scripthash',
+    'witness_v0_keyhash',
+    'witness_v0_scripthash',
+    'witness_v1_taproot',
+  ].includes(output?.scriptPubKey?.type || '')
+    ? output?.scriptPubKey?.addresses?.[0]
+    : undefined;
 
 const getAssetMetadataError = (
   assetGuid: string,
@@ -130,6 +143,18 @@ export const getSyscoinPsbtReviewError = (
 
   const assets = decodedTx.syscoin?.allocations?.assets || [];
   const normalizedType = normalizeSyscoinTransactionType(txType);
+  if (normalizedType && normalizedType !== 'nevmdata' && assets.length === 0) {
+    return 'Unable to verify Syscoin asset allocations';
+  }
+
+  for (const output of decodedTx.vout || []) {
+    const hasCanonicalAddress = Boolean(getCanonicalOutputRecipient(output));
+    const scriptHex = output.scriptPubKey?.hex || '';
+    if (!hasCanonicalAddress && !/^(?:[0-9a-fA-F]{2})+$/.test(scriptHex)) {
+      return `Unable to verify output ${output.n} script`;
+    }
+  }
+
   for (const asset of assets) {
     const metadataError = getAssetMetadataError(
       asset.assetGuid,
@@ -206,7 +231,7 @@ export const getAssetReviewRows = (
         assetGuid: asset.assetGuid,
         outputIndex: value.n,
         rawAmount,
-        recipient: output?.scriptPubKey?.addresses?.[0],
+        recipient: getCanonicalOutputRecipient(output),
         isBurn: output?.scriptPubKey?.type === 'nulldata',
         symbol:
           metadata?.symbol ||

--- a/source/utils/syscoinPsbtReview.ts
+++ b/source/utils/syscoinPsbtReview.ts
@@ -59,13 +59,24 @@ const getAssetMetadataError = (
 
   const isNftGuid = BigInt(assetGuid) >> BigInt(32) > BigInt(0);
   const assetType = metadata?.assetType;
-  if (!assetType) {
-    return `Unable to verify the origin type for asset ${assetGuid}`;
-  }
   if (assetGuid === '123456') {
     if (assetType !== 'SYSX' || decimals !== 8) {
       return 'SYSX metadata does not match its canonical identity';
     }
+    return null;
+  }
+
+  if (!assetType) {
+    const hasBridgeOriginMetadata =
+      Boolean(metadata?.contract) ||
+      metadata?.originDecimals !== undefined ||
+      metadata?.tokenId !== undefined;
+    if (isNftGuid || hasBridgeOriginMetadata) {
+      return `Unable to verify the origin type for asset ${assetGuid}`;
+    }
+
+    // Native SPTs have no bridge origin. Their consensus GUID, precision, and
+    // decoded integer amounts are sufficient for transaction review.
     return null;
   }
 
@@ -98,10 +109,7 @@ const getAssetMetadataError = (
   if (!/^0x[0-9a-fA-F]{40}$/.test(metadata.contract || '')) {
     return `Unable to verify origin contract for asset ${assetGuid}`;
   }
-  if (
-    !/^\d+$/.test(metadata.tokenId || '') ||
-    BigInt(metadata.tokenId!) <= BigInt(0)
-  ) {
+  if (!/^\d+$/.test(metadata.tokenId || '')) {
     return `Unable to verify token ID for asset ${assetGuid}`;
   }
 

--- a/source/utils/syscoinPsbtValues.spec.ts
+++ b/source/utils/syscoinPsbtValues.spec.ts
@@ -1,8 +1,73 @@
 jest.unmock('syscoinjs-lib');
 
-import { utils as syscoinUtils } from 'syscoinjs-lib';
+import {
+  syscoin as SyscoinTransaction,
+  utils as syscoinUtils,
+} from 'syscoinjs-lib';
 
+import { getSyscoinPsbtReviewError } from './syscoinPsbtReview';
 import { getSyscoinPsbtValueSummary } from './syscoinPsbtValues';
+
+const syscointx = jest.requireActual('syscointx-js');
+
+const createUnfinalizedBurnToSyscoinPsbt = ({
+  allocationAssetGuid = '123456',
+  allocationOutputIndex = 2,
+  allocationValue = '100000000',
+  mintedSys = BigInt(100000000),
+}: {
+  allocationAssetGuid?: string;
+  allocationOutputIndex?: number;
+  allocationValue?: string;
+  mintedSys?: bigint;
+} = {}) => {
+  const allocationData = syscointx.bufferUtils.serializeAssetAllocations([
+    {
+      assetGuid: allocationAssetGuid,
+      values: [
+        {
+          n: allocationOutputIndex,
+          value: new syscoinUtils.BN(allocationValue),
+        },
+      ],
+    },
+  ]);
+  const burnData = syscointx.bufferUtils.serializeAllocationBurn({
+    ethaddress: Buffer.alloc(0),
+  });
+  const psbt = new syscoinUtils.bitcoinjs.Psbt({
+    network: syscoinUtils.syscoinNetworks.testnet,
+  });
+
+  psbt.setVersion(138);
+  psbt.addInput({
+    hash: Buffer.alloc(32),
+    index: 0,
+    witnessUtxo: {
+      script: Buffer.from(
+        '00140000000000000000000000000000000000000000',
+        'hex'
+      ),
+      value: BigInt(10000),
+    },
+  });
+  psbt.addOutput({
+    script: Buffer.from('00140000000000000000000000000000000000000000', 'hex'),
+    value: mintedSys,
+  });
+  psbt.addOutput({
+    script: Buffer.from('00140000000000000000000000000000000000000001', 'hex'),
+    value: BigInt(9000),
+  });
+  psbt.addOutput({
+    script: syscoinUtils.bitcoinjs.payments.embed({
+      data: [Buffer.concat([allocationData, burnData])],
+    }).output!,
+    value: BigInt(0),
+  });
+
+  return psbt;
+};
 
 const emptyTransaction = () => {
   const transaction = new syscoinUtils.bitcoinjs.Transaction();
@@ -53,7 +118,68 @@ describe('Syscoin PSBT value summary', () => {
         txOutputs: [{ value: BigInt(2) }],
         extractTransaction: emptyTransaction,
       })
-    ).toThrow('PSBT outputs exceed its inputs');
+    ).toThrow('PSBT outputs exceed its effective inputs');
+  });
+
+  it('accounts for the exact SYSX burned into native SYS in an unfinalized v138 SPSBT', () => {
+    const psbt = createUnfinalizedBurnToSyscoinPsbt();
+    const transaction = psbt.extractTransaction(true, true);
+    const rawInput = BigInt(psbt.data.inputs[0].witnessUtxo!.value);
+    const rawOutput = transaction.outs.reduce(
+      (total: bigint, output: any) => total + BigInt(output.value),
+      BigInt(0)
+    );
+
+    expect(psbt.data.inputs[0].finalScriptSig).toBeUndefined();
+    expect(psbt.data.inputs[0].finalScriptWitness).toBeUndefined();
+    expect(transaction.version).toBe(138);
+    expect(transaction.outs[0].value).toBe(BigInt(100000000));
+    expect(rawOutput).toBeGreaterThan(rawInput);
+
+    const summary = getSyscoinPsbtValueSummary(psbt);
+    expect(rawInput + transaction.outs[0].value).toBeGreaterThanOrEqual(
+      rawOutput
+    );
+    expect(summary).toEqual({
+      assetAllocations: [
+        {
+          assetGuid: '123456',
+          values: [{ n: 2, value: '100000000' }],
+        },
+      ],
+      feeSatoshis: '1000',
+      outputValuesSatoshis: ['100000000', '9000', '0'],
+    });
+
+    const decoder = new SyscoinTransaction(
+      null,
+      null,
+      syscoinUtils.syscoinNetworks.testnet
+    );
+    const decoded = decoder.decodeRawTransaction(psbt);
+    decoded.feeSatoshis = summary.feeSatoshis;
+    decoded.vout.forEach((output: any, index: number) => {
+      output.valueSatoshis = summary.outputValuesSatoshis[index];
+    });
+    decoded.syscoin.allocations = { assets: summary.assetAllocations };
+
+    expect(
+      getSyscoinPsbtReviewError(decoded, {
+        '123456': { assetType: 'SYSX', decimals: 8, symbol: 'SYSX' },
+      })
+    ).toBeNull();
+  });
+
+  it.each([
+    ['a non-SYSX allocation', { allocationAssetGuid: '123457' }],
+    ['a burn assigned to a spendable output', { allocationOutputIndex: 1 }],
+    ['a burn amount different from output zero', { allocationValue: '1' }],
+  ])('rejects v138 with %s', (_description, fixtureOptions) => {
+    expect(() =>
+      getSyscoinPsbtValueSummary(
+        createUnfinalizedBurnToSyscoinPsbt(fixtureOptions)
+      )
+    ).toThrow('SYSX burn amount does not match the native SYS mint output');
   });
 
   it('extracts large asset allocations as exact decimal strings', () => {

--- a/source/utils/syscoinPsbtValues.spec.ts
+++ b/source/utils/syscoinPsbtValues.spec.ts
@@ -170,6 +170,55 @@ describe('Syscoin PSBT value summary', () => {
     ).toBeNull();
   });
 
+  it('counts the value-bearing SYS burn output when computing a v139 fee', () => {
+    const allocationData = syscointx.bufferUtils.serializeAssetAllocations([
+      {
+        assetGuid: '123456',
+        values: [{ n: 0, value: new syscoinUtils.BN('100000000') }],
+      },
+    ]);
+    const psbt = new syscoinUtils.bitcoinjs.Psbt({
+      network: syscoinUtils.syscoinNetworks.testnet,
+    });
+
+    psbt.setVersion(139);
+    psbt.addInput({
+      hash: Buffer.alloc(32),
+      index: 0,
+      witnessUtxo: {
+        script: Buffer.from(
+          '00140000000000000000000000000000000000000000',
+          'hex'
+        ),
+        value: BigInt(100010000),
+      },
+    });
+    psbt.addOutput({
+      script: Buffer.from(
+        '00140000000000000000000000000000000000000001',
+        'hex'
+      ),
+      value: BigInt(9000),
+    });
+    psbt.addOutput({
+      script: syscoinUtils.bitcoinjs.payments.embed({
+        data: [allocationData],
+      }).output!,
+      value: BigInt(100000000),
+    });
+
+    expect(getSyscoinPsbtValueSummary(psbt)).toEqual({
+      assetAllocations: [
+        {
+          assetGuid: '123456',
+          values: [{ n: 0, value: '100000000' }],
+        },
+      ],
+      feeSatoshis: '1000',
+      outputValuesSatoshis: ['9000', '100000000'],
+    });
+  });
+
   it.each([
     ['a non-SYSX allocation', { allocationAssetGuid: '123457' }],
     ['a burn assigned to a spendable output', { allocationOutputIndex: 1 }],

--- a/source/utils/syscoinPsbtValues.spec.ts
+++ b/source/utils/syscoinPsbtValues.spec.ts
@@ -1,0 +1,44 @@
+import { getSyscoinPsbtValueSummary } from './syscoinPsbtValues';
+
+describe('Syscoin PSBT value summary', () => {
+  it('computes the exact fee and output values from witness inputs', () => {
+    const summary = getSyscoinPsbtValueSummary({
+      data: {
+        inputs: [
+          { witnessUtxo: { value: BigInt('9007199254740991') } },
+          { witnessUtxo: { value: BigInt(1000) } },
+        ],
+      },
+      txInputs: [{ index: 0 }, { index: 1 }],
+      txOutputs: [
+        { value: BigInt('9007199254740000') },
+        { value: BigInt(500) },
+      ],
+    });
+
+    expect(summary).toEqual({
+      feeSatoshis: '1491',
+      outputValuesSatoshis: ['9007199254740000', '500'],
+    });
+  });
+
+  it('fails closed when an input value is unavailable', () => {
+    expect(() =>
+      getSyscoinPsbtValueSummary({
+        data: { inputs: [{}] },
+        txInputs: [{ index: 0 }],
+        txOutputs: [{ value: BigInt(1) }],
+      })
+    ).toThrow('Unable to verify PSBT input 0');
+  });
+
+  it('rejects outputs whose value exceeds the inputs', () => {
+    expect(() =>
+      getSyscoinPsbtValueSummary({
+        data: { inputs: [{ witnessUtxo: { value: BigInt(1) } }] },
+        txInputs: [{ index: 0 }],
+        txOutputs: [{ value: BigInt(2) }],
+      })
+    ).toThrow('PSBT outputs exceed its inputs');
+  });
+});

--- a/source/utils/syscoinPsbtValues.spec.ts
+++ b/source/utils/syscoinPsbtValues.spec.ts
@@ -111,10 +111,35 @@ describe('Syscoin PSBT value summary', () => {
             },
           ],
         },
-        txInputs: [{ index: 0 }],
+        txInputs: [{ hash: previousTransaction.getHash(), index: 0 }],
         txOutputs: [{ value: BigInt(0) }],
         extractTransaction: emptyTransaction,
       })
     ).toThrow('Conflicting PSBT input 0 UTXO data');
+  });
+
+  it('rejects a non-witness UTXO from a different transaction', () => {
+    const referencedTransaction = emptyTransaction();
+    referencedTransaction.addInput(Buffer.alloc(32), 0xffffffff);
+    referencedTransaction.addOutput(Buffer.from('51', 'hex'), BigInt(5000));
+
+    const unrelatedTransaction = emptyTransaction();
+    unrelatedTransaction.addInput(Buffer.alloc(32, 1), 0xffffffff);
+    unrelatedTransaction.addOutput(Buffer.from('51', 'hex'), BigInt(5000));
+
+    expect(() =>
+      getSyscoinPsbtValueSummary({
+        data: {
+          inputs: [
+            {
+              nonWitnessUtxo: unrelatedTransaction.toBuffer(),
+            },
+          ],
+        },
+        txInputs: [{ hash: referencedTransaction.getHash(), index: 0 }],
+        txOutputs: [{ value: BigInt(0) }],
+        extractTransaction: emptyTransaction,
+      })
+    ).toThrow('PSBT input 0 previous transaction mismatch');
   });
 });

--- a/source/utils/syscoinPsbtValues.spec.ts
+++ b/source/utils/syscoinPsbtValues.spec.ts
@@ -1,4 +1,14 @@
+jest.unmock('syscoinjs-lib');
+
+import { utils as syscoinUtils } from 'syscoinjs-lib';
+
 import { getSyscoinPsbtValueSummary } from './syscoinPsbtValues';
+
+const emptyTransaction = () => {
+  const transaction = new syscoinUtils.bitcoinjs.Transaction();
+  transaction.version = 2;
+  return transaction;
+};
 
 describe('Syscoin PSBT value summary', () => {
   it('computes the exact fee and output values from witness inputs', () => {
@@ -14,9 +24,11 @@ describe('Syscoin PSBT value summary', () => {
         { value: BigInt('9007199254740000') },
         { value: BigInt(500) },
       ],
+      extractTransaction: emptyTransaction,
     });
 
     expect(summary).toEqual({
+      assetAllocations: [],
       feeSatoshis: '1491',
       outputValuesSatoshis: ['9007199254740000', '500'],
     });
@@ -28,6 +40,7 @@ describe('Syscoin PSBT value summary', () => {
         data: { inputs: [{}] },
         txInputs: [{ index: 0 }],
         txOutputs: [{ value: BigInt(1) }],
+        extractTransaction: emptyTransaction,
       })
     ).toThrow('Unable to verify PSBT input 0');
   });
@@ -38,7 +51,33 @@ describe('Syscoin PSBT value summary', () => {
         data: { inputs: [{ witnessUtxo: { value: BigInt(1) } }] },
         txInputs: [{ index: 0 }],
         txOutputs: [{ value: BigInt(2) }],
+        extractTransaction: emptyTransaction,
       })
     ).toThrow('PSBT outputs exceed its inputs');
+  });
+
+  it('extracts large asset allocations as exact decimal strings', () => {
+    const transaction = emptyTransaction();
+    transaction.version = 142;
+    transaction.addOutput(
+      syscoinUtils.bitcoinjs.payments.embed({
+        data: [Buffer.from('018efefeff010101808efefefefefeff03', 'hex')],
+      }).output!,
+      BigInt(0)
+    );
+
+    const summary = getSyscoinPsbtValueSummary({
+      data: { inputs: [{ witnessUtxo: { value: BigInt(1000) } }] },
+      txInputs: [{ index: 0 }],
+      txOutputs: [{ value: BigInt(0) }],
+      extractTransaction: () => transaction,
+    });
+
+    expect(summary.assetAllocations).toEqual([
+      {
+        assetGuid: '4294967297',
+        values: [{ n: 1, value: '9007199254740993' }],
+      },
+    ]);
   });
 });

--- a/source/utils/syscoinPsbtValues.spec.ts
+++ b/source/utils/syscoinPsbtValues.spec.ts
@@ -57,21 +57,29 @@ describe('Syscoin PSBT value summary', () => {
   });
 
   it('extracts large asset allocations as exact decimal strings', () => {
-    const transaction = emptyTransaction();
-    transaction.version = 142;
-    transaction.addOutput(
-      syscoinUtils.bitcoinjs.payments.embed({
+    const psbt = new syscoinUtils.bitcoinjs.Psbt({
+      network: syscoinUtils.syscoinNetworks.testnet,
+    });
+    psbt.setVersion(142);
+    psbt.addInput({
+      hash: Buffer.alloc(32),
+      index: 0,
+      witnessUtxo: {
+        script: Buffer.from(
+          '00140000000000000000000000000000000000000000',
+          'hex'
+        ),
+        value: BigInt(1000),
+      },
+    });
+    psbt.addOutput({
+      script: syscoinUtils.bitcoinjs.payments.embed({
         data: [Buffer.from('018efefeff010101808efefefefefeff03', 'hex')],
       }).output!,
-      BigInt(0)
-    );
-
-    const summary = getSyscoinPsbtValueSummary({
-      data: { inputs: [{ witnessUtxo: { value: BigInt(1000) } }] },
-      txInputs: [{ index: 0 }],
-      txOutputs: [{ value: BigInt(0) }],
-      extractTransaction: () => transaction,
+      value: BigInt(0),
     });
+
+    const summary = getSyscoinPsbtValueSummary(psbt);
 
     expect(summary.assetAllocations).toEqual([
       {
@@ -79,5 +87,34 @@ describe('Syscoin PSBT value summary', () => {
         values: [{ n: 1, value: '9007199254740993' }],
       },
     ]);
+  });
+
+  it('rejects conflicting witness and non-witness UTXO data', () => {
+    const previousTransaction = emptyTransaction();
+    previousTransaction.addInput(Buffer.alloc(32), 0xffffffff);
+    const previousScript = Buffer.from(
+      '76a914000000000000000000000000000000000000000088ac',
+      'hex'
+    );
+    previousTransaction.addOutput(previousScript, BigInt(5000));
+
+    expect(() =>
+      getSyscoinPsbtValueSummary({
+        data: {
+          inputs: [
+            {
+              nonWitnessUtxo: previousTransaction.toBuffer(),
+              witnessUtxo: {
+                script: previousScript,
+                value: BigInt(1000),
+              },
+            },
+          ],
+        },
+        txInputs: [{ index: 0 }],
+        txOutputs: [{ value: BigInt(0) }],
+        extractTransaction: emptyTransaction,
+      })
+    ).toThrow('Conflicting PSBT input 0 UTXO data');
   });
 });

--- a/source/utils/syscoinPsbtValues.ts
+++ b/source/utils/syscoinPsbtValues.ts
@@ -1,0 +1,62 @@
+import * as syscoinjs from 'syscoinjs-lib';
+
+const toBigIntValue = (value: unknown, field: string): bigint => {
+  const normalized = String(value);
+  if (!/^\d+$/.test(normalized)) {
+    throw new Error(`Unable to verify ${field}`);
+  }
+  return BigInt(normalized);
+};
+
+export const getSyscoinPsbtValueSummary = (
+  psbt: any
+): { feeSatoshis: string; outputValuesSatoshis: string[] } => {
+  if (
+    !psbt?.data?.inputs ||
+    !Array.isArray(psbt.txInputs) ||
+    !Array.isArray(psbt.txOutputs) ||
+    psbt.data.inputs.length === 0 ||
+    psbt.txOutputs.length === 0 ||
+    psbt.data.inputs.length !== psbt.txInputs.length
+  ) {
+    throw new Error('Unable to verify PSBT inputs and outputs');
+  }
+
+  let totalInput = BigInt(0);
+  for (let index = 0; index < psbt.data.inputs.length; index++) {
+    const input = psbt.data.inputs[index];
+    let inputValue: unknown;
+
+    if (input.witnessUtxo?.value !== undefined) {
+      inputValue = input.witnessUtxo.value;
+    } else if (input.nonWitnessUtxo) {
+      const previousTransaction =
+        syscoinjs.utils.bitcoinjs.Transaction.fromBuffer(input.nonWitnessUtxo);
+      inputValue =
+        previousTransaction.outs?.[psbt.txInputs[index].index]?.value;
+    }
+
+    if (inputValue === undefined) {
+      throw new Error(`Unable to verify PSBT input ${index}`);
+    }
+    totalInput += toBigIntValue(inputValue, `PSBT input ${index}`);
+  }
+
+  const outputValuesSatoshis = psbt.txOutputs.map(
+    (output: any, index: number) =>
+      toBigIntValue(output.value, `PSBT output ${index}`).toString()
+  );
+  const totalOutput = outputValuesSatoshis.reduce(
+    (total: bigint, value: string) => total + BigInt(value),
+    BigInt(0)
+  );
+
+  if (totalInput < totalOutput) {
+    throw new Error('PSBT outputs exceed its inputs');
+  }
+
+  return {
+    feeSatoshis: (totalInput - totalOutput).toString(),
+    outputValuesSatoshis,
+  };
+};

--- a/source/utils/syscoinPsbtValues.ts
+++ b/source/utils/syscoinPsbtValues.ts
@@ -1,5 +1,8 @@
 import { utils as syscoinUtils } from 'syscoinjs-lib';
 
+const ALLOCATION_BURN_TO_SYSCOIN_VERSION = 138;
+const SYSX_ASSET_GUID = '123456';
+
 const toBigIntValue = (value: unknown, field: string): bigint => {
   const normalized = String(value);
   if (!/^\d+$/.test(normalized)) {
@@ -79,10 +82,6 @@ export const getSyscoinPsbtValueSummary = (
     BigInt(0)
   );
 
-  if (totalInput < totalOutput) {
-    throw new Error('PSBT outputs exceed its inputs');
-  }
-
   if (typeof psbt.extractTransaction !== 'function') {
     throw new Error('Unable to verify PSBT asset allocations');
   }
@@ -97,9 +96,49 @@ export const getSyscoinPsbtValueSummary = (
     })),
   }));
 
+  let effectiveInput = totalInput;
+  if (transaction.version === ALLOCATION_BURN_TO_SYSCOIN_VERSION) {
+    const mintedSys = toBigIntValue(
+      transaction.outs?.[0]?.value,
+      'SYSX to SYS mint output'
+    );
+    const burnOutputIndex = transaction.outs?.findIndex(
+      (output: any) =>
+        output?.script?.[0] === syscoinUtils.bitcoinjs.opcodes.OP_RETURN
+    );
+    const matchingBurns = assetAllocations.flatMap((allocation) =>
+      allocation.assetGuid === SYSX_ASSET_GUID
+        ? allocation.values.filter(
+            ({ n, value }) =>
+              Number.isInteger(n) &&
+              n === burnOutputIndex &&
+              burnOutputIndex > 0 &&
+              BigInt(value) === mintedSys
+          )
+        : []
+    );
+
+    if (
+      mintedSys <= BigInt(0) ||
+      transaction.outs?.length !== outputValuesSatoshis.length ||
+      mintedSys.toString() !== outputValuesSatoshis[0] ||
+      matchingBurns.length !== 1
+    ) {
+      throw new Error(
+        'SYSX burn amount does not match the native SYS mint output'
+      );
+    }
+
+    effectiveInput += mintedSys;
+  }
+
+  if (effectiveInput < totalOutput) {
+    throw new Error('PSBT outputs exceed its effective inputs');
+  }
+
   return {
     assetAllocations,
-    feeSatoshis: (totalInput - totalOutput).toString(),
+    feeSatoshis: (effectiveInput - totalOutput).toString(),
     outputValuesSatoshis,
   };
 };

--- a/source/utils/syscoinPsbtValues.ts
+++ b/source/utils/syscoinPsbtValues.ts
@@ -34,14 +34,27 @@ export const getSyscoinPsbtValueSummary = (
     const input = psbt.data.inputs[index];
     let inputValue: unknown;
 
-    if (input.witnessUtxo?.value !== undefined) {
-      inputValue = input.witnessUtxo.value;
-    } else if (input.nonWitnessUtxo) {
+    if (input.nonWitnessUtxo) {
       const previousTransaction = syscoinUtils.bitcoinjs.Transaction.fromBuffer(
         input.nonWitnessUtxo
       );
-      inputValue =
-        previousTransaction.outs?.[psbt.txInputs[index].index]?.value;
+      const previousOutput =
+        previousTransaction.outs?.[psbt.txInputs[index].index];
+      if (!previousOutput) {
+        throw new Error(`Unable to verify PSBT input ${index}`);
+      }
+
+      if (
+        input.witnessUtxo &&
+        (toBigIntValue(input.witnessUtxo.value, `PSBT input ${index}`) !==
+          toBigIntValue(previousOutput.value, `PSBT input ${index}`) ||
+          !Buffer.from(input.witnessUtxo.script).equals(previousOutput.script))
+      ) {
+        throw new Error(`Conflicting PSBT input ${index} UTXO data`);
+      }
+      inputValue = previousOutput.value;
+    } else if (input.witnessUtxo?.value !== undefined) {
+      inputValue = input.witnessUtxo.value;
     }
 
     if (inputValue === undefined) {

--- a/source/utils/syscoinPsbtValues.ts
+++ b/source/utils/syscoinPsbtValues.ts
@@ -1,4 +1,4 @@
-import * as syscoinjs from 'syscoinjs-lib';
+import { utils as syscoinUtils } from 'syscoinjs-lib';
 
 const toBigIntValue = (value: unknown, field: string): bigint => {
   const normalized = String(value);
@@ -10,7 +10,14 @@ const toBigIntValue = (value: unknown, field: string): bigint => {
 
 export const getSyscoinPsbtValueSummary = (
   psbt: any
-): { feeSatoshis: string; outputValuesSatoshis: string[] } => {
+): {
+  assetAllocations: Array<{
+    assetGuid: string;
+    values: Array<{ n: number; value: string }>;
+  }>;
+  feeSatoshis: string;
+  outputValuesSatoshis: string[];
+} => {
   if (
     !psbt?.data?.inputs ||
     !Array.isArray(psbt.txInputs) ||
@@ -30,8 +37,9 @@ export const getSyscoinPsbtValueSummary = (
     if (input.witnessUtxo?.value !== undefined) {
       inputValue = input.witnessUtxo.value;
     } else if (input.nonWitnessUtxo) {
-      const previousTransaction =
-        syscoinjs.utils.bitcoinjs.Transaction.fromBuffer(input.nonWitnessUtxo);
+      const previousTransaction = syscoinUtils.bitcoinjs.Transaction.fromBuffer(
+        input.nonWitnessUtxo
+      );
       inputValue =
         previousTransaction.outs?.[psbt.txInputs[index].index]?.value;
     }
@@ -55,7 +63,22 @@ export const getSyscoinPsbtValueSummary = (
     throw new Error('PSBT outputs exceed its inputs');
   }
 
+  if (typeof psbt.extractTransaction !== 'function') {
+    throw new Error('Unable to verify PSBT asset allocations');
+  }
+  const transaction = psbt.extractTransaction(true, true);
+  const assetAllocations = (
+    syscoinUtils.getAllocationsFromTx(transaction) || []
+  ).map((allocation: any) => ({
+    assetGuid: String(allocation.assetGuid),
+    values: (allocation.values || []).map((value: any) => ({
+      n: value.n,
+      value: toBigIntValue(value.value, 'asset allocation').toString(),
+    })),
+  }));
+
   return {
+    assetAllocations,
     feeSatoshis: (totalInput - totalOutput).toString(),
     outputValuesSatoshis,
   };

--- a/source/utils/syscoinPsbtValues.ts
+++ b/source/utils/syscoinPsbtValues.ts
@@ -38,6 +38,13 @@ export const getSyscoinPsbtValueSummary = (
       const previousTransaction = syscoinUtils.bitcoinjs.Transaction.fromBuffer(
         input.nonWitnessUtxo
       );
+      if (
+        !Buffer.from(psbt.txInputs[index].hash).equals(
+          previousTransaction.getHash()
+        )
+      ) {
+        throw new Error(`PSBT input ${index} previous transaction mismatch`);
+      }
       const previousOutput =
         previousTransaction.outs?.[psbt.txInputs[index].index];
       if (!previousOutput) {

--- a/source/utils/transactions.ts
+++ b/source/utils/transactions.ts
@@ -489,7 +489,9 @@ export const getAssetBalance = (
   }
 
   const formattedBalance = truncate(
-    formatCurrency(String(+asset.balance), asset.decimals),
+    asset.decimals === 0
+      ? String(asset.balance ?? '0')
+      : formatCurrency(String(asset.balance ?? '0'), asset.decimals),
     14
   );
 


### PR DESCRIPTION
## Summary
- preserve zero-decimal ERC-721/ERC-1155 quantities and exact large SPT balances
- adapt asset amounts to the installed keyring builder without a `Number` intermediate
- persist Bridge V2 origin metadata through import, refresh, and signing flows
- fail closed on undecodable or metadata-inconsistent dapp PSBTs
- show exact fee, every SYS output, asset amount/recipient, standard, origin contract, GUID, and token ID before signing
- reject non-representable low-decimal ERC-20 return burns
- bump Pali to 4.0.63

## Root cause
Pali treated a valid asset precision of zero as missing in several paths, stored aggregated SPT balances as JavaScript numbers, and passed every asset amount to a builder API that interprets its input as eight-decimal units. The dapp signing popup also did not require an exact PSBT fee or keep all security-relevant outputs and asset allocations in the non-collapsible review.

## Security and compatibility
ERC-20-backed UTXO SPTs remain eight-decimal. ERC-721/ERC-1155 quantities are converted to their exact integer base units. Dapp signing now refuses unknown bridge origin metadata, invalid NFT metadata, missing outputs, unknown transaction types, unverifiable fees, and low-decimal ERC-20 burns that the vault cannot redeem.

This PR should ship with the Blockbook Bridge V2 metadata changes in syscoin/blockbook#29. Existing persisted assets are refreshed before a dapp signature is enabled.

## Validation
- `yarn test --runInBand source/scripts/Background/controllers/assets/syscoin.spec.ts source/utils/syscoinAssetAmount.spec.ts source/utils/syscoinPsbtReview.spec.ts source/utils/syscoinPsbtValues.spec.ts` (17 tests)
- `yarn type-check`
- changed-file ESLint
- `yarn i18n:check`
- `git diff --check`