### PR TITLE
Review v140 bridge mint allocations

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "redux-thunk": "^3.1.0",
     "sass": "^1.80.7",
     "syscoinjs-lib": "^1.0.273",
+    "syscointx-js": "1.0.127",
     "tailwindcss": "^3.4.15",
     "tippy.js": "^6.3.7",
     "uuid": "^9.0.1",

--- a/source/utils/syscoinPsbtValues.spec.ts
+++ b/source/utils/syscoinPsbtValues.spec.ts
@@ -69,6 +69,59 @@ const createUnfinalizedBurnToSyscoinPsbt = ({
   return psbt;
 };
 
+const createUnfinalizedMintPsbt = (mintedAssetValue = '100000000') => {
+  const allocationData = syscointx.bufferUtils.serializeAssetAllocations([
+    {
+      assetGuid: '123456',
+      values: [
+        {
+          n: 0,
+          value: new syscoinUtils.BN(mintedAssetValue),
+        },
+      ],
+    },
+  ]);
+  const mintProof = syscointx.bufferUtils.serializeMintSyscoin({
+    ethtxid: Buffer.alloc(32),
+    blockhash: Buffer.alloc(32),
+    txpos: 0,
+    txparentnodes: Buffer.alloc(32),
+    txpath: Buffer.alloc(1),
+    receiptpos: 0,
+    receiptparentnodes: Buffer.alloc(32),
+    txroot: Buffer.alloc(32),
+    receiptroot: Buffer.alloc(32),
+  });
+  const psbt = new syscoinUtils.bitcoinjs.Psbt({
+    network: syscoinUtils.syscoinNetworks.testnet,
+  });
+
+  psbt.setVersion(140);
+  psbt.addInput({
+    hash: Buffer.alloc(32),
+    index: 0,
+    witnessUtxo: {
+      script: Buffer.from(
+        '00140000000000000000000000000000000000000000',
+        'hex'
+      ),
+      value: BigInt(10000),
+    },
+  });
+  psbt.addOutput({
+    script: Buffer.from('00140000000000000000000000000000000000000001', 'hex'),
+    value: BigInt(9000),
+  });
+  psbt.addOutput({
+    script: syscoinUtils.bitcoinjs.payments.embed({
+      data: [Buffer.concat([allocationData, mintProof])],
+    }).output!,
+    value: BigInt(0),
+  });
+
+  return psbt;
+};
+
 const emptyTransaction = () => {
   const transaction = new syscoinUtils.bitcoinjs.Transaction();
   transaction.version = 2;
@@ -217,6 +270,61 @@ describe('Syscoin PSBT value summary', () => {
       feeSatoshis: '1000',
       outputValuesSatoshis: ['9000', '100000000'],
     });
+  });
+
+  it('reviews exact v140 bridge-mint allocations from an unfinalized SPSBT', () => {
+    const mintedAssetValue = '100000000';
+    const psbt = createUnfinalizedMintPsbt(mintedAssetValue);
+
+    const transaction = psbt.extractTransaction(true, true);
+    expect(psbt.data.inputs[0].finalScriptSig).toBeUndefined();
+    expect(psbt.data.inputs[0].finalScriptWitness).toBeUndefined();
+    expect(transaction.version).toBe(140);
+
+    const summary = getSyscoinPsbtValueSummary(psbt);
+    expect(summary).toEqual({
+      assetAllocations: [
+        {
+          assetGuid: '123456',
+          values: [{ n: 0, value: mintedAssetValue }],
+        },
+      ],
+      feeSatoshis: '1000',
+      outputValuesSatoshis: ['9000', '0'],
+    });
+
+    const decoder = new SyscoinTransaction(
+      null,
+      null,
+      syscoinUtils.syscoinNetworks.testnet
+    );
+    const decoded = decoder.decodeRawTransaction(psbt);
+    decoded.feeSatoshis = summary.feeSatoshis;
+    decoded.vout.forEach((output: any, index: number) => {
+      output.valueSatoshis = summary.outputValuesSatoshis[index];
+    });
+    decoded.syscoin.allocations = { assets: summary.assetAllocations };
+
+    expect(decoded.syscoin.txtype).toBe('assetallocation_mint');
+    expect(
+      getSyscoinPsbtReviewError(decoded, {
+        '123456': { assetType: 'SYSX', decimals: 8, symbol: 'SYSX' },
+      })
+    ).toBeNull();
+  });
+
+  it('preserves v140 bridge-mint allocations above the safe integer limit', () => {
+    const mintedAssetValue = '9007199254740993';
+
+    expect(
+      getSyscoinPsbtValueSummary(createUnfinalizedMintPsbt(mintedAssetValue))
+        .assetAllocations
+    ).toEqual([
+      {
+        assetGuid: '123456',
+        values: [{ n: 0, value: mintedAssetValue }],
+      },
+    ]);
   });
 
   it.each([

--- a/source/utils/syscoinPsbtValues.ts
+++ b/source/utils/syscoinPsbtValues.ts
@@ -1,6 +1,8 @@
 import { utils as syscoinUtils } from 'syscoinjs-lib';
+import { getAllocationsFromOutputs } from 'syscointx-js';
 
 const ALLOCATION_BURN_TO_SYSCOIN_VERSION = 138;
+const ALLOCATION_MINT_VERSION = 140;
 const SYSX_ASSET_GUID = '123456';
 
 const toBigIntValue = (value: unknown, field: string): bigint => {
@@ -86,15 +88,19 @@ export const getSyscoinPsbtValueSummary = (
     throw new Error('Unable to verify PSBT asset allocations');
   }
   const transaction = psbt.extractTransaction(true, true);
-  const assetAllocations = (
-    syscoinUtils.getAllocationsFromTx(transaction) || []
-  ).map((allocation: any) => ({
-    assetGuid: String(allocation.assetGuid),
-    values: (allocation.values || []).map((value: any) => ({
-      n: value.n,
-      value: toBigIntValue(value.value, 'asset allocation').toString(),
-    })),
-  }));
+  const rawAssetAllocations =
+    transaction.version === ALLOCATION_MINT_VERSION
+      ? getAllocationsFromOutputs(transaction.outs)
+      : syscoinUtils.getAllocationsFromTx(transaction);
+  const assetAllocations = (rawAssetAllocations || []).map(
+    (allocation: any) => ({
+      assetGuid: String(allocation.assetGuid),
+      values: (allocation.values || []).map((value: any) => ({
+        n: value.n,
+        value: toBigIntValue(value.value, 'asset allocation').toString(),
+      })),
+    })
+  );
 
   let effectiveInput = totalInput;
   if (transaction.version === ALLOCATION_BURN_TO_SYSCOIN_VERSION) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11938,7 +11938,7 @@ syscoinjs-lib@^1.0.273:
     syscointx-js "^1.0.127"
     varuint-bitcoin "^2.0.0"
 
-syscointx-js@^1.0.127:
+syscointx-js@1.0.127, syscointx-js@^1.0.127:
   version "1.0.127"
   resolved "https://registry.yarnpkg.com/syscointx-js/-/syscointx-js-1.0.127.tgz#95c3822c0aa8f10eba1efa60f7ab348df31495f6"
   integrity sha512-9bZ86RxcJvs7YdwiaPIqSgP2z0HD7n0E9mb0WG4deJRfbrRXLhMczmICvwJ/yIxlKx0SgF5rmF49rrX8mNKSEw==


### PR DESCRIPTION
## Summary

- decode version-140 bridge-mint allocations directly from transaction outputs in Pali's PSBT review summary
- keep `syscointx-js` transaction classifiers and every construction/signing path unchanged
- pin the directly used `syscointx-js` 1.0.127 dependency
- add unfinalized v140 review coverage and exact allocation coverage above JavaScript's safe-integer limit

## Root cause

Pali's fail-closed PSBT review replaced decoded allocations with `syscoinjs-lib`'s `getAllocationsFromTx` result. Its underlying `syscointx-js` classifier omits Core's distinct version-140 mint type, so a valid NEVM-to-Syscoin bridge mint produced an empty allocation summary and the review gate disabled Confirm.

This patch handles only version 140 at Pali's review boundary by calling the already exported output allocation decoder. Other transaction versions retain the existing path. No asset inputs are assumed, and no builder, coin selection, transaction serialization, signing, or consensus behavior changes.

## Verification

- focused PSBT summary/review tests: 20 passed
- full unit suite: 61 suites, 374 tests passed
- `yarn type-check`: passed
- `yarn lint`: passed with one pre-existing naming warning
- `yarn i18n:check`: passed
- `yarn build:chrome`: passed (existing build warnings only)