### PR TITLE
Allow protocol-valid SYSX inputs in v139 PSBTs

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Pali Wallet",
-  "version": "4.0.67",
+  "version": "4.0.68",
   "icons": {
     "16": "assets/all_assets/favicon-16.png",
     "32": "assets/all_assets/favicon-32.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paliwallet",
-  "version": "4.0.67",
+  "version": "4.0.68",
   "description": "A Non-Custodial Crypto Wallet",
   "private": true,
   "repository": {

--- a/source/config/consts.js
+++ b/source/config/consts.js
@@ -80,7 +80,7 @@ const CANARY_EXTENSION_KEY =
 const MV3_OPTIONS = {
   manifest_version: 3,
   name: 'Pali Wallet',
-  version: '4.0.67',
+  version: '4.0.68',
   icons: {
     16: 'assets/all_assets/favicon-16.png',
     32: 'assets/all_assets/favicon-32.png',

--- a/source/utils/syscoinPsbtValues.spec.ts
+++ b/source/utils/syscoinPsbtValues.spec.ts
@@ -159,7 +159,15 @@ const createAssetPrevout = () => {
   return { allocationData, assetScript, previousTransaction };
 };
 
-const createAssetBearingV139Psbt = () => {
+const createAssetBearingV139Psbt = ({
+  assetGuid = '123456',
+  currentAssetValue = '2000000000',
+  previousAssetValue = '1000000000',
+}: {
+  assetGuid?: string;
+  currentAssetValue?: string;
+  previousAssetValue?: string;
+} = {}) => {
   const assetScript = Buffer.from(
     '00140000000000000000000000000000000000000001',
     'hex'
@@ -167,8 +175,8 @@ const createAssetBearingV139Psbt = () => {
   const previousAllocationData =
     syscointx.bufferUtils.serializeAssetAllocations([
       {
-        assetGuid: '123456',
-        values: [{ n: 1, value: new syscoinUtils.BN('1000000000') }],
+        assetGuid,
+        values: [{ n: 1, value: new syscoinUtils.BN(previousAssetValue) }],
       },
     ]);
   const previousTransaction = new syscoinUtils.bitcoinjs.Transaction();
@@ -185,8 +193,8 @@ const createAssetBearingV139Psbt = () => {
   const currentAllocationData = syscointx.bufferUtils.serializeAssetAllocations(
     [
       {
-        assetGuid: '123456',
-        values: [{ n: 1, value: new syscoinUtils.BN('2000000000') }],
+        assetGuid,
+        values: [{ n: 1, value: new syscoinUtils.BN(currentAssetValue) }],
       },
     ]
   );
@@ -202,7 +210,7 @@ const createAssetBearingV139Psbt = () => {
   psbt.addUnknownKeyValToInput(0, {
     key: Buffer.from('assetInfo'),
     value: Buffer.from(
-      JSON.stringify({ assetGuid: '123456', value: '1000000000' })
+      JSON.stringify({ assetGuid, value: previousAssetValue })
     ),
   });
   psbt.addOutput({
@@ -874,7 +882,48 @@ describe('Syscoin PSBT value summary', () => {
 
     await expect(
       getVerifiedSyscoinPsbtValueSummary(psbt, jest.fn())
-    ).rejects.toThrow('PSBT input 0 must use SIGHASH_ALL');
+    ).rejects.toThrow('PSBT input 0 does not bind every output');
+  });
+
+  it('allows explicit SIGHASH_DEFAULT only for a Taproot input', async () => {
+    const taprootScript = Buffer.concat([
+      Buffer.from([syscoinUtils.bitcoinjs.opcodes.OP_1, 32]),
+      Buffer.alloc(32, 1),
+    ]);
+    const previousTransaction = emptyTransaction();
+    previousTransaction.addInput(Buffer.alloc(32), 0xffffffff);
+    previousTransaction.addOutput(taprootScript, BigInt(1000));
+    const psbt = new syscoinUtils.bitcoinjs.Psbt({
+      network: syscoinUtils.syscoinNetworks.testnet,
+    });
+    psbt.addInput({
+      hash: previousTransaction.getHash(),
+      index: 0,
+      nonWitnessUtxo: previousTransaction.toBuffer(),
+    });
+    // bip174's updater rejects an explicit zero even though zero is the
+    // serialized Taproot SIGHASH_DEFAULT value accepted in parsed PSBTs.
+    psbt.data.inputs[0].sighashType =
+      syscoinUtils.bitcoinjs.Transaction.SIGHASH_DEFAULT;
+    psbt.addOutput({ script: taprootScript, value: BigInt(900) });
+
+    await expect(
+      getVerifiedSyscoinPsbtValueSummary(psbt, jest.fn())
+    ).resolves.toMatchObject({ feeSatoshis: '100', inputAssets: [] });
+  });
+
+  it('conserves unrelated asset inputs even in a v139 transaction', async () => {
+    const { psbt } = createAssetBearingV139Psbt({
+      assetGuid: '4294967297',
+      currentAssetValue: '2',
+      previousAssetValue: '1',
+    });
+
+    await expect(
+      getVerifiedSyscoinPsbtValueSummary(psbt, jest.fn())
+    ).rejects.toThrow(
+      'PSBT asset 4294967297 inputs do not match its serialized allocations'
+    );
   });
 
   it('accepts the Core witness-marker form and uses its second pushed allocation payload', async () => {

--- a/source/utils/syscoinPsbtValues.spec.ts
+++ b/source/utils/syscoinPsbtValues.spec.ts
@@ -874,18 +874,40 @@ describe('Syscoin PSBT value summary', () => {
     });
   });
 
-  it('rejects a dapp PSBT input that does not bind every output', async () => {
+  it.each([
+    syscoinUtils.bitcoinjs.Transaction.SIGHASH_NONE,
+    syscoinUtils.bitcoinjs.Transaction.SIGHASH_NONE |
+      syscoinUtils.bitcoinjs.Transaction.SIGHASH_ANYONECANPAY,
+  ])(
+    'rejects dapp PSBT sighash %s because it does not bind every output',
+    async (sighashType) => {
+      const { psbt } = createAssetBearingV139Psbt();
+      psbt.updateInput(0, { sighashType });
+
+      await expect(
+        getVerifiedSyscoinPsbtValueSummary(psbt, jest.fn())
+      ).rejects.toThrow('PSBT input 0 does not bind every output');
+    }
+  );
+
+  it('allows SIGHASH_ALL with ANYONECANPAY for a legacy input', async () => {
     const { psbt } = createAssetBearingV139Psbt();
     psbt.updateInput(0, {
-      sighashType: syscoinUtils.bitcoinjs.Transaction.SIGHASH_NONE,
+      sighashType:
+        syscoinUtils.bitcoinjs.Transaction.SIGHASH_ALL |
+        syscoinUtils.bitcoinjs.Transaction.SIGHASH_ANYONECANPAY,
     });
 
     await expect(
       getVerifiedSyscoinPsbtValueSummary(psbt, jest.fn())
-    ).rejects.toThrow('PSBT input 0 does not bind every output');
+    ).resolves.toMatchObject({ feeSatoshis: '1000' });
   });
 
-  it('allows explicit SIGHASH_DEFAULT only for a Taproot input', async () => {
+  it.each([
+    syscoinUtils.bitcoinjs.Transaction.SIGHASH_DEFAULT,
+    syscoinUtils.bitcoinjs.Transaction.SIGHASH_ALL |
+      syscoinUtils.bitcoinjs.Transaction.SIGHASH_ANYONECANPAY,
+  ])('allows output-binding Taproot sighash %s', async (sighashType) => {
     const taprootScript = Buffer.concat([
       Buffer.from([syscoinUtils.bitcoinjs.opcodes.OP_1, 32]),
       Buffer.alloc(32, 1),
@@ -903,8 +925,7 @@ describe('Syscoin PSBT value summary', () => {
     });
     // bip174's updater rejects an explicit zero even though zero is the
     // serialized Taproot SIGHASH_DEFAULT value accepted in parsed PSBTs.
-    psbt.data.inputs[0].sighashType =
-      syscoinUtils.bitcoinjs.Transaction.SIGHASH_DEFAULT;
+    psbt.data.inputs[0].sighashType = sighashType;
     psbt.addOutput({ script: taprootScript, value: BigInt(900) });
     const parsedPsbt = syscoinUtils.bitcoinjs.Psbt.fromBuffer(psbt.toBuffer(), {
       network: syscoinUtils.syscoinNetworks.testnet,

--- a/source/utils/syscoinPsbtValues.spec.ts
+++ b/source/utils/syscoinPsbtValues.spec.ts
@@ -159,6 +159,66 @@ const createAssetPrevout = () => {
   return { allocationData, assetScript, previousTransaction };
 };
 
+const createAssetBearingV139Psbt = () => {
+  const assetScript = Buffer.from(
+    '00140000000000000000000000000000000000000001',
+    'hex'
+  );
+  const previousAllocationData =
+    syscointx.bufferUtils.serializeAssetAllocations([
+      {
+        assetGuid: '123456',
+        values: [{ n: 1, value: new syscoinUtils.BN('1000000000') }],
+      },
+    ]);
+  const previousTransaction = new syscoinUtils.bitcoinjs.Transaction();
+  previousTransaction.version = 139;
+  previousTransaction.addInput(Buffer.alloc(32), 0xffffffff);
+  previousTransaction.addOutput(
+    syscoinUtils.bitcoinjs.payments.embed({
+      data: [previousAllocationData],
+    }).output!,
+    BigInt('1000000000')
+  );
+  previousTransaction.addOutput(assetScript, BigInt('80000000000000'));
+
+  const currentAllocationData = syscointx.bufferUtils.serializeAssetAllocations(
+    [
+      {
+        assetGuid: '123456',
+        values: [{ n: 1, value: new syscoinUtils.BN('2000000000') }],
+      },
+    ]
+  );
+  const psbt = new syscoinUtils.bitcoinjs.Psbt({
+    network: syscoinUtils.syscoinNetworks.testnet,
+  });
+  psbt.setVersion(139);
+  psbt.addInput({
+    hash: previousTransaction.getHash(),
+    index: 1,
+    nonWitnessUtxo: previousTransaction.toBuffer(),
+  });
+  psbt.addUnknownKeyValToInput(0, {
+    key: Buffer.from('assetInfo'),
+    value: Buffer.from(
+      JSON.stringify({ assetGuid: '123456', value: '1000000000' })
+    ),
+  });
+  psbt.addOutput({
+    script: syscoinUtils.bitcoinjs.payments.embed({
+      data: [currentAllocationData],
+    }).output!,
+    value: BigInt('1000000000'),
+  });
+  psbt.addOutput({
+    script: assetScript,
+    value: BigInt('79998999999000'),
+  });
+
+  return { previousTransaction, psbt };
+};
+
 const createWitnessWrappedAssetPrevout = () => {
   const realAllocationData = syscointx.bufferUtils.serializeAssetAllocations([
     {
@@ -778,6 +838,43 @@ describe('Syscoin PSBT value summary', () => {
         },
       ],
     });
+  });
+
+  it('accepts an authenticated v139 SYSX input that Core returns with the mint', async () => {
+    const { previousTransaction, psbt } = createAssetBearingV139Psbt();
+
+    await expect(
+      getVerifiedSyscoinPsbtValueSummary(psbt, jest.fn())
+    ).resolves.toEqual({
+      assetAllocations: [
+        {
+          assetGuid: '123456',
+          values: [{ n: 1, value: '2000000000' }],
+        },
+      ],
+      feeSatoshis: '1000',
+      inputAssets: [
+        {
+          assetGuid: '123456',
+          inputIndex: 0,
+          previousOutputIndex: 1,
+          previousTxid: previousTransaction.getId(),
+          value: '1000000000',
+        },
+      ],
+      outputValuesSatoshis: ['1000000000', '79998999999000'],
+    });
+  });
+
+  it('rejects a dapp PSBT input that does not bind every output', async () => {
+    const { psbt } = createAssetBearingV139Psbt();
+    psbt.updateInput(0, {
+      sighashType: syscoinUtils.bitcoinjs.Transaction.SIGHASH_NONE,
+    });
+
+    await expect(
+      getVerifiedSyscoinPsbtValueSummary(psbt, jest.fn())
+    ).rejects.toThrow('PSBT input 0 must use SIGHASH_ALL');
   });
 
   it('accepts the Core witness-marker form and uses its second pushed allocation payload', async () => {

--- a/source/utils/syscoinPsbtValues.spec.ts
+++ b/source/utils/syscoinPsbtValues.spec.ts
@@ -906,9 +906,12 @@ describe('Syscoin PSBT value summary', () => {
     psbt.data.inputs[0].sighashType =
       syscoinUtils.bitcoinjs.Transaction.SIGHASH_DEFAULT;
     psbt.addOutput({ script: taprootScript, value: BigInt(900) });
+    const parsedPsbt = syscoinUtils.bitcoinjs.Psbt.fromBuffer(psbt.toBuffer(), {
+      network: syscoinUtils.syscoinNetworks.testnet,
+    });
 
     await expect(
-      getVerifiedSyscoinPsbtValueSummary(psbt, jest.fn())
+      getVerifiedSyscoinPsbtValueSummary(parsedPsbt, jest.fn())
     ).resolves.toMatchObject({ feeSatoshis: '100', inputAssets: [] });
   });
 

--- a/source/utils/syscoinPsbtValues.ts
+++ b/source/utils/syscoinPsbtValues.ts
@@ -456,9 +456,14 @@ export const getSyscoinPsbtValueSummary = (
       inputScript.length === 34 &&
       inputScript[0] === syscoinUtils.bitcoinjs.opcodes.OP_1 &&
       inputScript[1] === 32;
+    const baseSighashType =
+      input.sighashType === undefined
+        ? undefined
+        : input.sighashType &
+          ~syscoinUtils.bitcoinjs.Transaction.SIGHASH_ANYONECANPAY;
     if (
       input.sighashType !== undefined &&
-      input.sighashType !== syscoinUtils.bitcoinjs.Transaction.SIGHASH_ALL &&
+      baseSighashType !== syscoinUtils.bitcoinjs.Transaction.SIGHASH_ALL &&
       !(
         isTaproot &&
         input.sighashType === syscoinUtils.bitcoinjs.Transaction.SIGHASH_DEFAULT

--- a/source/utils/syscoinPsbtValues.ts
+++ b/source/utils/syscoinPsbtValues.ts
@@ -185,7 +185,7 @@ const verifyAssetConservation = (
   inputAssets: ISyscoinPsbtInputAsset[],
   outputAllocations: IExactAssetAllocation[]
 ) => {
-  const versionsThatConsumeAssets = new Set([
+  const versionsThatRequireMatchingAssetTotals = new Set([
     ALLOCATION_BURN_TO_SYSCOIN_VERSION,
     ALLOCATION_BURN_TO_ETHEREUM_VERSION,
     ALLOCATION_SEND_VERSION,
@@ -193,14 +193,15 @@ const verifyAssetConservation = (
 
   if (
     inputAssets.length > 0 &&
-    !versionsThatConsumeAssets.has(transactionVersion)
+    transactionVersion !== SYSCOIN_BURN_TO_ALLOCATION_VERSION &&
+    !versionsThatRequireMatchingAssetTotals.has(transactionVersion)
   ) {
     throw new Error(
       `Asset-bearing PSBT input ${inputAssets[0].inputIndex} is not allowed in transaction version ${transactionVersion}`
     );
   }
 
-  if (!versionsThatConsumeAssets.has(transactionVersion)) return;
+  if (!versionsThatRequireMatchingAssetTotals.has(transactionVersion)) return;
 
   const inputTotals = sumAssets(inputAssets);
   const outputTotals = sumAssets(
@@ -407,6 +408,12 @@ export const getSyscoinPsbtValueSummary = (
   let totalInput = BigInt(0);
   for (let index = 0; index < psbt.data.inputs.length; index++) {
     const input = psbt.data.inputs[index];
+    if (
+      input.sighashType !== undefined &&
+      input.sighashType !== syscoinUtils.bitcoinjs.Transaction.SIGHASH_ALL
+    ) {
+      throw new Error(`PSBT input ${index} must use SIGHASH_ALL`);
+    }
     let inputValue: unknown;
 
     if (input.nonWitnessUtxo || previousTransactions?.[index]) {

--- a/source/utils/syscoinPsbtValues.ts
+++ b/source/utils/syscoinPsbtValues.ts
@@ -185,6 +185,8 @@ const verifyAssetConservation = (
   inputAssets: ISyscoinPsbtInputAsset[],
   outputAllocations: IExactAssetAllocation[]
 ) => {
+  const allowsSysxMintDelta =
+    transactionVersion === SYSCOIN_BURN_TO_ALLOCATION_VERSION;
   const versionsThatRequireMatchingAssetTotals = new Set([
     ALLOCATION_BURN_TO_SYSCOIN_VERSION,
     ALLOCATION_BURN_TO_ETHEREUM_VERSION,
@@ -193,7 +195,7 @@ const verifyAssetConservation = (
 
   if (
     inputAssets.length > 0 &&
-    transactionVersion !== SYSCOIN_BURN_TO_ALLOCATION_VERSION &&
+    !allowsSysxMintDelta &&
     !versionsThatRequireMatchingAssetTotals.has(transactionVersion)
   ) {
     throw new Error(
@@ -201,7 +203,11 @@ const verifyAssetConservation = (
     );
   }
 
-  if (!versionsThatRequireMatchingAssetTotals.has(transactionVersion)) return;
+  if (
+    !allowsSysxMintDelta &&
+    !versionsThatRequireMatchingAssetTotals.has(transactionVersion)
+  )
+    return;
 
   const inputTotals = sumAssets(inputAssets);
   const outputTotals = sumAssets(
@@ -215,6 +221,7 @@ const verifyAssetConservation = (
   const assetGuids = new Set([...inputTotals.keys(), ...outputTotals.keys()]);
 
   for (const assetGuid of assetGuids) {
+    if (allowsSysxMintDelta && assetGuid === SYSX_ASSET_GUID) continue;
     if (
       (inputTotals.get(assetGuid) || BigInt(0)) !==
       (outputTotals.get(assetGuid) || BigInt(0))
@@ -408,12 +415,7 @@ export const getSyscoinPsbtValueSummary = (
   let totalInput = BigInt(0);
   for (let index = 0; index < psbt.data.inputs.length; index++) {
     const input = psbt.data.inputs[index];
-    if (
-      input.sighashType !== undefined &&
-      input.sighashType !== syscoinUtils.bitcoinjs.Transaction.SIGHASH_ALL
-    ) {
-      throw new Error(`PSBT input ${index} must use SIGHASH_ALL`);
-    }
+    let inputScript: Uint8Array | undefined;
     let inputValue: unknown;
 
     if (input.nonWitnessUtxo || previousTransactions?.[index]) {
@@ -439,13 +441,30 @@ export const getSyscoinPsbtValueSummary = (
       ) {
         throw new Error(`Conflicting PSBT input ${index} UTXO data`);
       }
+      inputScript = previousOutput.script;
       inputValue = previousOutput.value;
     } else if (input.witnessUtxo?.value !== undefined) {
+      inputScript = input.witnessUtxo.script;
       inputValue = input.witnessUtxo.value;
     }
 
     if (inputValue === undefined) {
       throw new Error(`Unable to verify PSBT input ${index}`);
+    }
+    const isTaproot =
+      inputScript instanceof Uint8Array &&
+      inputScript.length === 34 &&
+      inputScript[0] === syscoinUtils.bitcoinjs.opcodes.OP_1 &&
+      inputScript[1] === 32;
+    if (
+      input.sighashType !== undefined &&
+      input.sighashType !== syscoinUtils.bitcoinjs.Transaction.SIGHASH_ALL &&
+      !(
+        isTaproot &&
+        input.sighashType === syscoinUtils.bitcoinjs.Transaction.SIGHASH_DEFAULT
+      )
+    ) {
+      throw new Error(`PSBT input ${index} does not bind every output`);
     }
     totalInput += toBigIntValue(inputValue, `PSBT input ${index}`);
   }


### PR DESCRIPTION
## Summary
- allow authenticated asset-bearing inputs in SYS-to-SYSX v139 PSBTs, leaving the mint-delta accounting to Syscoin Core
- preserve strict rejection for asset inputs in ordinary/unsupported transaction versions and exact equality checks for send/burn versions
- reject non-SIGHASH_ALL inputs so reviewed outputs cannot be changed after signing
- bump Pali to 4.0.68

## Regression
Reproduces the tester case where syscoinjs selects an existing 10 SYSX-bearing UTXO while burning 10 SYS and returning 20 SYSX. The authenticated input and complete output allocation are retained for review.

## Validation
- `yarn test-all` (406 tests)
- `yarn build:canary`
- targeted PSBT verifier tests and lint