### PR TITLE
fix(provider): embed EIP-6963 wallet icon

### DIFF
--- a/source/config/webpack.common.js
+++ b/source/config/webpack.common.js
@@ -78,7 +78,14 @@ module.exports = {
   module: {
     rules: [
       {
+        test: /\.png$/i,
+        resourceQuery: /inline/,
+        type: 'asset/inline',
+        exclude: /node_modules/,
+      },
+      {
         test: /\.(jpg|png|svg|webp|xlsx|xls|csv)$/i,
+        resourceQuery: { not: [/inline/] },
         type: 'asset/resource',
         generator: {
           filename: 'assets/all_assets/[name][ext]',

--- a/source/declare.d.ts
+++ b/source/declare.d.ts
@@ -3,6 +3,11 @@ declare module '*.png' {
   export default value;
 }
 
+declare module '*.png?inline' {
+  const value: string;
+  export default value;
+}
+
 declare module '*.svg' {
   const value: string;
   export default value;

--- a/source/scripts/ContentScript/inject/utils.ts
+++ b/source/scripts/ContentScript/inject/utils.ts
@@ -1,3 +1,5 @@
+import paliIcon from 'assets/all_assets/favicon-128.png?inline';
+
 export interface IEIP6963ProviderInfo {
   icon: string;
   name: string;
@@ -61,46 +63,10 @@ export const EMITTED_NOTIFICATIONS = Object.freeze([
 ]);
 
 export const announceProvider = (provider: any, uuid: string) => {
-  const localIconUrl = (() => {
-    try {
-      // Try extension API first (available in content script contexts)
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      const maybeChromeUrl = chrome?.runtime?.getURL?.(
-        'assets/all_assets/favicon-48.png'
-      );
-      if (maybeChromeUrl) return maybeChromeUrl;
-    } catch (_) {
-      return undefined;
-    }
-    // Fallback: derive extension origin from the inpage script tag URL
-    try {
-      // Find the script element whose src points to our inpage bundle
-      const scripts = Array.from(
-        document.getElementsByTagName('script')
-      ) as HTMLScriptElement[];
-      const inpageScript = scripts.find(
-        (s) =>
-          s.src &&
-          (s.src.includes('/js/inpage.bundle.js') ||
-            s.src.startsWith('chrome-extension://'))
-      );
-      if (inpageScript && inpageScript.src) {
-        const origin = new URL(inpageScript.src).origin;
-        return `${origin}/assets/all_assets/favicon-48.png`;
-      }
-    } catch (_) {
-      // ignore
-    }
-    return undefined;
-  })();
-
-  // Prefer HTTPS icon to bypass site CSP that blocks chrome-extension:// images
-  const httpsIcon =
-    'https://raw.githubusercontent.com/syscoin/pali-wallet/master/source/assets/all_assets/favicon-128.png';
-
   const providerInfo: IEIP6963ProviderInfo = {
-    icon: localIconUrl || httpsIcon || '',
+    // EIP-6963 requires a URI. Keeping the image in the bundle avoids remote
+    // rate limits and extension-origin CSP restrictions in wallet selectors.
+    icon: paliIcon,
     name: 'Pali Wallet',
     rdns: 'com.paliwallet',
     uuid,


### PR DESCRIPTION
## Summary

- embed the Pali Wallet icon as a data URI in EIP-6963 provider metadata
- remove the GitHub Raw fallback that can return HTTP 429 and leave wallet selectors with broken images
- add an explicit webpack inline-PNG resource path and TypeScript declaration

## Verification

- `yarn type-check`
- targeted ESLint checks
- production Chrome webpack build
- verified the emitted in-page icon matches the source PNG byte-for-byte
- verified the emitted bundle no longer contains the GitHub Raw URL