### PR TITLE
Fix browser PSBT prevout verification

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Pali Wallet",
-  "version": "4.0.66",
+  "version": "4.0.67",
   "icons": {
     "16": "assets/all_assets/favicon-16.png",
     "32": "assets/all_assets/favicon-32.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paliwallet",
-  "version": "4.0.66",
+  "version": "4.0.67",
   "description": "A Non-Custodial Crypto Wallet",
   "private": true,
   "repository": {
@@ -67,6 +67,7 @@
     "antd": "^6.0.0",
     "axios": "^1.18.1",
     "bignumber.js": "^9.1.2",
+    "buffer": "^6.0.3",
     "currency-symbol-map": "^5.1.0",
     "currency.js": "^2.0.4",
     "date-fns": "^2.30.0",

--- a/source/config/consts.js
+++ b/source/config/consts.js
@@ -80,7 +80,7 @@ const CANARY_EXTENSION_KEY =
 const MV3_OPTIONS = {
   manifest_version: 3,
   name: 'Pali Wallet',
-  version: '4.0.66',
+  version: '4.0.67',
   icons: {
     16: 'assets/all_assets/favicon-16.png',
     32: 'assets/all_assets/favicon-32.png',

--- a/source/utils/syscoinPsbtValues.spec.ts
+++ b/source/utils/syscoinPsbtValues.spec.ts
@@ -1,5 +1,6 @@
 jest.unmock('syscoinjs-lib');
 
+import { Buffer as BrowserBuffer } from 'buffer/';
 import {
   syscoin as SyscoinTransaction,
   utils as syscoinUtils,
@@ -563,6 +564,37 @@ describe('Syscoin PSBT value summary', () => {
     expect(fetchRawTransaction).toHaveBeenCalledWith(
       previousTransaction.getId()
     );
+  });
+
+  it('verifies an embedded witness prevout with the browser Buffer polyfill', async () => {
+    const previousTransaction = emptyTransaction();
+    previousTransaction.addInput(Buffer.alloc(32), 0xffffffff);
+    const script = Buffer.from(
+      '00140000000000000000000000000000000000000001',
+      'hex'
+    );
+    previousTransaction.addOutput(script, BigInt(1000));
+    const psbt = new syscoinUtils.bitcoinjs.Psbt({
+      network: syscoinUtils.syscoinNetworks.testnet,
+    });
+    psbt.setVersion(2);
+    psbt.addInput({
+      hash: previousTransaction.getHash(),
+      index: 0,
+      nonWitnessUtxo: previousTransaction.toBuffer(),
+      witnessUtxo: { script, value: BigInt(1000) },
+    });
+    psbt.addOutput({ script, value: BigInt(900) });
+    const originalBuffer = global.Buffer;
+    global.Buffer = BrowserBuffer as unknown as typeof Buffer;
+
+    try {
+      await expect(
+        getVerifiedSyscoinPsbtValueSummary(psbt, jest.fn())
+      ).resolves.toMatchObject({ feeSatoshis: '100', inputAssets: [] });
+    } finally {
+      global.Buffer = originalBuffer;
+    }
   });
 
   it('deduplicates witness prevout lookups from the same transaction', async () => {

--- a/source/utils/syscoinPsbtValues.ts
+++ b/source/utils/syscoinPsbtValues.ts
@@ -33,6 +33,10 @@ interface IExactAssetAllocation {
 
 type RawTransactionFetcher = (txid: string) => Promise<unknown>;
 
+const equalBytes = (left: Uint8Array, right: Uint8Array): boolean =>
+  left.length === right.length &&
+  left.every((value, index) => value === right[index]);
+
 const toBigIntValue = (value: unknown, field: string): bigint => {
   const normalized = String(value);
   if (!/^\d+$/.test(normalized)) {
@@ -228,7 +232,7 @@ const verifyPreviousTransaction = (
 ) => {
   const txInput = psbt.txInputs[inputIndex];
   const input = psbt.data.inputs[inputIndex];
-  if (!Buffer.from(txInput.hash).equals(previousTransaction.getHash())) {
+  if (!equalBytes(txInput.hash, previousTransaction.getHash())) {
     throw new Error(`PSBT input ${inputIndex} previous transaction mismatch`);
   }
 
@@ -240,7 +244,7 @@ const verifyPreviousTransaction = (
     input.witnessUtxo &&
     (toBigIntValue(input.witnessUtxo.value, `PSBT input ${inputIndex}`) !==
       toBigIntValue(previousOutput.value, `PSBT input ${inputIndex}`) ||
-      !Buffer.from(input.witnessUtxo.script).equals(previousOutput.script))
+      !equalBytes(input.witnessUtxo.script, previousOutput.script))
   ) {
     throw new Error(`Conflicting PSBT input ${inputIndex} UTXO data`);
   }
@@ -410,9 +414,7 @@ export const getSyscoinPsbtValueSummary = (
         previousTransactions?.[index] ||
         syscoinUtils.bitcoinjs.Transaction.fromBuffer(input.nonWitnessUtxo);
       if (
-        !Buffer.from(psbt.txInputs[index].hash).equals(
-          previousTransaction.getHash()
-        )
+        !equalBytes(psbt.txInputs[index].hash, previousTransaction.getHash())
       ) {
         throw new Error(`PSBT input ${index} previous transaction mismatch`);
       }
@@ -426,7 +428,7 @@ export const getSyscoinPsbtValueSummary = (
         input.witnessUtxo &&
         (toBigIntValue(input.witnessUtxo.value, `PSBT input ${index}`) !==
           toBigIntValue(previousOutput.value, `PSBT input ${index}`) ||
-          !Buffer.from(input.witnessUtxo.script).equals(previousOutput.script))
+          !equalBytes(input.witnessUtxo.script, previousOutput.script))
       ) {
         throw new Error(`Conflicting PSBT input ${index} UTXO data`);
       }


### PR DESCRIPTION
## Summary
- replace Node-only `Buffer.equals(Uint8Array)` assumptions in Syscoin PSBT parent-hash and witness-script verification with typed-array-safe byte comparisons
- add a browser Buffer polyfill regression covering an embedded authenticated prevout and matching witness UTXO
- declare the Buffer 6 runtime dependency explicitly
- bump Pali to 4.0.67

## Root cause
`bitcoinjs-lib` v7 returns `Uint8Array` hashes and scripts. Node Buffer accepts those as `.equals()` targets, so tests passed, but the browser Buffer polyfill throws `Argument must be a Buffer`. The popup caught that verifier exception and displayed `Failed to decode transaction details`.

## Verification
- `yarn test-all` — lint/i18n and 404 tests pass
- `yarn build:canary` — production Canary bundle passes
- regression runs the embedded parent txid and witness-script checks under Buffer 6