### PR TITLE
Verify PSBT input assets before signing

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Pali Wallet",
-  "version": "4.0.64",
+  "version": "4.0.65",
   "icons": {
     "16": "assets/all_assets/favicon-16.png",
     "32": "assets/all_assets/favicon-32.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paliwallet",
-  "version": "4.0.64",
+  "version": "4.0.65",
   "description": "A Non-Custodial Crypto Wallet",
   "private": true,
   "repository": {

--- a/source/components/TransactionDetails/SyscoinTransactionDetailsFromPSBT.tsx
+++ b/source/components/TransactionDetails/SyscoinTransactionDetailsFromPSBT.tsx
@@ -15,6 +15,7 @@ import { useUtils } from 'hooks/index';
 import { useController } from 'hooks/useController';
 import { RootState } from 'state/store';
 import { selectActiveAccountAssets } from 'state/vault/selectors';
+import { SYSCOIN_PSBT_VERIFICATION_TIMEOUT_MS } from 'utils/constants';
 import { ellipsis } from 'utils/format';
 import { formatSyscoinValue } from 'utils/formatSyscoinValue';
 import {
@@ -244,7 +245,8 @@ const SyscoinTransactionDetailsFromPSBTComponent: React.FC<
       try {
         const decodedData = (await controllerEmitter(
           ['wallet', 'decodeRawTransaction'],
-          [psbtData]
+          [psbtData],
+          SYSCOIN_PSBT_VERIFICATION_TIMEOUT_MS
         )) as IDecodedTransaction;
         setDecodedTx(decodedData);
 

--- a/source/components/TransactionDetails/SyscoinTransactionDetailsFromPSBT.tsx
+++ b/source/components/TransactionDetails/SyscoinTransactionDetailsFromPSBT.tsx
@@ -44,6 +44,13 @@ export interface IDecodedTransaction {
     burn?: {
       ethaddress: string;
     };
+    inputAssets?: Array<{
+      assetGuid: string;
+      inputIndex: number;
+      previousOutputIndex: number;
+      previousTxid: string;
+      value: string;
+    }>;
     mint?: {
       blockhash: string;
       ethtxid: string;
@@ -755,6 +762,66 @@ const SyscoinTransactionDetailsFromPSBTComponent: React.FC<
           </div>
         </div>
       ))()}
+
+      {decodedTx.syscoin?.inputAssets &&
+        decodedTx.syscoin.inputAssets.length > 0 && (
+          <div className="space-y-3">
+            <Typography.Text className="text-white text-sm font-medium">
+              {t('send.assetsInvolved')} · {t('send.inputs')}
+            </Typography.Text>
+            <div className="space-y-2">
+              {decodedTx.syscoin.inputAssets.map((inputAsset) => {
+                const assetInfo = assetInfoMap[inputAsset.assetGuid] || {
+                  decimals: 8,
+                  symbol:
+                    inputAsset.assetGuid === SYSX_ASSET_GUID
+                      ? 'SYSX'
+                      : 'Unknown',
+                };
+
+                return (
+                  <div
+                    key={`${inputAsset.previousTxid}-${inputAsset.previousOutputIndex}-${inputAsset.assetGuid}`}
+                    className="bg-brand-blue800 p-4 rounded-lg space-y-2"
+                  >
+                    <div className="flex justify-between items-center gap-3">
+                      <Typography.Text className="text-brand-gray200 text-xs sm:text-sm">
+                        {t('send.inputs')} #{inputAsset.inputIndex}:
+                      </Typography.Text>
+                      <Typography.Text className="text-white text-xs sm:text-sm font-semibold text-right">
+                        {formatSyscoinValue(
+                          inputAsset.value,
+                          assetInfo.decimals ?? 8
+                        )}{' '}
+                        {assetInfo.symbol}
+                      </Typography.Text>
+                    </div>
+                    <CopyableField
+                      label={t('send.assetGuid')}
+                      value={inputAsset.assetGuid}
+                      displayValue={ellipsis(inputAsset.assetGuid, 12, 12)}
+                      monospace
+                      copyMessage={t('home.assetGuidCopied')}
+                    />
+                    <CopyableField
+                      label={`${t('send.transactionId')} / ${t(
+                        'send.outputs'
+                      )}`}
+                      value={`${inputAsset.previousTxid}:${inputAsset.previousOutputIndex}`}
+                      displayValue={`${ellipsis(
+                        inputAsset.previousTxid,
+                        10,
+                        10
+                      )}:${inputAsset.previousOutputIndex}`}
+                      monospace
+                      copyMessage={t('home.hashCopied')}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
 
       {/* Outputs Summary - show based on technical details or detail toggle */}
       {(showTechnicalDetails || showDetails) &&

--- a/source/config/consts.js
+++ b/source/config/consts.js
@@ -80,7 +80,7 @@ const CANARY_EXTENSION_KEY =
 const MV3_OPTIONS = {
   manifest_version: 3,
   name: 'Pali Wallet',
-  version: '4.0.64',
+  version: '4.0.65',
   icons: {
     16: 'assets/all_assets/favicon-16.png',
     32: 'assets/all_assets/favicon-32.png',

--- a/source/pages/Send/Confirm.tsx
+++ b/source/pages/Send/Confirm.tsx
@@ -52,6 +52,7 @@ import {
   removeScientificNotation,
   omitTransactionObjectData,
   INITIAL_FEE,
+  SYSCOIN_PSBT_VERIFICATION_TIMEOUT_MS,
   saveNavigationState,
   clearNavigationState,
 } from 'utils/index';
@@ -638,7 +639,7 @@ export const SendConfirm = () => {
               ],
               activeAccount.isTrezorWallet || activeAccount.isLedgerWallet
                 ? 300000 // 5 minutes timeout for hardware wallet operations
-                : 10000 // Default 10 seconds for regular wallets
+                : SYSCOIN_PSBT_VERIFICATION_TIMEOUT_MS
             );
 
             setConfirmed(true);

--- a/source/pages/Transactions/Sign.tsx
+++ b/source/pages/Transactions/Sign.tsx
@@ -98,7 +98,7 @@ const Sign: React.FC<ISign> = ({ signOnly = false }) => {
       } else {
         // Sign-only flow
         response = await controllerEmitter(
-          ['wallet', 'syscoinTransaction', 'signPSBT'],
+          ['wallet', 'signSyscoinPsbt'],
           [
             {
               psbt: data,

--- a/source/pages/Transactions/Sign.tsx
+++ b/source/pages/Transactions/Sign.tsx
@@ -10,6 +10,7 @@ import { useController } from 'hooks/useController';
 import { RootState } from 'state/store';
 import { createTemporaryAlarm } from 'utils/alarmUtils';
 import { dispatchBackgroundEvent } from 'utils/browser';
+import { SYSCOIN_PSBT_VERIFICATION_TIMEOUT_MS } from 'utils/constants';
 import { handleTransactionError } from 'utils/errorHandling';
 import { clearNavigationState } from 'utils/navigationState';
 import { sanitizeErrorMessage } from 'utils/syscoinErrorSanitizer';
@@ -93,7 +94,7 @@ const Sign: React.FC<ISign> = ({ signOnly = false }) => {
           ],
           activeAccount.isTrezorWallet || activeAccount.isLedgerWallet
             ? 300000 // 5 minutes timeout for hardware wallet operations
-            : 10000 // Default 10 seconds for regular wallets
+            : SYSCOIN_PSBT_VERIFICATION_TIMEOUT_MS
         );
       } else {
         // Sign-only flow
@@ -108,7 +109,7 @@ const Sign: React.FC<ISign> = ({ signOnly = false }) => {
           ],
           activeAccount.isTrezorWallet || activeAccount.isLedgerWallet
             ? 300000 // 5 minutes timeout for hardware wallet operations
-            : 10000 // Default 10 seconds for regular wallets
+            : SYSCOIN_PSBT_VERIFICATION_TIMEOUT_MS
         );
       }
       // Show success toast

--- a/source/scripts/Background/controllers/MainController.ts
+++ b/source/scripts/Background/controllers/MainController.ts
@@ -150,7 +150,7 @@ import type {
   SmartAccountPackedUserOperation,
 } from 'utils/smartAccount';
 import { chromeStorage } from 'utils/storageAPI';
-import { getSyscoinPsbtValueSummary } from 'utils/syscoinPsbtValues';
+import { getVerifiedSyscoinPsbtValueSummary } from 'utils/syscoinPsbtValues';
 import { getKnownTokenLogo } from 'utils/tokens';
 import {
   isTransactionInBlock,
@@ -4569,7 +4569,7 @@ class MainController {
         const controller = getController();
 
         // Step 1: Sign the PSBT
-        const signedPsbt = await controller.wallet.syscoinTransaction.signPSBT({
+        const signedPsbt = await this.signSyscoinPsbt({
           psbt: params.psbt,
           isTrezor: params.isTrezor,
           isLedger: params.isLedger,
@@ -6541,8 +6541,27 @@ class MainController {
   // Expose txUtils methods individually for better type safety
   public getRawTransaction = this.txUtils.getRawTransaction;
 
+  private verifySyscoinPsbt = async (psbtData: any) => {
+    const activeNetwork = store.getState().vault.activeNetwork;
+    const psbt = PsbtUtils.fromPali(psbtData, activeNetwork);
+    const summary = await getVerifiedSyscoinPsbtValueSummary(psbt, (txid) =>
+      this.txUtils.getRawTransaction(activeNetwork.url, txid)
+    );
+
+    return { psbt, summary };
+  };
+
+  public signSyscoinPsbt = async (params: {
+    isLedger?: boolean;
+    isTrezor?: boolean;
+    psbt: any;
+  }) => {
+    await this.verifySyscoinPsbt(params.psbt);
+    return this.syscoinTransaction.signPSBT(params);
+  };
+
   // Add decodeRawTransaction method for PSBT/transaction details display
-  public decodeRawTransaction = (psbtOrHex: any, isRawHex = false) => {
+  public decodeRawTransaction = async (psbtOrHex: any, isRawHex = false) => {
     try {
       const decoded = this.syscoinTransaction.decodeRawTransaction(
         psbtOrHex,
@@ -6550,11 +6569,7 @@ class MainController {
       );
 
       if (!isRawHex) {
-        const psbt = PsbtUtils.fromPali(
-          psbtOrHex,
-          store.getState().vault.activeNetwork
-        );
-        const summary = getSyscoinPsbtValueSummary(psbt);
+        const { summary } = await this.verifySyscoinPsbt(psbtOrHex);
         if (
           !Array.isArray(decoded.vout) ||
           decoded.vout.length !== summary.outputValuesSatoshis.length
@@ -6569,6 +6584,7 @@ class MainController {
           decoded.syscoin.allocations = summary.assetAllocations.length
             ? { assets: summary.assetAllocations }
             : null;
+          decoded.syscoin.inputAssets = summary.inputAssets;
         }
       }
 

--- a/source/utils/constants.ts
+++ b/source/utils/constants.ts
@@ -42,6 +42,9 @@ export type FieldValuesType = {
 
 export const MINIMUM_FEE = 0.00001;
 
+// Large consolidation PSBTs resolve prevouts through a bounded worker pool.
+export const SYSCOIN_PSBT_VERIFICATION_TIMEOUT_MS = 60_000;
+
 // Define the keys you are interested in
 export const syscoinKeysOfInterest = [
   'symbol',

--- a/source/utils/syscoinPsbtValues.spec.ts
+++ b/source/utils/syscoinPsbtValues.spec.ts
@@ -6,7 +6,10 @@ import {
 } from 'syscoinjs-lib';
 
 import { getSyscoinPsbtReviewError } from './syscoinPsbtReview';
-import { getSyscoinPsbtValueSummary } from './syscoinPsbtValues';
+import {
+  getSyscoinPsbtValueSummary,
+  getVerifiedSyscoinPsbtValueSummary,
+} from './syscoinPsbtValues';
 
 const syscointx = jest.requireActual('syscointx-js');
 
@@ -126,6 +129,29 @@ const emptyTransaction = () => {
   const transaction = new syscoinUtils.bitcoinjs.Transaction();
   transaction.version = 2;
   return transaction;
+};
+
+const createAssetPrevout = () => {
+  const allocationData = syscointx.bufferUtils.serializeAssetAllocations([
+    {
+      assetGuid: '4294967297',
+      values: [{ n: 0, value: new syscoinUtils.BN(1) }],
+    },
+  ]);
+  const previousTransaction = new syscoinUtils.bitcoinjs.Transaction();
+  previousTransaction.version = 142;
+  previousTransaction.addInput(Buffer.alloc(32), 0xffffffff);
+  const assetScript = Buffer.from(
+    '00140000000000000000000000000000000000000001',
+    'hex'
+  );
+  previousTransaction.addOutput(assetScript, BigInt(546));
+  previousTransaction.addOutput(
+    syscoinUtils.bitcoinjs.payments.embed({ data: [allocationData] }).output!,
+    BigInt(0)
+  );
+
+  return { allocationData, assetScript, previousTransaction };
 };
 
 describe('Syscoin PSBT value summary', () => {
@@ -424,5 +450,206 @@ describe('Syscoin PSBT value summary', () => {
         extractTransaction: emptyTransaction,
       })
     ).toThrow('PSBT input 0 previous transaction mismatch');
+  });
+
+  it('rejects a standard transaction that hides an asset-bearing input', async () => {
+    const { assetScript, previousTransaction } = createAssetPrevout();
+
+    const psbt = new syscoinUtils.bitcoinjs.Psbt({
+      network: syscoinUtils.syscoinNetworks.testnet,
+    });
+    psbt.setVersion(2);
+    psbt.addInput({
+      hash: previousTransaction.getHash(),
+      index: 0,
+      nonWitnessUtxo: previousTransaction.toBuffer(),
+    });
+    psbt.addOutput({ script: assetScript, value: BigInt(500) });
+
+    await expect(
+      getVerifiedSyscoinPsbtValueSummary(psbt, jest.fn())
+    ).rejects.toThrow(
+      'Asset-bearing PSBT input 0 is not allowed in transaction version 2'
+    );
+  });
+
+  it('accepts a standard transaction after hash-binding its witness prevout', async () => {
+    const previousTransaction = emptyTransaction();
+    previousTransaction.addInput(Buffer.alloc(32), 0xffffffff);
+    const script = Buffer.from(
+      '00140000000000000000000000000000000000000001',
+      'hex'
+    );
+    previousTransaction.addOutput(script, BigInt(1000));
+    const psbt = new syscoinUtils.bitcoinjs.Psbt({
+      network: syscoinUtils.syscoinNetworks.testnet,
+    });
+    psbt.setVersion(2);
+    psbt.addInput({
+      hash: previousTransaction.getHash(),
+      index: 0,
+      witnessUtxo: { script, value: BigInt(1000) },
+    });
+    psbt.addOutput({ script, value: BigInt(900) });
+    const fetchRawTransaction = jest.fn().mockResolvedValue({
+      hex: previousTransaction.toHex(),
+    });
+
+    await expect(
+      getVerifiedSyscoinPsbtValueSummary(psbt, fetchRawTransaction)
+    ).resolves.toMatchObject({ feeSatoshis: '100', inputAssets: [] });
+    expect(fetchRawTransaction).toHaveBeenCalledWith(
+      previousTransaction.getId()
+    );
+  });
+
+  it('accepts a supported asset send whose inputs and outputs match exactly', async () => {
+    const { allocationData, assetScript, previousTransaction } =
+      createAssetPrevout();
+    const psbt = new syscoinUtils.bitcoinjs.Psbt({
+      network: syscoinUtils.syscoinNetworks.testnet,
+    });
+    psbt.setVersion(142);
+    psbt.addInput({
+      hash: previousTransaction.getHash(),
+      index: 0,
+      nonWitnessUtxo: previousTransaction.toBuffer(),
+    });
+    psbt.addUnknownKeyValToInput(0, {
+      key: Buffer.from('assetInfo'),
+      value: Buffer.from(
+        JSON.stringify({ assetGuid: '4294967297', value: '1' })
+      ),
+    });
+    psbt.addOutput({ script: assetScript, value: BigInt(500) });
+    psbt.addOutput({
+      script: syscoinUtils.bitcoinjs.payments.embed({
+        data: [allocationData],
+      }).output!,
+      value: BigInt(0),
+    });
+
+    await expect(
+      getVerifiedSyscoinPsbtValueSummary(psbt, jest.fn())
+    ).resolves.toMatchObject({
+      feeSatoshis: '46',
+      inputAssets: [
+        {
+          assetGuid: '4294967297',
+          inputIndex: 0,
+          previousOutputIndex: 0,
+          previousTxid: previousTransaction.getId(),
+          value: '1',
+        },
+      ],
+    });
+  });
+
+  it('rejects an asset send whose serialized outputs do not conserve inputs', async () => {
+    const { assetScript, previousTransaction } = createAssetPrevout();
+    const mismatchedAllocationData =
+      syscointx.bufferUtils.serializeAssetAllocations([
+        {
+          assetGuid: '4294967297',
+          values: [{ n: 0, value: new syscoinUtils.BN(2) }],
+        },
+      ]);
+    const psbt = new syscoinUtils.bitcoinjs.Psbt({
+      network: syscoinUtils.syscoinNetworks.testnet,
+    });
+    psbt.setVersion(142);
+    psbt.addInput({
+      hash: previousTransaction.getHash(),
+      index: 0,
+      nonWitnessUtxo: previousTransaction.toBuffer(),
+    });
+    psbt.addUnknownKeyValToInput(0, {
+      key: Buffer.from('assetInfo'),
+      value: Buffer.from(
+        JSON.stringify({ assetGuid: '4294967297', value: '1' })
+      ),
+    });
+    psbt.addOutput({ script: assetScript, value: BigInt(500) });
+    psbt.addOutput({
+      script: syscoinUtils.bitcoinjs.payments.embed({
+        data: [mismatchedAllocationData],
+      }).output!,
+      value: BigInt(0),
+    });
+
+    await expect(
+      getVerifiedSyscoinPsbtValueSummary(psbt, jest.fn())
+    ).rejects.toThrow(
+      'PSBT asset 4294967297 inputs do not match its serialized allocations'
+    );
+  });
+
+  it('rejects omitted or conflicting asset input metadata', async () => {
+    const { allocationData, assetScript, previousTransaction } =
+      createAssetPrevout();
+    const createPsbt = (metadata?: { assetGuid: string; value: string }) => {
+      const psbt = new syscoinUtils.bitcoinjs.Psbt({
+        network: syscoinUtils.syscoinNetworks.testnet,
+      });
+      psbt.setVersion(142);
+      psbt.addInput({
+        hash: previousTransaction.getHash(),
+        index: 0,
+        nonWitnessUtxo: previousTransaction.toBuffer(),
+      });
+      if (metadata) {
+        psbt.addUnknownKeyValToInput(0, {
+          key: Buffer.from('assetInfo'),
+          value: Buffer.from(JSON.stringify(metadata)),
+        });
+      }
+      psbt.addOutput({ script: assetScript, value: BigInt(500) });
+      psbt.addOutput({
+        script: syscoinUtils.bitcoinjs.payments.embed({
+          data: [allocationData],
+        }).output!,
+        value: BigInt(0),
+      });
+      return psbt;
+    };
+
+    await expect(
+      getVerifiedSyscoinPsbtValueSummary(createPsbt(), jest.fn())
+    ).rejects.toThrow('PSBT input 0 omits its asset metadata');
+    await expect(
+      getVerifiedSyscoinPsbtValueSummary(
+        createPsbt({ assetGuid: '4294967297', value: '2' }),
+        jest.fn()
+      )
+    ).rejects.toThrow('Conflicting PSBT input 0 asset metadata');
+  });
+
+  it('rejects a fetched witness prevout whose hash does not match', async () => {
+    const referencedTransaction = emptyTransaction();
+    referencedTransaction.addInput(Buffer.alloc(32), 0xffffffff);
+    const script = Buffer.from(
+      '00140000000000000000000000000000000000000001',
+      'hex'
+    );
+    referencedTransaction.addOutput(script, BigInt(1000));
+    const unrelatedTransaction = emptyTransaction();
+    unrelatedTransaction.addInput(Buffer.alloc(32, 1), 0xffffffff);
+    unrelatedTransaction.addOutput(script, BigInt(1000));
+    const psbt = new syscoinUtils.bitcoinjs.Psbt({
+      network: syscoinUtils.syscoinNetworks.testnet,
+    });
+    psbt.addInput({
+      hash: referencedTransaction.getHash(),
+      index: 0,
+      witnessUtxo: { script, value: BigInt(1000) },
+    });
+    psbt.addOutput({ script, value: BigInt(900) });
+
+    await expect(
+      getVerifiedSyscoinPsbtValueSummary(
+        psbt,
+        jest.fn().mockResolvedValue(unrelatedTransaction.toHex())
+      )
+    ).rejects.toThrow('PSBT input 0 previous transaction mismatch');
   });
 });

--- a/source/utils/syscoinPsbtValues.spec.ts
+++ b/source/utils/syscoinPsbtValues.spec.ts
@@ -565,6 +565,147 @@ describe('Syscoin PSBT value summary', () => {
     );
   });
 
+  it('deduplicates witness prevout lookups from the same transaction', async () => {
+    const previousTransaction = emptyTransaction();
+    previousTransaction.addInput(Buffer.alloc(32), 0xffffffff);
+    const script = Buffer.from(
+      '00140000000000000000000000000000000000000001',
+      'hex'
+    );
+    previousTransaction.addOutput(script, BigInt(1000));
+    previousTransaction.addOutput(script, BigInt(2000));
+    const psbt = new syscoinUtils.bitcoinjs.Psbt({
+      network: syscoinUtils.syscoinNetworks.testnet,
+    });
+    psbt.setVersion(2);
+    psbt.addInput({
+      hash: previousTransaction.getHash(),
+      index: 0,
+      witnessUtxo: { script, value: BigInt(1000) },
+    });
+    psbt.addInput({
+      hash: previousTransaction.getHash(),
+      index: 1,
+      witnessUtxo: { script, value: BigInt(2000) },
+    });
+    psbt.addOutput({ script, value: BigInt(2900) });
+    const fetchRawTransaction = jest.fn().mockResolvedValue({
+      hex: previousTransaction.toHex(),
+    });
+
+    await expect(
+      getVerifiedSyscoinPsbtValueSummary(psbt, fetchRawTransaction)
+    ).resolves.toMatchObject({ feeSatoshis: '100', inputAssets: [] });
+    expect(fetchRawTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('bounds concurrent witness prevout lookups', async () => {
+    const script = Buffer.from(
+      '00140000000000000000000000000000000000000001',
+      'hex'
+    );
+    const previousTransactions = Array.from({ length: 12 }, (_, index) => {
+      const previousTransaction = emptyTransaction();
+      previousTransaction.addInput(Buffer.alloc(32, index + 1), 0xffffffff);
+      previousTransaction.addOutput(script, BigInt(1000));
+      return previousTransaction;
+    });
+    const previousTransactionsById = new Map(
+      previousTransactions.map((transaction) => [
+        transaction.getId(),
+        transaction,
+      ])
+    );
+    const psbt = new syscoinUtils.bitcoinjs.Psbt({
+      network: syscoinUtils.syscoinNetworks.testnet,
+    });
+    psbt.setVersion(2);
+    for (const previousTransaction of previousTransactions) {
+      psbt.addInput({
+        hash: previousTransaction.getHash(),
+        index: 0,
+        witnessUtxo: { script, value: BigInt(1000) },
+      });
+    }
+    psbt.addOutput({ script, value: BigInt(11900) });
+
+    let activeLookups = 0;
+    let maximumActiveLookups = 0;
+    const fetchRawTransaction = jest.fn(async (txid: string) => {
+      activeLookups += 1;
+      maximumActiveLookups = Math.max(maximumActiveLookups, activeLookups);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      activeLookups -= 1;
+      return { hex: previousTransactionsById.get(txid)?.toHex() };
+    });
+
+    await expect(
+      getVerifiedSyscoinPsbtValueSummary(psbt, fetchRawTransaction)
+    ).resolves.toMatchObject({ feeSatoshis: '100', inputAssets: [] });
+    expect(fetchRawTransaction).toHaveBeenCalledTimes(
+      previousTransactions.length
+    );
+    expect(maximumActiveLookups).toBe(8);
+  });
+
+  it('stops scheduling witness prevout lookups after a failure', async () => {
+    const script = Buffer.from(
+      '00140000000000000000000000000000000000000001',
+      'hex'
+    );
+    const previousTransactions = Array.from({ length: 12 }, (_, index) => {
+      const previousTransaction = emptyTransaction();
+      previousTransaction.addInput(Buffer.alloc(32, index + 1), 0xffffffff);
+      previousTransaction.addOutput(script, BigInt(1000));
+      return previousTransaction;
+    });
+    const psbt = new syscoinUtils.bitcoinjs.Psbt({
+      network: syscoinUtils.syscoinNetworks.testnet,
+    });
+    psbt.setVersion(2);
+    for (const previousTransaction of previousTransactions) {
+      psbt.addInput({
+        hash: previousTransaction.getHash(),
+        index: 0,
+        witnessUtxo: { script, value: BigInt(1000) },
+      });
+    }
+    psbt.addOutput({ script, value: BigInt(11900) });
+
+    let rejectFirstLookup: ((reason?: unknown) => void) | undefined;
+    const settleActiveLookups: Array<() => void> = [];
+    const previousTransactionsById = new Map(
+      previousTransactions.map((transaction) => [
+        transaction.getId(),
+        transaction,
+      ])
+    );
+    const fetchRawTransaction = jest.fn(
+      (txid: string) =>
+        new Promise((resolve, reject) => {
+          if (!rejectFirstLookup) {
+            rejectFirstLookup = reject;
+          } else {
+            settleActiveLookups.push(() =>
+              resolve({ hex: previousTransactionsById.get(txid)?.toHex() })
+            );
+          }
+        })
+    );
+    const verification = getVerifiedSyscoinPsbtValueSummary(
+      psbt,
+      fetchRawTransaction
+    );
+
+    expect(fetchRawTransaction).toHaveBeenCalledTimes(8);
+    rejectFirstLookup?.(new Error('lookup failed'));
+    await expect(verification).rejects.toThrow('lookup failed');
+    settleActiveLookups.forEach((settle) => settle());
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fetchRawTransaction).toHaveBeenCalledTimes(8);
+  });
+
   it('accepts a supported asset send whose inputs and outputs match exactly', async () => {
     const { allocationData, assetScript, previousTransaction } =
       createAssetPrevout();

--- a/source/utils/syscoinPsbtValues.spec.ts
+++ b/source/utils/syscoinPsbtValues.spec.ts
@@ -12,6 +12,10 @@ import {
 } from './syscoinPsbtValues';
 
 const syscointx = jest.requireActual('syscointx-js');
+const CORE_WITNESS_COMMITMENT = Buffer.concat([
+  Buffer.from('aa21a9ed', 'hex'),
+  Buffer.alloc(32),
+]);
 
 const createUnfinalizedBurnToSyscoinPsbt = ({
   allocationAssetGuid = '123456',
@@ -152,6 +156,36 @@ const createAssetPrevout = () => {
   );
 
   return { allocationData, assetScript, previousTransaction };
+};
+
+const createWitnessWrappedAssetPrevout = () => {
+  const realAllocationData = syscointx.bufferUtils.serializeAssetAllocations([
+    {
+      assetGuid: '4294967297',
+      values: [{ n: 1, value: new syscoinUtils.BN(1) }],
+    },
+  ]);
+  const javascriptDecoy = Buffer.concat([
+    Buffer.from('aa21a9ed00', 'hex'),
+    Buffer.alloc(168 * 2),
+    Buffer.alloc(169 * 2),
+  ]);
+  const previousTransaction = new syscoinUtils.bitcoinjs.Transaction();
+  previousTransaction.version = 142;
+  previousTransaction.addInput(Buffer.alloc(32), 0xffffffff);
+  const assetScript = Buffer.from(
+    '00140000000000000000000000000000000000000001',
+    'hex'
+  );
+  previousTransaction.addOutput(
+    syscoinUtils.bitcoinjs.payments.embed({
+      data: [javascriptDecoy, realAllocationData],
+    }).output!,
+    BigInt(0)
+  );
+  previousTransaction.addOutput(assetScript, BigInt(546));
+
+  return { assetScript, previousTransaction };
 };
 
 describe('Syscoin PSBT value summary', () => {
@@ -387,6 +421,13 @@ describe('Syscoin PSBT value summary', () => {
       }).output!,
       value: BigInt(0),
     });
+    psbt.addOutput({
+      script: Buffer.from(
+        '00140000000000000000000000000000000000000001',
+        'hex'
+      ),
+      value: BigInt(0),
+    });
 
     const summary = getSyscoinPsbtValueSummary(psbt);
 
@@ -473,6 +514,27 @@ describe('Syscoin PSBT value summary', () => {
     );
   });
 
+  it('rejects a standard transaction spending an asset hidden behind a Core witness-marker push', async () => {
+    const { assetScript, previousTransaction } =
+      createWitnessWrappedAssetPrevout();
+    const psbt = new syscoinUtils.bitcoinjs.Psbt({
+      network: syscoinUtils.syscoinNetworks.testnet,
+    });
+    psbt.setVersion(2);
+    psbt.addInput({
+      hash: previousTransaction.getHash(),
+      index: 1,
+      nonWitnessUtxo: previousTransaction.toBuffer(),
+    });
+    psbt.addOutput({ script: assetScript, value: BigInt(500) });
+
+    await expect(
+      getVerifiedSyscoinPsbtValueSummary(psbt, jest.fn())
+    ).rejects.toThrow(
+      'Asset-bearing PSBT input 0 is not allowed in transaction version 2'
+    );
+  });
+
   it('accepts a standard transaction after hash-binding its witness prevout', async () => {
     const previousTransaction = emptyTransaction();
     previousTransaction.addInput(Buffer.alloc(32), 0xffffffff);
@@ -543,6 +605,176 @@ describe('Syscoin PSBT value summary', () => {
         },
       ],
     });
+  });
+
+  it('accepts the Core witness-marker form and uses its second pushed allocation payload', async () => {
+    const { allocationData, assetScript, previousTransaction } =
+      createAssetPrevout();
+    const psbt = new syscoinUtils.bitcoinjs.Psbt({
+      network: syscoinUtils.syscoinNetworks.testnet,
+    });
+    psbt.setVersion(142);
+    psbt.addInput({
+      hash: previousTransaction.getHash(),
+      index: 0,
+      nonWitnessUtxo: previousTransaction.toBuffer(),
+    });
+    psbt.addUnknownKeyValToInput(0, {
+      key: Buffer.from('assetInfo'),
+      value: Buffer.from(
+        JSON.stringify({ assetGuid: '4294967297', value: '1' })
+      ),
+    });
+    psbt.addOutput({ script: assetScript, value: BigInt(500) });
+    psbt.addOutput({
+      script: syscoinUtils.bitcoinjs.payments.embed({
+        data: [CORE_WITNESS_COMMITMENT, allocationData],
+      }).output!,
+      value: BigInt(0),
+    });
+
+    await expect(
+      getVerifiedSyscoinPsbtValueSummary(psbt, jest.fn())
+    ).resolves.toMatchObject({
+      assetAllocations: [
+        {
+          assetGuid: '4294967297',
+          values: [{ n: 0, value: '1' }],
+        },
+      ],
+      feeSatoshis: '46',
+    });
+  });
+
+  it('rejects trailing pushes after the Core-selected Syscoin payload', async () => {
+    const { allocationData, assetScript, previousTransaction } =
+      createAssetPrevout();
+    const psbt = new syscoinUtils.bitcoinjs.Psbt({
+      network: syscoinUtils.syscoinNetworks.testnet,
+    });
+    psbt.setVersion(142);
+    psbt.addInput({
+      hash: previousTransaction.getHash(),
+      index: 0,
+      nonWitnessUtxo: previousTransaction.toBuffer(),
+    });
+    psbt.addUnknownKeyValToInput(0, {
+      key: Buffer.from('assetInfo'),
+      value: Buffer.from(
+        JSON.stringify({ assetGuid: '4294967297', value: '1' })
+      ),
+    });
+    psbt.addOutput({ script: assetScript, value: BigInt(500) });
+    psbt.addOutput({
+      script: syscoinUtils.bitcoinjs.payments.embed({
+        data: [
+          CORE_WITNESS_COMMITMENT,
+          allocationData,
+          Buffer.from('00', 'hex'),
+        ],
+      }).output!,
+      value: BigInt(0),
+    });
+
+    await expect(
+      getVerifiedSyscoinPsbtValueSummary(psbt, jest.fn())
+    ).rejects.toThrow('Unable to verify Syscoin transaction data');
+  });
+
+  it('rejects a Core witness marker without a second pushed payload', async () => {
+    const { assetScript, previousTransaction } = createAssetPrevout();
+    const psbt = new syscoinUtils.bitcoinjs.Psbt({
+      network: syscoinUtils.syscoinNetworks.testnet,
+    });
+    psbt.setVersion(142);
+    psbt.addInput({
+      hash: previousTransaction.getHash(),
+      index: 0,
+      nonWitnessUtxo: previousTransaction.toBuffer(),
+    });
+    psbt.addUnknownKeyValToInput(0, {
+      key: Buffer.from('assetInfo'),
+      value: Buffer.from(
+        JSON.stringify({ assetGuid: '4294967297', value: '1' })
+      ),
+    });
+    psbt.addOutput({ script: assetScript, value: BigInt(500) });
+    psbt.addOutput({
+      script: syscoinUtils.bitcoinjs.payments.embed({
+        data: [CORE_WITNESS_COMMITMENT],
+      }).output!,
+      value: BigInt(0),
+    });
+
+    await expect(
+      getVerifiedSyscoinPsbtValueSummary(psbt, jest.fn())
+    ).rejects.toThrow('Unable to verify Syscoin transaction data');
+  });
+
+  it('rejects a second push when the first payload is not a Core witness marker', async () => {
+    const { allocationData, assetScript, previousTransaction } =
+      createAssetPrevout();
+    const psbt = new syscoinUtils.bitcoinjs.Psbt({
+      network: syscoinUtils.syscoinNetworks.testnet,
+    });
+    psbt.setVersion(142);
+    psbt.addInput({
+      hash: previousTransaction.getHash(),
+      index: 0,
+      nonWitnessUtxo: previousTransaction.toBuffer(),
+    });
+    psbt.addUnknownKeyValToInput(0, {
+      key: Buffer.from('assetInfo'),
+      value: Buffer.from(
+        JSON.stringify({ assetGuid: '4294967297', value: '1' })
+      ),
+    });
+    psbt.addOutput({ script: assetScript, value: BigInt(500) });
+    psbt.addOutput({
+      script: syscoinUtils.bitcoinjs.payments.embed({
+        data: [allocationData, Buffer.from('00', 'hex')],
+      }).output!,
+      value: BigInt(0),
+    });
+
+    await expect(
+      getVerifiedSyscoinPsbtValueSummary(psbt, jest.fn())
+    ).rejects.toThrow('Unable to verify Syscoin transaction data');
+  });
+
+  it("does not skip Core's first unspendable output for a later parseable OP_RETURN", async () => {
+    const { allocationData, assetScript, previousTransaction } =
+      createAssetPrevout();
+    const psbt = new syscoinUtils.bitcoinjs.Psbt({
+      network: syscoinUtils.syscoinNetworks.testnet,
+    });
+    psbt.setVersion(142);
+    psbt.addInput({
+      hash: previousTransaction.getHash(),
+      index: 0,
+      nonWitnessUtxo: previousTransaction.toBuffer(),
+    });
+    psbt.addUnknownKeyValToInput(0, {
+      key: Buffer.from('assetInfo'),
+      value: Buffer.from(
+        JSON.stringify({ assetGuid: '4294967297', value: '1' })
+      ),
+    });
+    psbt.addOutput({ script: assetScript, value: BigInt(500) });
+    psbt.addOutput({
+      script: Buffer.alloc(10_001, syscoinUtils.bitcoinjs.opcodes.OP_TRUE),
+      value: BigInt(0),
+    });
+    psbt.addOutput({
+      script: syscoinUtils.bitcoinjs.payments.embed({
+        data: [allocationData],
+      }).output!,
+      value: BigInt(0),
+    });
+
+    await expect(
+      getVerifiedSyscoinPsbtValueSummary(psbt, jest.fn())
+    ).rejects.toThrow('Unable to verify Syscoin transaction data');
   });
 
   it('rejects an asset send whose serialized outputs do not conserve inputs', async () => {

--- a/source/utils/syscoinPsbtValues.ts
+++ b/source/utils/syscoinPsbtValues.ts
@@ -1,11 +1,21 @@
 import { utils as syscoinUtils } from 'syscoinjs-lib';
-import { getAllocationsFromOutputs } from 'syscointx-js';
+import { bufferUtils as syscoinBufferUtils } from 'syscointx-js';
 
 const ALLOCATION_BURN_TO_SYSCOIN_VERSION = 138;
+const SYSCOIN_BURN_TO_ALLOCATION_VERSION = 139;
 const ALLOCATION_MINT_VERSION = 140;
 const ALLOCATION_BURN_TO_ETHEREUM_VERSION = 141;
 const ALLOCATION_SEND_VERSION = 142;
 const SYSX_ASSET_GUID = '123456';
+const CORE_MAX_SCRIPT_SIZE = 10_000;
+const CORE_WITNESS_COMMITMENT_HEADER = Buffer.from('aa21a9ed', 'hex');
+const SYSCOIN_ASSET_VERSIONS = new Set([
+  ALLOCATION_BURN_TO_SYSCOIN_VERSION,
+  SYSCOIN_BURN_TO_ALLOCATION_VERSION,
+  ALLOCATION_MINT_VERSION,
+  ALLOCATION_BURN_TO_ETHEREUM_VERSION,
+  ALLOCATION_SEND_VERSION,
+]);
 
 export interface ISyscoinPsbtInputAsset {
   assetGuid: string;
@@ -41,12 +51,92 @@ const normalizeAssetAllocations = (
     })),
   }));
 
-const getExactAssetAllocations = (transaction: any) =>
-  normalizeAssetAllocations(
-    transaction.version === ALLOCATION_MINT_VERSION
-      ? getAllocationsFromOutputs(transaction.outs)
-      : syscoinUtils.getAllocationsFromTx(transaction)
-  );
+const asPushedBytes = (chunk: unknown): Buffer | null =>
+  chunk instanceof Uint8Array ? Buffer.from(chunk) : null;
+
+/**
+ * Mirror Syscoin Core's GetSyscoinData selection boundary. Core uses the
+ * first unspendable output, then treats a >=36-byte aa21a9ed first push as a
+ * witness commitment and consumes exactly one following push. Selecting a
+ * payload merely because it parses would let a decoy disagree with chainstate.
+ * Pali additionally requires a structurally complete script and fails closed
+ * on malformed trailing bytes rather than treating a decode failure as EOF.
+ */
+const getCoreSyscoinPayload = (transaction: any): Buffer => {
+  const dataOutput = (transaction?.outs || []).find((output: any) => {
+    const script = output?.script;
+    return (
+      script instanceof Uint8Array &&
+      (script.length > CORE_MAX_SCRIPT_SIZE ||
+        script[0] === syscoinUtils.bitcoinjs.opcodes.OP_RETURN)
+    );
+  });
+  const script = dataOutput?.script;
+  if (!(script instanceof Uint8Array)) {
+    throw new Error('Unable to verify Syscoin transaction data');
+  }
+
+  const chunks = syscoinUtils.bitcoinjs.script.decompile(script);
+  if (!chunks || chunks[0] !== syscoinUtils.bitcoinjs.opcodes.OP_RETURN) {
+    throw new Error('Unable to verify Syscoin transaction data');
+  }
+
+  const firstPush = asPushedBytes(chunks[1]);
+  if (!firstPush) {
+    throw new Error('Unable to verify Syscoin transaction data');
+  }
+
+  const hasWitnessCommitment =
+    firstPush.length >= 36 &&
+    firstPush
+      .subarray(0, CORE_WITNESS_COMMITMENT_HEADER.length)
+      .equals(CORE_WITNESS_COMMITMENT_HEADER);
+  const payloadIndex = hasWitnessCommitment ? 2 : 1;
+  const payload = asPushedBytes(chunks[payloadIndex]);
+  if (!payload || chunks.length !== payloadIndex + 1) {
+    throw new Error('Unable to verify Syscoin transaction data');
+  }
+
+  return payload;
+};
+
+const getExactAssetAllocations = (
+  transaction: any
+): IExactAssetAllocation[] => {
+  if (!SYSCOIN_ASSET_VERSIONS.has(transaction?.version)) return [];
+
+  try {
+    const payload = getCoreSyscoinPayload(transaction);
+    const decoded = syscoinBufferUtils.deserializeAssetAllocations(payload);
+    const allocations = normalizeAssetAllocations(decoded);
+    if (allocations.length === 0) {
+      throw new Error('Empty Syscoin asset allocations');
+    }
+
+    for (const allocation of allocations) {
+      if (
+        !/^\d+$/.test(allocation.assetGuid) ||
+        allocation.values.length === 0
+      ) {
+        throw new Error('Invalid Syscoin asset allocation');
+      }
+
+      for (const value of allocation.values) {
+        if (
+          !Number.isSafeInteger(value.n) ||
+          value.n < 0 ||
+          value.n >= transaction.outs.length
+        ) {
+          throw new Error('Invalid Syscoin asset output');
+        }
+      }
+    }
+
+    return allocations;
+  } catch (_error) {
+    throw new Error('Unable to verify Syscoin transaction data');
+  }
+};
 
 const getRawTransactionHex = (response: any): string | null => {
   if (typeof response === 'string') return response;

--- a/source/utils/syscoinPsbtValues.ts
+++ b/source/utils/syscoinPsbtValues.ts
@@ -3,7 +3,24 @@ import { getAllocationsFromOutputs } from 'syscointx-js';
 
 const ALLOCATION_BURN_TO_SYSCOIN_VERSION = 138;
 const ALLOCATION_MINT_VERSION = 140;
+const ALLOCATION_BURN_TO_ETHEREUM_VERSION = 141;
+const ALLOCATION_SEND_VERSION = 142;
 const SYSX_ASSET_GUID = '123456';
+
+export interface ISyscoinPsbtInputAsset {
+  assetGuid: string;
+  inputIndex: number;
+  previousOutputIndex: number;
+  previousTxid: string;
+  value: string;
+}
+
+interface IExactAssetAllocation {
+  assetGuid: string;
+  values: Array<{ n: number; value: string }>;
+}
+
+type RawTransactionFetcher = (txid: string) => Promise<unknown>;
 
 const toBigIntValue = (value: unknown, field: string): bigint => {
   const normalized = String(value);
@@ -13,8 +30,222 @@ const toBigIntValue = (value: unknown, field: string): bigint => {
   return BigInt(normalized);
 };
 
+const normalizeAssetAllocations = (
+  allocations: any[] | null | undefined
+): IExactAssetAllocation[] =>
+  (allocations || []).map((allocation: any) => ({
+    assetGuid: String(allocation.assetGuid),
+    values: (allocation.values || []).map((value: any) => ({
+      n: value.n,
+      value: toBigIntValue(value.value, 'asset allocation').toString(),
+    })),
+  }));
+
+const getExactAssetAllocations = (transaction: any) =>
+  normalizeAssetAllocations(
+    transaction.version === ALLOCATION_MINT_VERSION
+      ? getAllocationsFromOutputs(transaction.outs)
+      : syscoinUtils.getAllocationsFromTx(transaction)
+  );
+
+const getRawTransactionHex = (response: any): string | null => {
+  if (typeof response === 'string') return response;
+  if (typeof response?.hex === 'string') return response.hex;
+  if (typeof response?.result === 'string') return response.result;
+  if (typeof response?.result?.hex === 'string') return response.result.hex;
+  return null;
+};
+
+const getInputAssetMetadata = (input: any, inputIndex: number) => {
+  const entries = (input?.unknownKeyVals || []).filter(
+    (entry: any) => entry?.key?.toString() === 'assetInfo'
+  );
+  if (entries.length > 1) {
+    throw new Error(`Conflicting PSBT input ${inputIndex} asset metadata`);
+  }
+  if (entries.length === 0) return null;
+
+  try {
+    return JSON.parse(entries[0].value.toString());
+  } catch (_error) {
+    throw new Error(`Invalid PSBT input ${inputIndex} asset metadata`);
+  }
+};
+
+const sumAssets = (
+  assets: Array<{ assetGuid: string; value: string }>
+): Map<string, bigint> => {
+  const totals = new Map<string, bigint>();
+  for (const asset of assets) {
+    totals.set(
+      asset.assetGuid,
+      (totals.get(asset.assetGuid) || BigInt(0)) + BigInt(asset.value)
+    );
+  }
+  return totals;
+};
+
+const verifyAssetConservation = (
+  transactionVersion: number,
+  inputAssets: ISyscoinPsbtInputAsset[],
+  outputAllocations: IExactAssetAllocation[]
+) => {
+  const versionsThatConsumeAssets = new Set([
+    ALLOCATION_BURN_TO_SYSCOIN_VERSION,
+    ALLOCATION_BURN_TO_ETHEREUM_VERSION,
+    ALLOCATION_SEND_VERSION,
+  ]);
+
+  if (
+    inputAssets.length > 0 &&
+    !versionsThatConsumeAssets.has(transactionVersion)
+  ) {
+    throw new Error(
+      `Asset-bearing PSBT input ${inputAssets[0].inputIndex} is not allowed in transaction version ${transactionVersion}`
+    );
+  }
+
+  if (!versionsThatConsumeAssets.has(transactionVersion)) return;
+
+  const inputTotals = sumAssets(inputAssets);
+  const outputTotals = sumAssets(
+    outputAllocations.flatMap((allocation) =>
+      allocation.values.map(({ value }) => ({
+        assetGuid: allocation.assetGuid,
+        value,
+      }))
+    )
+  );
+  const assetGuids = new Set([...inputTotals.keys(), ...outputTotals.keys()]);
+
+  for (const assetGuid of assetGuids) {
+    if (
+      (inputTotals.get(assetGuid) || BigInt(0)) !==
+      (outputTotals.get(assetGuid) || BigInt(0))
+    ) {
+      throw new Error(
+        `PSBT asset ${assetGuid} inputs do not match its serialized allocations`
+      );
+    }
+  }
+};
+
+const resolvePreviousTransactions = async (
+  psbt: any,
+  fetchRawTransaction: RawTransactionFetcher
+): Promise<any[]> =>
+  Promise.all(
+    psbt.txInputs.map(async (txInput: any, inputIndex: number) => {
+      const input = psbt.data.inputs[inputIndex];
+      let previousTransaction: any;
+
+      if (input.nonWitnessUtxo) {
+        previousTransaction = syscoinUtils.bitcoinjs.Transaction.fromBuffer(
+          input.nonWitnessUtxo
+        );
+      } else {
+        const previousTxid = Buffer.from(txInput.hash)
+          .reverse()
+          .toString('hex');
+        const response = await fetchRawTransaction(previousTxid);
+        const rawTransactionHex = getRawTransactionHex(response);
+        if (
+          !rawTransactionHex ||
+          rawTransactionHex.length % 2 !== 0 ||
+          !/^[0-9a-fA-F]+$/.test(rawTransactionHex)
+        ) {
+          throw new Error(`Unable to verify PSBT input ${inputIndex} prevout`);
+        }
+        previousTransaction =
+          syscoinUtils.bitcoinjs.Transaction.fromHex(rawTransactionHex);
+      }
+
+      if (!Buffer.from(txInput.hash).equals(previousTransaction.getHash())) {
+        throw new Error(
+          `PSBT input ${inputIndex} previous transaction mismatch`
+        );
+      }
+
+      const previousOutput = previousTransaction.outs?.[txInput.index];
+      if (!previousOutput) {
+        throw new Error(`Unable to verify PSBT input ${inputIndex}`);
+      }
+      if (
+        input.witnessUtxo &&
+        (toBigIntValue(input.witnessUtxo.value, `PSBT input ${inputIndex}`) !==
+          toBigIntValue(previousOutput.value, `PSBT input ${inputIndex}`) ||
+          !Buffer.from(input.witnessUtxo.script).equals(previousOutput.script))
+      ) {
+        throw new Error(`Conflicting PSBT input ${inputIndex} UTXO data`);
+      }
+
+      return previousTransaction;
+    })
+  );
+
+const getVerifiedInputAssets = (
+  psbt: any,
+  previousTransactions: any[],
+  transactionVersion: number,
+  outputAllocations: IExactAssetAllocation[]
+): ISyscoinPsbtInputAsset[] => {
+  const inputAssets = previousTransactions.flatMap(
+    (previousTransaction, inputIndex) => {
+      const previousOutputIndex = psbt.txInputs[inputIndex].index;
+      const previousTxid = previousTransaction.getId();
+      const assets = getExactAssetAllocations(previousTransaction).flatMap(
+        (allocation) =>
+          allocation.values
+            .filter(({ n }) => n === previousOutputIndex)
+            .map(({ value }) => ({
+              assetGuid: allocation.assetGuid,
+              inputIndex,
+              previousOutputIndex,
+              previousTxid,
+              value,
+            }))
+      );
+
+      return assets;
+    }
+  );
+
+  verifyAssetConservation(transactionVersion, inputAssets, outputAllocations);
+
+  for (let inputIndex = 0; inputIndex < psbt.data.inputs.length; inputIndex++) {
+    const metadata = getInputAssetMetadata(
+      psbt.data.inputs[inputIndex],
+      inputIndex
+    );
+    const actualAssets = inputAssets.filter(
+      (asset) => asset.inputIndex === inputIndex
+    );
+
+    if (actualAssets.length === 0) {
+      if (metadata) {
+        throw new Error(`Conflicting PSBT input ${inputIndex} asset metadata`);
+      }
+      continue;
+    }
+    if (!metadata) {
+      throw new Error(`PSBT input ${inputIndex} omits its asset metadata`);
+    }
+    if (
+      actualAssets.length !== 1 ||
+      String(metadata.assetGuid) !== actualAssets[0].assetGuid ||
+      toBigIntValue(metadata.value, `PSBT input ${inputIndex} asset`) !==
+        BigInt(actualAssets[0].value)
+    ) {
+      throw new Error(`Conflicting PSBT input ${inputIndex} asset metadata`);
+    }
+  }
+
+  return inputAssets;
+};
+
 export const getSyscoinPsbtValueSummary = (
-  psbt: any
+  psbt: any,
+  previousTransactions?: any[]
 ): {
   assetAllocations: Array<{
     assetGuid: string;
@@ -39,10 +270,10 @@ export const getSyscoinPsbtValueSummary = (
     const input = psbt.data.inputs[index];
     let inputValue: unknown;
 
-    if (input.nonWitnessUtxo) {
-      const previousTransaction = syscoinUtils.bitcoinjs.Transaction.fromBuffer(
-        input.nonWitnessUtxo
-      );
+    if (input.nonWitnessUtxo || previousTransactions?.[index]) {
+      const previousTransaction =
+        previousTransactions?.[index] ||
+        syscoinUtils.bitcoinjs.Transaction.fromBuffer(input.nonWitnessUtxo);
       if (
         !Buffer.from(psbt.txInputs[index].hash).equals(
           previousTransaction.getHash()
@@ -88,19 +319,7 @@ export const getSyscoinPsbtValueSummary = (
     throw new Error('Unable to verify PSBT asset allocations');
   }
   const transaction = psbt.extractTransaction(true, true);
-  const rawAssetAllocations =
-    transaction.version === ALLOCATION_MINT_VERSION
-      ? getAllocationsFromOutputs(transaction.outs)
-      : syscoinUtils.getAllocationsFromTx(transaction);
-  const assetAllocations = (rawAssetAllocations || []).map(
-    (allocation: any) => ({
-      assetGuid: String(allocation.assetGuid),
-      values: (allocation.values || []).map((value: any) => ({
-        n: value.n,
-        value: toBigIntValue(value.value, 'asset allocation').toString(),
-      })),
-    })
-  );
+  const assetAllocations = getExactAssetAllocations(transaction);
 
   let effectiveInput = totalInput;
   if (transaction.version === ALLOCATION_BURN_TO_SYSCOIN_VERSION) {
@@ -147,4 +366,28 @@ export const getSyscoinPsbtValueSummary = (
     feeSatoshis: (effectiveInput - totalOutput).toString(),
     outputValuesSatoshis,
   };
+};
+
+export const getVerifiedSyscoinPsbtValueSummary = async (
+  psbt: any,
+  fetchRawTransaction: RawTransactionFetcher
+): Promise<
+  ReturnType<typeof getSyscoinPsbtValueSummary> & {
+    inputAssets: ISyscoinPsbtInputAsset[];
+  }
+> => {
+  const previousTransactions = await resolvePreviousTransactions(
+    psbt,
+    fetchRawTransaction
+  );
+  const summary = getSyscoinPsbtValueSummary(psbt, previousTransactions);
+  const transaction = psbt.extractTransaction(true, true);
+  const inputAssets = getVerifiedInputAssets(
+    psbt,
+    previousTransactions,
+    transaction.version,
+    summary.assetAllocations
+  );
+
+  return { ...summary, inputAssets };
 };

--- a/source/utils/syscoinPsbtValues.ts
+++ b/source/utils/syscoinPsbtValues.ts
@@ -8,6 +8,7 @@ const ALLOCATION_BURN_TO_ETHEREUM_VERSION = 141;
 const ALLOCATION_SEND_VERSION = 142;
 const SYSX_ASSET_GUID = '123456';
 const CORE_MAX_SCRIPT_SIZE = 10_000;
+const MAX_CONCURRENT_PREVOUT_LOOKUPS = 8;
 const CORE_WITNESS_COMMITMENT_HEADER = Buffer.from('aa21a9ed', 'hex');
 const SYSCOIN_ASSET_VERSIONS = new Set([
   ALLOCATION_BURN_TO_SYSCOIN_VERSION,
@@ -220,23 +221,68 @@ const verifyAssetConservation = (
   }
 };
 
+const verifyPreviousTransaction = (
+  psbt: any,
+  inputIndex: number,
+  previousTransaction: any
+) => {
+  const txInput = psbt.txInputs[inputIndex];
+  const input = psbt.data.inputs[inputIndex];
+  if (!Buffer.from(txInput.hash).equals(previousTransaction.getHash())) {
+    throw new Error(`PSBT input ${inputIndex} previous transaction mismatch`);
+  }
+
+  const previousOutput = previousTransaction.outs?.[txInput.index];
+  if (!previousOutput) {
+    throw new Error(`Unable to verify PSBT input ${inputIndex}`);
+  }
+  if (
+    input.witnessUtxo &&
+    (toBigIntValue(input.witnessUtxo.value, `PSBT input ${inputIndex}`) !==
+      toBigIntValue(previousOutput.value, `PSBT input ${inputIndex}`) ||
+      !Buffer.from(input.witnessUtxo.script).equals(previousOutput.script))
+  ) {
+    throw new Error(`Conflicting PSBT input ${inputIndex} UTXO data`);
+  }
+};
+
 const resolvePreviousTransactions = async (
   psbt: any,
   fetchRawTransaction: RawTransactionFetcher
-): Promise<any[]> =>
-  Promise.all(
-    psbt.txInputs.map(async (txInput: any, inputIndex: number) => {
-      const input = psbt.data.inputs[inputIndex];
-      let previousTransaction: any;
+): Promise<any[]> => {
+  const previousTransactions = new Array(psbt.txInputs.length);
+  const remoteInputIndexesByTxid = new Map<string, number[]>();
 
-      if (input.nonWitnessUtxo) {
-        previousTransaction = syscoinUtils.bitcoinjs.Transaction.fromBuffer(
-          input.nonWitnessUtxo
-        );
-      } else {
-        const previousTxid = Buffer.from(txInput.hash)
-          .reverse()
-          .toString('hex');
+  psbt.txInputs.forEach((txInput: any, inputIndex: number) => {
+    const input = psbt.data.inputs[inputIndex];
+    if (input.nonWitnessUtxo) {
+      const previousTransaction = syscoinUtils.bitcoinjs.Transaction.fromBuffer(
+        input.nonWitnessUtxo
+      );
+      verifyPreviousTransaction(psbt, inputIndex, previousTransaction);
+      previousTransactions[inputIndex] = previousTransaction;
+      return;
+    }
+
+    const previousTxid = Buffer.from(txInput.hash).reverse().toString('hex');
+    const inputIndexes = remoteInputIndexesByTxid.get(previousTxid);
+    if (inputIndexes) {
+      inputIndexes.push(inputIndex);
+    } else {
+      remoteInputIndexesByTxid.set(previousTxid, [inputIndex]);
+    }
+  });
+
+  const lookups = Array.from(remoteInputIndexesByTxid.entries());
+  let nextLookupIndex = 0;
+  let lookupFailed = false;
+  const runLookupWorker = async () => {
+    while (!lookupFailed) {
+      const lookup = lookups[nextLookupIndex++];
+      if (!lookup) return;
+
+      const [previousTxid, inputIndexes] = lookup;
+      try {
         const response = await fetchRawTransaction(previousTxid);
         const rawTransactionHex = getRawTransactionHex(response);
         if (
@@ -244,34 +290,33 @@ const resolvePreviousTransactions = async (
           rawTransactionHex.length % 2 !== 0 ||
           !/^[0-9a-fA-F]+$/.test(rawTransactionHex)
         ) {
-          throw new Error(`Unable to verify PSBT input ${inputIndex} prevout`);
+          throw new Error(
+            `Unable to verify PSBT input ${inputIndexes[0]} prevout`
+          );
         }
-        previousTransaction =
+        const previousTransaction =
           syscoinUtils.bitcoinjs.Transaction.fromHex(rawTransactionHex);
-      }
 
-      if (!Buffer.from(txInput.hash).equals(previousTransaction.getHash())) {
-        throw new Error(
-          `PSBT input ${inputIndex} previous transaction mismatch`
-        );
+        for (const inputIndex of inputIndexes) {
+          verifyPreviousTransaction(psbt, inputIndex, previousTransaction);
+          previousTransactions[inputIndex] = previousTransaction;
+        }
+      } catch (error) {
+        lookupFailed = true;
+        throw error;
       }
+    }
+  };
 
-      const previousOutput = previousTransaction.outs?.[txInput.index];
-      if (!previousOutput) {
-        throw new Error(`Unable to verify PSBT input ${inputIndex}`);
-      }
-      if (
-        input.witnessUtxo &&
-        (toBigIntValue(input.witnessUtxo.value, `PSBT input ${inputIndex}`) !==
-          toBigIntValue(previousOutput.value, `PSBT input ${inputIndex}`) ||
-          !Buffer.from(input.witnessUtxo.script).equals(previousOutput.script))
-      ) {
-        throw new Error(`Conflicting PSBT input ${inputIndex} UTXO data`);
-      }
-
-      return previousTransaction;
-    })
+  await Promise.all(
+    Array.from(
+      { length: Math.min(MAX_CONCURRENT_PREVOUT_LOOKUPS, lookups.length) },
+      runLookupWorker
+    )
   );
+
+  return previousTransactions;
+};
 
 const getVerifiedInputAssets = (
   psbt: any,


### PR DESCRIPTION
## What changed

- Resolve and hash-bind every PSBT input's complete previous transaction before review or signing.
- Reconstruct the actual SPT/NFT allocation carried by each selected prevout.
- Match Syscoin Core's payload boundary: the first unspendable output, with the conditional witness-commitment second push.
- Reject malformed, missing, or trailing Syscoin payload pushes instead of accepting a parser differential.
- Reject omitted or conflicting proprietary asset metadata.
- Reject asset-bearing inputs in non-asset transaction versions.
- Enforce exact per-GUID input/output allocation conservation for versions 138, 141, and 142.
- Show every verified asset-bearing input in the approval popup.
- Route both `sys_sign` and `sys_signAndSend` through the same sign-time preflight.
- Deduplicate witness prevouts by txid and resolve them through an eight-request pool that stops scheduling after failure.
- Allow up to 60 seconds for bounded prevout verification so large legitimate consolidation PSBTs remain reviewable.
- Bump Pali to 4.0.65.

## Why

A hostile connected DApp could supply a version-2 PSBT that spends an asset-bearing UTXO while omitting asset metadata. The previous review verified only the native SYS prevout fields and could present the request as an ordinary SYS transaction, allowing the hidden SPT/NFT to be destroyed.

The preflight derives asset state from the hash-bound raw previous transaction rather than trusting optional PSBT metadata. Witness-only prevouts are fetched through the existing cached raw-transaction path with verification-scoped deduplication and bounded concurrency.

The parser hardening also prevents a Core-vs-JavaScript differential where a 679-byte `aa21a9ed` decoy in the first push made JavaScript inspect the decoy while Core consumed the real asset allocation from the second push.

## Validation

- Both exploit regressions were captured failing before their fixes and passing after them.
- The exact 679-byte decoy parent is now identified as asset-bearing, and its version-2 child is rejected.
- Honest native witness-only PSBTs, normal one-push asset transactions, Core witness-marker/two-push transactions, and supported version-142 sends pass.
- Missing/extra/non-byte payload pushes, omitted/conflicting metadata, forged fetched prevouts, conservation mismatches, and asset-bearing version-2 cases reject.
- Concurrent lookup, same-txid deduplication, and fail-stop scheduling regressions are covered.
- `yarn test:unit --runInBand` — 61 suites / 389 tests passed.
- `yarn type-check` passed.
- Focused ESLint passed.
- `yarn build:canary` passed (existing webpack warnings only).
